### PR TITLE
Fix ms-van3t-CARLA co-existence with all the other modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The version of CARLA supported by ms-van3t-CARLA is CARLA 0.9.12.
 
 **Installing ms-van3t-CARLA**
 
-To enable ms-van3t-CARLA, after following the steps detailed above to build the project, from inside the `ns-3-dev` folder execute the `switch_ms-van3t-CARLA.sh` script. 
+To be able to use ms-van3t-CARLA, CARLA and OpenCDA need to be installed. After following the steps detailed above to build the project, from inside the `ns-3-dev` folder execute the `install_carla_opencda.sh` script to install all necessary dependencies. 
 The script will try to find the path of your CARLA and OpenCDA installation to be defined in the `CARLA-OpenCDA.conf` file. If the user already has an installation of either CARLA or OpenCDA they should specify the path to the installation together with the path to their Python environment in the following way: 
 
 `CARLA_HOME=/path/to/CARLA_0.9.12`

--- a/install_carla_opencda.sh
+++ b/install_carla_opencda.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+is_anaconda_installed() {
+    # Check if 'conda' command is available
+    if command -v conda &> /dev/null; then
+        return 0 # Anaconda is installed
+    else
+        return 1 # Anaconda is not installed
+    fi
+}
+
+
+ns_3_dir=$(pwd)
+
+
+config_file="CARLA-OpenCDA.conf"
+
+carla_found=false
+opencda_found=false
+
+
+
+if [ -f "$config_file" ]; then
+    
+    # If the file exists, check for CARLA_HOME and OpenCDA_HOME
+    if grep -q "CARLA_HOME" "$config_file"; then
+        carla_found=true
+	echo "CARLA installation found."
+    fi
+    if grep -q "OpenCDA_HOME" "$config_file"; then
+        opencda_found=true
+	echo "OpenCDA installation found."
+    fi
+fi
+
+
+if [ "$carla_found" = false ]; then
+    read -p "CARLA installation not found in CARLA-OpenCDA.conf. Press Enter to install CARLA or Ctrl+C to cancel."
+
+    lsb_release -d | grep Ubuntu > /dev/null
+    if [ $? -eq 0 ]; then
+		version=$(lsb_release -d | cut -d " " -f2 | cut -d "." -f1)
+		subversion=$(lsb_release -d | cut -d " " -f2 | cut -d "." -f2)
+		
+		if [ $version -gt 22 -o \( $version -ge 22 -a $subversion -ge 04 \) ]; then
+			echo "WARNING: Detected Ubuntu >= 22.04 - CARLA only officially supports Ubuntu 18.04 and Ubuntu 20.04 "
+			sudo apt install libomp5
+		fi
+	else
+		echo "Error: Detected a distribution different than Ubuntu"
+		exit 1
+	fi
+
+	sudo apt install -y software-properties-common build-essential cmake debhelper git wget curl xdg-user-dirs xserver-xorg libvulkan1 libsdl2-2.0-0 libsm6 libgl1-mesa-glx libomp5 pip unzip libjpeg8 libtiff5 software-properties-common nano fontconfig
+
+	ns_3_dir=$(pwd)
+	wget https://tiny.carla.org/carla-0-9-12-linux
+	wget https://tiny.carla.org/additional-maps-0-9-12-linux
+	mkdir CARLA_0.9.12
+	tar -xzf carla-0-9-12-linux -C CARLA_0.9.12/
+	cp additional-maps-0-9-12-linux CARLA_0.9.12/Import/
+	rm carla-0-9-12-linux 
+	rm additional-maps-0-9-12-linux
+	cd CARLA_0.9.12/Import/
+	tar -xzf additional-maps-0-9-12-linux
+	mv additional-maps-0-9-12-linux additional-maps-0-9-12-linux.tar.gz
+	cd ..
+	./ImportAssets.sh
+	carla_dir=$(pwd)
+	cd .. 
+
+	echo "CARLA_HOME=$carla_dir" >> "$config_file"
+	echo "CARLA_0.9.12 installation completed."
+fi
+
+
+if [ "$opencda_found" = false ]; then
+    read -p "OpenCDA installation not found in CARLA-OpenCDA.conf! Press Enter to install OpenCDA or Ctrl+C to cancel."
+    echo "Enter 'conda' to install OpenCDA with conda (HIGHLY RECOMMENDED) or 'pip' to install OpenCDA with pip:"
+    read -r install_method 
+
+	ns_3_dir=$(pwd)
+	sudo apt install -y software-properties-common build-essential cmake debhelper git wget curl xdg-user-dirs xserver-xorg libvulkan1 libsdl2-2.0-0 libsm6 libgl1-mesa-glx libomp5 pip unzip libjpeg8 libtiff5 software-properties-common nano fontconfig
+
+	# Add Python PPA and install Python 3.7 and other dependencies
+	sudo add-apt-repository ppa:deadsnakes/ppa
+	sudo apt-get install -y python3.7 ffmpeg libsm6 libxext6 python3-pip python3.7-distutils python3-apt python3-dev protobuf-compiler libprotobuf-dev libgrpc++-dev libzmq5-dev libglfw3-dev python-dev libpython3.7-dev libpython3-dev libyaml-cpp-dev
+
+	git clone https://github.com/carlosrisma/OpenCDA.git
+	cd OpenCDA
+
+    case $install_method in
+            conda)
+                echo "Installing OpenCDA with conda..."
+                
+                if is_anaconda_installed; then
+    				echo "Anaconda is already installed."
+				else
+				    echo "Installing Anaconda..."
+				    wget https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh -O anaconda.sh
+				    bash anaconda.sh -b
+				    source ~/anaconda3/etc/profile.d/conda.sh
+				    rm anaconda.sh
+				fi
+
+				conda env create -f environment.yml
+
+				# Get the path of the interpreter
+				env_name="msvan3t_carla" 
+				interpreter_path=$(conda env list | grep "^$env_name\s" | awk '{print $2 "/bin/python3"}')
+
+				export CARLA_HOME="$ns_3_dir/CARLA_0.9.12"
+				export CARLA_VERSION=0.9.12 
+
+				# Initialize Conda for the script's shell
+				eval "$(conda shell.bash hook)"
+
+				. setup.sh
+
+				conda activate msvan3t_carla
+
+				# Installing following packages one by one for reliability 
+				conda install cudatoolkit=11.1 -c pytorch -c conda-forge
+				conda install pytorch==1.8.0 -c pytorch -c conda-forge
+				conda install torchvision -c pytorch -c conda-forge
+				conda install torchaudio -c pytorch -c conda-forge
+
+				pip install carla==0.9.12
+				pip install lxml
+				pip install cycler
+				pip install pandas
+				pip install open3d
+				pip install filterpy
+				pip install psutil
+ 					pip install grpcio grpcio-tools conan==1.54.0
+
+				cd ..
+
+				echo "OpenCDA_HOME=$ns_3_dir/OpenCDA" >> "$config_file"
+				echo "Python_Interpreter=$interpreter_path" >> "$config_file"
+				echo "OpenCDA installation completed."	
+
+                ;;
+            pip)
+                echo "Installing OpenCDA with pip..."
+                python3.7 -m pip install -r requirements.txt
+
+				python3.7 -m pip install carla==0.9.12
+				python3.7 -m pip install coloredlogs omegaconf 
+				python3.7 -m pip install 'gitpython>=3.1.30'
+				python3.7 -m pip install 'Pillow>=10.0.1'
+				python3.7 -m pip install 'ultralytics>=8.0.147'
+				python3.7 -m pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 torchtext==0.14.1 torchaudio==0.13.1 torchdata==0.5.1 --extra-index-url https://download.pytorch.org/whl/cu117
+				python3.7 -m pip install open3d
+				python3.7 -m pip install grpcio-tools grpcio conan==1.52.0
+				python3.7 -m pip install pyzmq==25.0.2 zmq
+				python3.7 -m pip install filterpy
+
+				export CARLA_HOME="$ns_3_dir/CARLA_0.9.12"
+				export CARLA_VERSION=0.9.12 
+				# FROM OpenCDA setup.sh
+				CARLA_EGG_FILE=${CARLA_HOME}/PythonAPI/carla/dist/carla-"${CARLA_VERSION}"-py3.7-linux-x86_64.egg
+				if [ ! -f "$CARLA_EGG_FILE" ]; then
+				    echo "Error: $CARLA_EGG_FILE can not be found. Please make sure you are using python3.7 and carla 0.9.11. "
+				    return 0
+				fi
+
+				CACHE=${PWD}/cache
+				if [ ! -d "$CACHE" ]; then
+				  echo "creating cache folder for carla PythonAPI egg file"
+				  mkdir -p "$CACHE"
+				fi
+
+				echo "copying egg file to cache folder"
+				cp  $CARLA_EGG_FILE $CACHE
+
+				echo "unzip egg file"
+				unzip "${CACHE}"/carla-"${CARLA_VERSION}"-py3.7-linux-x86_64.egg -d "${CACHE}"/carla-"${CARLA_VERSION}"-py3.7-linux-x86_64
+
+				echo "copy setup file to egg folder"
+				SETUP_PY=${PWD}/scripts/setup.py
+				cp "$SETUP_PY"  "${CACHE}"/carla-"${CARLA_VERSION}"-py3.7-linux-x86_64/
+
+				python3.7 -m pip install -e ${CACHE}/carla-"${CARLA_VERSION}"-py3.7-linux-x86_64
+				
+				cd ..
+
+				echo "OpenCDA_HOME=$ns_3_dir/OpenCDA" >> "$config_file"
+				echo "Python_Interpreter=python3.7" >> "$config_file"
+				echo "OpenCDA installation completed."
+
+                ;;
+            *)
+                echo "Invalid input. Installation aborted."
+                exit 1
+                ;;
+        esac
+fi
+
+
+
+
+

--- a/src/automotive/CMakeLists.txt
+++ b/src/automotive/CMakeLists.txt
@@ -17,10 +17,10 @@ Set(source_files
     helper/trafficManagerClientLTE-helper.cc
     helper/trafficManagerServerLTE-helper.cc
 
-#     helper/cooperativePerception-helper.cc
-#     model/Applications/cooperativePerception.cc
-#     model/Facilities/vdpopencda.cc
-#     model/utilities/opencda-sensor.cc
+     helper/cooperativePerception-helper.cc
+     model/Applications/cooperativePerception.cc
+     model/Facilities/vdpopencda.cc
+     model/utilities/opencda-sensor.cc
 
     model/Applications/areaSpeedAdvisorClient80211p.cc
     model/Applications/areaSpeedAdvisorServer80211p.cc
@@ -1329,10 +1329,10 @@ set(header_files
     helper/v2xEmulator-helper.h
     helper/simpleCAMSender-helper.h
 
-#     helper/cooperativePerception-helper.h
-#     model/utilities/opencda-sensor.h
-#     model/Applications/cooperativePerception.h
-#     model/Facilities/vdpopencda.h
+     helper/cooperativePerception-helper.h
+     model/utilities/opencda-sensor.h
+     model/Applications/cooperativePerception.h
+     model/Facilities/vdpopencda.h
 
 
     model/Applications/areaSpeedAdvisorClient80211p.h
@@ -3803,5 +3803,6 @@ build_lib(
     ${libinternet}
     ${libvehicle-visualizer}
     ${libtraci}
+    ${libcarla}
   TEST_SOURCES ${test_sources}
 )

--- a/src/automotive/examples/CMakeLists.txt
+++ b/src/automotive/examples/CMakeLists.txt
@@ -2,6 +2,7 @@ build_lib_example(
     NAME v2i-areaSpeedAdvisor-lte 
     SOURCE_FILES v2i-areaSpeedAdvisor-lte.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${liblte}
     ${libtraci}
@@ -12,6 +13,7 @@ build_lib_example(
     NAME v2i-areaSpeedAdvisor-80211p
     SOURCE_FILES v2i-areaSpeedAdvisor-80211p.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${libwave}
     ${libtraci}
@@ -21,6 +23,7 @@ build_lib_example(
     NAME v2i-emergencyVehicleWarning-80211p
     SOURCE_FILES v2i-emergencyVehicleWarning-80211p.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${libwave}
     ${libtraci}
@@ -30,6 +33,7 @@ build_lib_example(
     NAME v2i-trafficManager-80211p
     SOURCE_FILES v2i-trafficManager-80211p.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${libwave}
     ${libtraci}
@@ -39,6 +43,7 @@ build_lib_example(
     NAME v2i-trafficManager-LTE
     SOURCE_FILES v2i-trafficManager-LTE.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${liblte}
     ${libtraci}
@@ -48,6 +53,7 @@ build_lib_example(
     NAME v2v-emergencyVehicleAlert-cv2x
     SOURCE_FILES v2v-emergencyVehicleAlert-cv2x.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${libcv2x}
     ${libtraci}
@@ -57,6 +63,7 @@ build_lib_example(
     NAME v2v-emergencyVehicleAlert-80211p
     SOURCE_FILES v2v-emergencyVehicleAlert-80211p.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${libwave}
     ${libtraci}
@@ -66,6 +73,7 @@ build_lib_example(
     NAME v2v-emergencyVehicleAlert-nrv2x
     SOURCE_FILES v2v-emergencyVehicleAlert-nrv2x.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${libnr}
     ${libtraci}
@@ -75,6 +83,7 @@ build_lib_example(
     NAME v2x-emulator
     SOURCE_FILES v2x-emulator.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${libfd-net-device}
     ${libtraci}
@@ -84,6 +93,7 @@ build_lib_example(
     NAME v2v-80211p-gps-tc-example
     SOURCE_FILES v2v-80211p-gps-tc-example.cc
     LIBRARIES_TO_LINK
+    ${libcarla}
     ${libautomotive}
     ${libwave}
     ${libgps-tc}
@@ -93,6 +103,7 @@ build_lib_example(
         NAME v2p-vam-80211p
         SOURCE_FILES v2p-vam-80211p.cc
         LIBRARIES_TO_LINK
+        ${libcarla}
         ${libautomotive}
         ${libwave}
         ${libtraci}
@@ -102,6 +113,7 @@ build_lib_example(
         NAME v2v-simple-cam-exchange-80211p
         SOURCE_FILES v2v-simple-cam-exchange-80211p.cc
         LIBRARIES_TO_LINK
+        ${libcarla}
         ${libautomotive}
         ${libwave}
         ${libtraci}
@@ -111,6 +123,7 @@ build_lib_example(
         NAME v2v-congestion-80211p
         SOURCE_FILES v2v-congestion-80211p.cc
         LIBRARIES_TO_LINK
+        ${libcarla}
         ${libautomotive}
         ${libwave}
         ${libtraci}
@@ -125,22 +138,22 @@ build_lib_example(
 #        ${libtraci}
 #)
 
-# build_lib_example(
-# NAME v2v-carla-nrv2x
-# SOURCE_FILES v2v-carlaMobility-nrv2x.cc
-# LIBRARIES_TO_LINK
-# ${libcarla}
-# ${libautomotive}
-# ${libnr}
-# ${libtraci}
-# )
+ build_lib_example(
+ NAME v2v-carla-nrv2x
+ SOURCE_FILES v2v-carlaMobility-nrv2x.cc
+ LIBRARIES_TO_LINK
+ ${libcarla}
+ ${libautomotive}
+ ${libnr}
+ ${libtraci}
+ )
 
-# build_lib_example(
-# NAME v2v-carla-80211p
-# SOURCE_FILES v2v-carlaMobility-80211p.cc
-# LIBRARIES_TO_LINK
-# ${libcarla}
-# ${libautomotive}
-# ${libwave}
-# ${libtraci}
-# )
+ build_lib_example(
+ NAME v2v-carla-80211p
+ SOURCE_FILES v2v-carlaMobility-80211p.cc
+ LIBRARIES_TO_LINK
+ ${libcarla}
+ ${libautomotive}
+ ${libwave}
+ ${libtraci}
+ )

--- a/src/automotive/examples/v2i-areaSpeedAdvisor-80211p.cc
+++ b/src/automotive/examples/v2i-areaSpeedAdvisor-80211p.cc
@@ -19,7 +19,12 @@
  *  Carlos Mateo Risma Carletti, Politecnico di Torino (carlosrisma@gmail.com)
 */
 
-#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/areaSpeedAdvisorServer80211p-helper.h"
+#include "ns3/areaSpeedAdvisorServer80211p.h"
+#include "ns3/areaSpeedAdvisorClient80211p.h"
+#include "ns3/areaSpeedAdvisorClient80211p-helper.h"
 #include "ns3/traci-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/wave-module.h"

--- a/src/automotive/examples/v2i-areaSpeedAdvisor-lte.cc
+++ b/src/automotive/examples/v2i-areaSpeedAdvisor-lte.cc
@@ -19,7 +19,12 @@
  *  Carlos Mateo Risma Carletti, Politecnico di Torino (carlosrisma@gmail.com)
 */
 
-#include "ns3/automotive-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+#include "ns3/areaSpeedAdvisorClientLTE-helper.h"
+#include "ns3/areaSpeedAdvisorClientLTE.h"
+#include "ns3/areaSpeedAdvisorServerLTE-helper.h"
+#include "ns3/areaSpeedAdvisorServerLTE.h"
 #include "ns3/traci-module.h"
 #include "ns3/lte-helper.h"
 #include "ns3/config-store.h"

--- a/src/automotive/examples/v2i-emergencyVehicleWarning-80211p.cc
+++ b/src/automotive/examples/v2i-emergencyVehicleWarning-80211p.cc
@@ -18,8 +18,12 @@
  *  Francesco Raviglione, Politecnico di Torino (francescorav.es483@gmail.com)
  *  Carlos Mateo Risma Carletti, Politecnico di Torino (carlosrisma@gmail.com)
 */
-
-#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/emergencyVehicleWarningClient80211p-helper.h"
+#include "ns3/emergencyVehicleWarningClient80211p.h"
+#include "ns3/emergencyVehicleWarningServer80211p-helper.h"
+#include "ns3/emergencyVehicleWarningServer80211p.h"
 #include "ns3/traci-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/wave-module.h"
@@ -306,7 +310,7 @@ main (int argc, char *argv[])
   SHUTDOWN_FCN shutdownWifiNode = [] (Ptr<Node> exNode,std::string vehicleID)
     {
       /* stop all applications */
-      Ptr<emergencyVehicleAlert> appSample_ = exNode->GetApplication(0)->GetObject<emergencyVehicleAlert>();
+      Ptr<emergencyVehicleWarningClient80211p> appSample_ = exNode->GetApplication(0)->GetObject<emergencyVehicleWarningClient80211p>();
 
       if(appSample_)
         appSample_->StopApplicationNow();

--- a/src/automotive/examples/v2i-trafficManager-80211p.cc
+++ b/src/automotive/examples/v2i-trafficManager-80211p.cc
@@ -19,7 +19,12 @@
  *  Carlos Mateo Risma Carletti, Politecnico di Torino (carlosrisma@gmail.com)
 */
 
-#include "ns3/automotive-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+#include "ns3/trafficManagerClient80211p-helper.h"
+#include "ns3/trafficManagerServer80211p-helper.h"
+#include "ns3/trafficManagerClient80211p.h"
+#include "ns3/trafficManagerServer80211p.h"
 #include "ns3/traci-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/wave-module.h"

--- a/src/automotive/examples/v2i-trafficManager-LTE.cc
+++ b/src/automotive/examples/v2i-trafficManager-LTE.cc
@@ -19,7 +19,12 @@
  *  Carlos Mateo Risma Carletti, Politecnico di Torino (carlosrisma@gmail.com)
 */
 
-#include "ns3/automotive-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+#include "ns3/trafficManagerClientLTE-helper.h"
+#include "ns3/trafficManagerServerLTE-helper.h"
+#include "ns3/trafficManagerServerLTE.h"
+#include "ns3/trafficManagerClientLTE.h"
 #include "ns3/traci-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/lte-module.h"

--- a/src/automotive/examples/v2p-vam-80211p.cc
+++ b/src/automotive/examples/v2p-vam-80211p.cc
@@ -1,4 +1,5 @@
-#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+//#include "ns3/automotive-module.h"
 #include "ns3/traci-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/wave-module.h"

--- a/src/automotive/examples/v2v-80211p-gps-tc-example.cc
+++ b/src/automotive/examples/v2v-80211p-gps-tc-example.cc
@@ -19,7 +19,11 @@
 */
 
 
-#include "ns3/automotive-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+#include "ns3/OpenCDAClient.h"
+#include "ns3/simpleCAMSender-gps-tc.h"
+#include "ns3/simpleCAMSender-helper.h"
 #include "ns3/gps-tc-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/wave-module.h"
@@ -211,7 +215,7 @@ main (int argc, char *argv[])
   }
 
   /* callback function for node creation */
-  STARTUP_FCN setupNewWifiNode = [&] (std::string vehicleID,TraciClient::StationTypeTraCI_t stationType) -> Ptr<Node>
+  STARTUP_GPS_FCN setupNewWifiNode = [&] (std::string vehicleID) -> Ptr<Node>
     {
 
       if (nodeCounter >= obuNodes.GetN())
@@ -234,7 +238,7 @@ main (int argc, char *argv[])
   int remainingNodes = obuNodes.GetN();
 
   /* callback function for node shutdown */
-  SHUTDOWN_FCN shutdownWifiNode = [&] (Ptr<Node> exNode,std::string vehicleID)
+  SHUTDOWN_GPS_FCN shutdownWifiNode = [&] (Ptr<Node> exNode,std::string vehicleID)
     {
       /* stop all applications */
       Ptr<simpleCAMSender> AppSimpleSender_ = exNode->GetApplication(0)->GetObject<simpleCAMSender>();

--- a/src/automotive/examples/v2v-carlaMobility-80211p.cc
+++ b/src/automotive/examples/v2v-carlaMobility-80211p.cc
@@ -17,7 +17,9 @@
  *  Carlos Mateo Risma Carletti, Politecnico di Torino (carlosrisma@gmail.com)
 */
 #include "ns3/carla-module.h"
-#include "ns3/automotive-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/cooperativePerception-helper.h"
+#include "ns3/cooperativePerception.h"
 #include "ns3/traci-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/wave-module.h"
@@ -328,7 +330,7 @@ main (int argc, char *argv[])
   cooperativePerceptionHelper.SetAttribute ("Model", StringValue ("80211p"));
   cooperativePerceptionHelper.SetAttribute("VisualizeSensor", BooleanValue(visualize_sensor));
   /* callback function for node creation */
-  STARTUP_FCN setupNewWifiNode = [&] (std::string vehicleID,TraciClient::StationTypeTraCI_t stationType) -> Ptr<Node>
+  STARTUP_OPENCDA_FCN setupNewWifiNode = [&] (std::string vehicleID) -> Ptr<Node>
     {
       if (nodeCounter >= obuNodes.GetN())
         NS_FATAL_ERROR("Node Pool empty!: " << nodeCounter << " nodes created.");
@@ -346,7 +348,7 @@ main (int argc, char *argv[])
     };
 
   /* Callback function for node shutdown */
-  SHUTDOWN_FCN shutdownWifiNode = [] (Ptr<Node> exNode,std::string vehicleID)
+  SHUTDOWN_OPENCDA_FCN shutdownWifiNode = [] (Ptr<Node> exNode,std::string vehicleID)
     {
       /* stop all applications */
       Ptr<cooperativePerception> appSample_ = exNode->GetApplication(0)->GetObject<cooperativePerception>();

--- a/src/automotive/examples/v2v-carlaMobility-nrv2x.cc
+++ b/src/automotive/examples/v2v-carlaMobility-nrv2x.cc
@@ -17,8 +17,9 @@
  *
  */
 #include "ns3/carla-module.h"
-#include "ns3/automotive-module.h"
-
+//#include "ns3/automotive-module.h"
+#include "ns3/cooperativePerception-helper.h"
+#include "ns3/cooperativePerception.h"
 #include "ns3/config-store.h"
 #include "ns3/network-module.h"
 #include "ns3/internet-module.h"
@@ -698,7 +699,7 @@ main (int argc, char *argv[])
 
   /* callback function for node creation */
   int i=0;
-  STARTUP_FCN setupNewWifiNode = [&] (std::string vehicleID,TraciClient::StationTypeTraCI_t stationType) -> Ptr<Node>
+  STARTUP_OPENCDA_FCN setupNewWifiNode = [&] (std::string vehicleID) -> Ptr<Node>
     {
       if (nodeCounter >= allSlUesContainer.GetN())
         NS_FATAL_ERROR("Node Pool empty!: " << nodeCounter << " nodes created.");
@@ -719,7 +720,7 @@ main (int argc, char *argv[])
     };
 
   /* callback function for node shutdown */
-  SHUTDOWN_FCN shutdownWifiNode = [] (Ptr<Node> exNode,std::string vehicleID)
+  SHUTDOWN_OPENCDA_FCN shutdownWifiNode = [] (Ptr<Node> exNode,std::string vehicleID)
     {
       Ptr<cooperativePerception> appSample_ = exNode->GetApplication(0)->GetObject<cooperativePerception>();
 

--- a/src/automotive/examples/v2v-congestion-80211p.cc
+++ b/src/automotive/examples/v2v-congestion-80211p.cc
@@ -38,7 +38,7 @@
  * The reported latency of vehicle 3 is expected to be 0 as it transmits interfering traffic (so, no ETSI-compliant
  * message is transmitted), that is not considered by the PRRSupervisor.
  */
-
+#include "ns3/carla-module.h"
 #include "ns3/vector.h"
 #include "ns3/string.h"
 #include "ns3/socket.h"

--- a/src/automotive/examples/v2v-emergencyVehicleAlert-80211p.cc
+++ b/src/automotive/examples/v2v-emergencyVehicleAlert-80211p.cc
@@ -18,8 +18,10 @@
  *  Francesco Raviglione, Politecnico di Torino (francescorav.es483@gmail.com)
  *  Carlos Mateo Risma Carletti, Politecnico di Torino (carlosrisma@gmail.com)
 */
-
-#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/emergencyVehicleAlert-helper.h"
+#include "ns3/emergencyVehicleAlert.h"
 #include "ns3/traci-module.h"
 #include "ns3/internet-module.h"
 #include "ns3/wave-module.h"

--- a/src/automotive/examples/v2v-emergencyVehicleAlert-cv2x.cc
+++ b/src/automotive/examples/v2v-emergencyVehicleAlert-cv2x.cc
@@ -19,7 +19,10 @@
  *  Carlos Mateo Risma Carletti, Politecnico di Torino (carlosrisma@gmail.com)
 */
 
-#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/emergencyVehicleAlert-helper.h"
+#include "ns3/emergencyVehicleAlert.h"
 #include "ns3/traci-module.h"
 #include "ns3/cv2x_lte-v2x-helper.h"
 #include "ns3/config-store.h"

--- a/src/automotive/examples/v2v-emergencyVehicleAlert-nrv2x.cc
+++ b/src/automotive/examples/v2v-emergencyVehicleAlert-nrv2x.cc
@@ -17,7 +17,10 @@
  *
  */
 
-#include "ns3/automotive-module.h"
+#include "ns3/carla-module.h"
+//#include "ns3/automotive-module.h"
+#include "ns3/emergencyVehicleAlert-helper.h"
+#include "ns3/emergencyVehicleAlert.h"
 #include "ns3/traci-module.h"
 #include "ns3/config-store.h"
 #include "ns3/network-module.h"

--- a/src/automotive/examples/v2v-simple-cam-exchange-80211p.cc
+++ b/src/automotive/examples/v2v-simple-cam-exchange-80211p.cc
@@ -38,6 +38,7 @@
  * The reported latency of vehicle 3 is expected to be 0 as it transmits interfering traffic (so, no ETSI-compliant
  * message is transmitted), that is not considered by the PRRSupervisor.
  */
+#include "ns3/carla-module.h"
 
 #include "ns3/vector.h"
 #include "ns3/string.h"

--- a/src/automotive/examples/v2x-emulator.cc
+++ b/src/automotive/examples/v2x-emulator.cc
@@ -18,7 +18,8 @@
  *  Francesco Raviglione, Politecnico di Torino (francescorav.es483@gmail.com)
  *  Carlos Mateo Risma Carletti, Politecnico di Torino (carlosrisma@gmail.com)
 */
-
+#include "ns3/carla-module.h"
+#include "ns3/OpenCDAClient.h"
 #include <fstream>
 #include "ns3/core-module.h"
 #include "ns3/internet-module.h"

--- a/src/automotive/helper/simpleCAMSender-helper.h
+++ b/src/automotive/helper/simpleCAMSender-helper.h
@@ -1,6 +1,7 @@
 #ifndef SIMPLECAMSENDER_HELPER_H
 #define SIMPLECAMSENDER_HELPER_H
 
+#include "ns3/OpenCDAClient.h"
 #include <stdint.h>
 #include "ns3/application-container.h"
 #include "ns3/node-container.h"

--- a/src/automotive/helper/v2xEmulator-helper.h
+++ b/src/automotive/helper/v2xEmulator-helper.h
@@ -1,6 +1,7 @@
 #ifndef V2XEMULATOR_HELPER_H
 #define V2XEMULATOR_HELPER_H
 
+#include "ns3/OpenCDAClient.h"
 #include <stdint.h>
 #include "ns3/application-container.h"
 #include "ns3/node-container.h"

--- a/src/automotive/model/Applications/simpleCAMSender-gps-tc.h
+++ b/src/automotive/model/Applications/simpleCAMSender-gps-tc.h
@@ -1,6 +1,7 @@
 #ifndef SIMPLECAMSENDER_H
 #define SIMPLECAMSENDER_H
 
+#include "ns3/OpenCDAClient.h"
 #include "ns3/traci-client.h"
 #include "ns3/gps-tc.h"
 

--- a/src/automotive/model/Measurements/MetricSupervisor.h
+++ b/src/automotive/model/Measurements/MetricSupervisor.h
@@ -1,6 +1,7 @@
 #ifndef METRICSUPERVISOR_H
 #define METRICSUPERVISOR_H
 
+#include "ns3/OpenCDAClient.h"
 #include <list>
 #include <unordered_map>
 #include <string>
@@ -80,6 +81,12 @@ public:
    * @param traci_ptr
    */
   void setTraCIClient(Ptr<TraciClient> traci_ptr) {m_traci_ptr = traci_ptr;}
+
+  /**
+   * @brief Set the OpenCDA client pointer.
+   * @param traci_ptr
+   */
+  void setOpenCDACLient(Ptr<OpenCDAClient> carla_ptr) {m_carla_ptr = carla_ptr;}
 
   /**
    * @brief This function is called everytime a packet is sent in the simulation by the GeoNet object. It is not expected to be called by the user.
@@ -500,6 +507,7 @@ private:
   std::unordered_map<messageType_e,double> m_avg_nvehbsln_per_messagetype;  //! key: message type, value: average number of road users within the baseline used for the PRR computation for that message type
 
   Ptr<TraciClient> m_traci_ptr = nullptr;
+  Ptr<OpenCDAClient> m_carla_ptr = nullptr;
   double m_baseline_m = 150.0;
 
   bool m_prr_verbose_stdout = false;

--- a/src/carla/CMakeLists.txt
+++ b/src/carla/CMakeLists.txt
@@ -31,7 +31,6 @@ build_lib(
   SOURCE_FILES ${source_files}
   HEADER_FILES ${header_files}
   LIBRARIES_TO_LINK
-#    ${gRPC}
     ${protobuf}
     ${libcore}
     ${libmobility}

--- a/src/carla/model/OpenCDAClient.h
+++ b/src/carla/model/OpenCDAClient.h
@@ -31,8 +31,8 @@
 
 #include "ns3/carla.grpc.pb.h"
 
-#define STARTUP_FCN std::function<Ptr<Node>(std::string)>
-#define SHUTDOWN_FCN std::function<void(Ptr<Node>,std::string)>
+#define STARTUP_OPENCDA_FCN std::function<Ptr<Node>(std::string)>
+#define SHUTDOWN_OPENCDA_FCN std::function<void(Ptr<Node>,std::string)>
 
 namespace ns3
 {
@@ -42,7 +42,7 @@ namespace ns3
       static TypeId GetTypeId (void);
       OpenCDAClient (void);
       ~OpenCDAClient (void);
-      void startCarlaAdapter(STARTUP_FCN includeNode, SHUTDOWN_FCN excludeNode);
+      void startCarlaAdapter(STARTUP_OPENCDA_FCN includeNode, SHUTDOWN_OPENCDA_FCN excludeNode);
       void startSimulation();
       void testInsertVehicle();
 
@@ -115,8 +115,8 @@ namespace ns3
       EventId m_executeOneTimestepTrigger;
 
       // function pointers to node include/exclude functions
-      STARTUP_FCN m_includeNode;
-      SHUTDOWN_FCN m_excludeNode;
+      STARTUP_OPENCDA_FCN m_includeNode;
+      SHUTDOWN_OPENCDA_FCN m_excludeNode;
 
       pid_t m_pid;
       pid_t m_carla_pid;

--- a/src/gps-tc/examples/gps-tc-example.cc
+++ b/src/gps-tc/examples/gps-tc-example.cc
@@ -80,7 +80,7 @@ main (int argc, char *argv[])
   uint32_t nodeCounter = 0;
 
   /* callback function for node creation */
-  STARTUP_FCN setupNode = [&] (std::string vehicleID) -> Ptr<Node>
+  STARTUP_GPS_FCN setupNode = [&] (std::string vehicleID) -> Ptr<Node>
     {
       if (nodeCounter >= obuNodes.GetN())
         NS_FATAL_ERROR("Node Pool empty!: " << nodeCounter << " nodes created.");

--- a/src/gps-tc/model/gps-tc.cc
+++ b/src/gps-tc/model/gps-tc.cc
@@ -239,7 +239,7 @@ namespace ns3
   }
 
   void
-  GPSTraceClient::GPSTraceClientSetup(STARTUP_FCN create_fcn,SHUTDOWN_FCN destroy_fcn)
+  GPSTraceClient::GPSTraceClientSetup(STARTUP_GPS_FCN create_fcn,SHUTDOWN_GPS_FCN destroy_fcn)
   {
       m_includeNode=create_fcn;
       m_excludeNode=destroy_fcn;
@@ -259,7 +259,7 @@ namespace ns3
   void
   GPSTraceClient::CreateNode()
   {
-      m_vehNode=m_includeNode(m_vehID,TraciClient::StationTypeTraci_unspecified);
+      m_vehNode=m_includeNode(m_vehID);
 
       // First position update
       m_lastvehicledataidx=0;

--- a/src/gps-tc/model/gps-tc.h
+++ b/src/gps-tc/model/gps-tc.h
@@ -17,6 +17,11 @@
 
 #include "ns3/vehicle-visualizer.h"
 
+
+#define STARTUP_GPS_FCN std::function<Ptr<Node>(std::string)>
+#define SHUTDOWN_GPS_FCN std::function<void(Ptr<Node>,std::string)>
+
+
 namespace ns3 {
 
   class GPSTraceClient : public Object
@@ -84,7 +89,7 @@ namespace ns3 {
           void playTrace(Time const &delay);
 
           // Set the functions to create/destroy node
-          void GPSTraceClientSetup(STARTUP_FCN create_fcn,SHUTDOWN_FCN destroy_fcn);
+          void GPSTraceClientSetup(STARTUP_GPS_FCN create_fcn,SHUTDOWN_GPS_FCN destroy_fcn);
 
           // Stop "playing" the trace
           void StopUpdates();
@@ -120,8 +125,8 @@ namespace ns3 {
           double m_travelled_distance;
 
           // Function pointers to node include/exclude functions
-          STARTUP_FCN m_includeNode;
-          SHUTDOWN_FCN m_excludeNode;
+          STARTUP_GPS_FCN m_includeNode;
+          SHUTDOWN_GPS_FCN m_excludeNode;
 
           EventId m_event_updatepos;
 

--- a/switch_ms-van3t-CARLA.sh
+++ b/switch_ms-van3t-CARLA.sh
@@ -64,15 +64,16 @@ if [ "$mode" = "base" ]; then
 		sudo apt install -y software-properties-common build-essential cmake debhelper git wget curl xdg-user-dirs xserver-xorg libvulkan1 libsdl2-2.0-0 libsm6 libgl1-mesa-glx libomp5 pip unzip libjpeg8 libtiff5 software-properties-common nano fontconfig
 
 		ns_3_dir=$(pwd)
-		wget https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/CARLA_0.9.12.tar.gz 
-		wget https://carla-releases.s3.eu-west-3.amazonaws.com/Linux/AdditionalMaps_0.9.12.tar.gz
+		wget https://tiny.carla.org/carla-0-9-12-linux
+		wget https://tiny.carla.org/additional-maps-0-9-12-linux
 		mkdir CARLA_0.9.12
-		tar -xzf CARLA_0.9.12.tar.gz -C CARLA_0.9.12/
-		cp AdditionalMaps_0.9.12.tar.gz CARLA_0.9.12/Import/
-		rm CARLA_0.9.12.tar.gz
-		rm AdditionalMaps_0.9.12.tar.gz
+		tar -xzf carla-0-9-12-linux -C CARLA_0.9.12/
+		cp additional-maps-0-9-12-linux CARLA_0.9.12/Import/
+		rm carla-0-9-12-linux 
+		rm additional-maps-0-9-12-linux
 		cd CARLA_0.9.12/Import/
-		tar -xzf AdditionalMaps_0.9.12.tar.gz
+		tar -xzf additional-maps-0-9-12-linux
+		mv additional-maps-0-9-12-linux additional-maps-0-9-12-linux.tar.gz
 		cd ..
 		./ImportAssets.sh
 		carla_dir=$(pwd)


### PR DESCRIPTION
This commit fixes a co-existence problem with the ms-van3t-CARLA extension that did not allow for the integration to co-exist with the gps-tc and emulation examples. Now there are no more different modes and ms-van3t-CARLA only needs the dependencies installation rather than changing modes.