### PR TITLE
Add 802.11bd NGV support

### DIFF
--- a/docs/80211bd-support.md
+++ b/docs/80211bd-support.md
@@ -1,0 +1,126 @@
+# 802.11bd support
+
+This patch adds an 802.11bd/NGV vehicular Wi-Fi path to the automotive module.
+It is intended for V2X simulations that already use the ns-3 WAVE/OCB stack and
+need to compare 802.11p, 802.11bd native NGV transmissions, and 802.11bd
+legacy-compatible fallback modes.
+
+## What is available
+
+- A new `WIFI_STANDARD_80211bd` Wi-Fi standard entry for the vehicular OCB path.
+- 802.11bd TXVECTOR metadata for PPDU format, NGV-MCS, spatial streams,
+  midamble periodicity, NGV-LTF type, LDPC, and `NON_NGV_10` repetitions.
+- Native NGV PPDU handling for 10 MHz and 20 MHz channel profiles.
+- Legacy-compatible `NON_NGV_10` and `NON_NGV_20_DUPLICATE` fallback modes.
+- Basic 802.11p/802.11bd interoperability behavior:
+  - 802.11bd receivers can receive supported non-NGV fallback transmissions.
+  - 802.11p receivers do not decode native NGV transmissions.
+  - 802.11p receivers can decode compatible non-NGV fallback transmissions.
+- 802.11bd profile helpers for configuring PHY, remote station manager, and
+  metrics consistently.
+- A bounded fallback controller for switching between native NGV, duplicated
+  non-NGV 20 MHz fallback, and primary-only non-NGV 10 MHz fallback.
+- A modular rate controller that can select 802.11bd NGV-MCS values and can
+  reuse the same SNR-threshold policy shape for 802.11p OFDM data rates.
+- CBR and DCC accounting paths updated to handle 802.11bd Wi-Fi devices.
+
+The implementation is a network-simulation model integrated into the existing
+Yans/WAVE-style automotive stack. It does not attempt to provide a full
+waveform-level 802.11bd PHY.
+
+## Helper API
+
+Use `VehicularWifiProfile` from `ns3/vehicular-wifi-helper.h` to configure
+common vehicular Wi-Fi profiles:
+
+```cpp
+VehicularWifiProfile profile = VehicularWifiProfile::Ieee80211bd ();
+profile.ConfigurePhy (wifiPhy);
+profile.ConfigureRemoteStationManager (wifi);
+```
+
+Useful factory methods include:
+
+- `VehicularWifiProfile::Ieee80211p()`
+- `VehicularWifiProfile::Ieee80211bd()`
+- `VehicularWifiProfile::Ieee80211bd20()`
+- `VehicularWifiProfile::Ieee80211bdNonNgv10()`
+- `VehicularWifiProfile::Ieee80211bdNonNgv20Duplicate()`
+
+For explicit fallback selection, use `VehicularWifiFallbackController`:
+
+```cpp
+auto mode = VehicularWifiFallbackController::SelectForLinkQuality (policy);
+VehicularWifiProfile profile = VehicularWifiFallbackController::MakeProfile (mode);
+```
+
+For MCS/rate decisions, use `VehicularWifiRateController`:
+
+```cpp
+VehicularWifiRateController::Policy policy;
+policy.linkQuality.estimatedSnrDb = 30.0;
+
+auto decision = VehicularWifiRateController::Select (policy);
+VehicularWifiProfile profile = VehicularWifiRateController::MakeProfile (decision);
+```
+
+The default 802.11bd rate policy selects native NGV MCS 7, 3, or 0 according to
+explicit SNR thresholds, then falls back to `NON_NGV_20_DUPLICATE` or
+`NON_NGV_10` through the fallback controller.
+
+## Examples
+
+The following examples exercise the new 802.11bd path:
+
+- `v2v-simple-cam-exchange-80211bd`
+- `v2v-congestion-80211bd`
+- `v2v-marginal-snr-80211bd`
+- `v2v-nss2-comparison-80211bd`
+- `v2v-runtime-fallback-80211bd`
+- `v2v-link-quality-fallback-80211bd`
+- `v2v-observed-fallback-80211bd`
+- `v2v-trace-observed-fallback-80211bd`
+- `v2v-rate-control-80211bd`
+- `v2v-coexistence-80211bd-nrv2x`
+
+Example runs:
+
+```bash
+./ns3 run "v2v-simple-cam-exchange-80211bd --sumo-gui=false --sim-time=1"
+./ns3 run "v2v-rate-control-80211bd"
+./ns3 run "v2v-runtime-fallback-80211bd"
+```
+
+## Tests
+
+The `vehicular-wifi-profile` test suite covers the core 802.11bd behavior:
+
+```bash
+./build/utils/ns3-dev-test-runner-optimized --suite=vehicular-wifi-profile --verbose
+```
+
+The suite includes tests for:
+
+- profile metadata and installed PHY settings;
+- NGV-MCS table validity;
+- TXVECTOR metadata;
+- `NON_NGV_10` repetition behavior;
+- 802.11p/802.11bd interoperability;
+- NGV error-rate model behavior;
+- CBR/DCC integration;
+- fallback and rate-control decisions.
+
+## Modeling limitations
+
+The current model uses static NGV PER and midamble/Doppler parameters in
+`src/automotive/model/SignalInfo/WiFi/ngv/ngv-calibration.h`. These values are
+modeling assumptions, not a calibrated link-level reference.
+
+The following items are intentionally left for future work:
+
+- calibrated PER-vs-SNR curves for NGV modes;
+- waveform-level duplicate combining;
+- full receiver-capability discovery;
+- failed-reception evidence for closed-loop rate control;
+- CBR-aware rate-control constraints;
+- a detailed MIMO PHY model for NSS greater than one.

--- a/sandbox_builder.sh
+++ b/sandbox_builder.sh
@@ -220,10 +220,39 @@ cp src/automotive/model/SignalInfo/size-tag.h src/nr/model/
 cp src/automotive/model/SignalInfo/size-tag.h src/lte/model/
 
 cp src/automotive/model/SignalInfo/WiFi/wifi-mac-queue-item.h src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/wifi-standards.h src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/wifi-phy-common.h src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/wifi-phy-common.cc src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/wifi-tx-vector.h src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/wifi-tx-vector.cc src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/wifi-remote-station-manager.h src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/wifi-remote-station-manager.cc src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/error-rate-model.cc src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/interference-helper.cc src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/yans-wifi-channel.cc src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/wifi-phy.cc src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/spectrum-wifi-phy.cc src/wifi/model/
+cp src/automotive/model/SignalInfo/WiFi/mac-rx-middle.cc src/wifi/model/
+mkdir -p src/wifi/model/ngv
+cp src/automotive/model/SignalInfo/WiFi/ngv/ngv-calibration.h src/wifi/model/ngv/
+cp src/automotive/model/SignalInfo/WiFi/ngv/ngv-phy.h src/wifi/model/ngv/
+cp src/automotive/model/SignalInfo/WiFi/ngv/ngv-phy.cc src/wifi/model/ngv/
+cp src/automotive/model/SignalInfo/WiFi/ngv/ngv-ppdu.h src/wifi/model/ngv/
+cp src/automotive/model/SignalInfo/WiFi/ngv/ngv-ppdu.cc src/wifi/model/ngv/
+cp src/automotive/model/SignalInfo/WiFi/non-ht/ofdm-ppdu.h src/wifi/model/non-ht/
+cp src/automotive/model/SignalInfo/WiFi/non-ht/ofdm-ppdu.cc src/wifi/model/non-ht/
 cp src/automotive/model/SignalInfo/WiFi/ocb-wifi-mac.cc src/wave/model/
+cp src/automotive/model/SignalInfo/WiFi/wifi-80211p-helper.h src/wave/helper/
+cp src/automotive/model/SignalInfo/WiFi/wifi-80211p-helper.cc src/wave/helper/
 cp src/automotive/model/SignalInfo/WiFi/frame-exchange-manager.cc src/wifi/model/
 cp src/automotive/model/SignalInfo/WiFi/qos-frame-exchange-manager.cc src/wifi/model/
 cp src/automotive/model/SignalInfo/WiFi/CMakeLists.txt src/wifi/
+sed -i '/\/\/ 802.11p 5 MHz channels at the 5.855-5.925 band/i\
+  // 802.11bd 20 MHz channels at the 5.855-5.925 band\
+  { std::make_tuple (173, 5865, 20, WIFI_PHY_80211p_CHANNEL, WIFI_PHY_BAND_5GHZ) },\
+  { std::make_tuple (177, 5885, 20, WIFI_PHY_80211p_CHANNEL, WIFI_PHY_BAND_5GHZ) },\
+  { std::make_tuple (181, 5905, 20, WIFI_PHY_80211p_CHANNEL, WIFI_PHY_BAND_5GHZ) },\
+' src/wifi/model/wifi-phy-operating-channel.cc
 
 cp src/automotive/model/SignalInfo/CV2X/cv2x_lte-spectrum-phy.cc src/cv2x/model/
 cp src/automotive/model/SignalInfo/CV2X/cv2x_lte-spectrum-phy.h src/cv2x/model/

--- a/src/automotive/CMakeLists.txt
+++ b/src/automotive/CMakeLists.txt
@@ -16,6 +16,8 @@ Set(source_files
         helper/v2xEmulator-helper.cc
         helper/simpleCAMSender-helper.cc
         helper/simpleVAMSender-helper.cc
+        helper/vehicular-wifi-helper.cc
+        model/Wifi/vehicular-ngv-wifi.cc
         helper/emergencyVehicleWarningServer80211p-helper.cc
         helper/emergencyVehicleWarningClient80211p-helper.cc
         helper/trafficManagerClient80211p-helper.cc
@@ -1574,6 +1576,8 @@ set(header_files
         helper/v2xEmulator-helper.h
         helper/simpleCAMSender-helper.h
         helper/simpleVAMSender-helper.h
+        helper/vehicular-wifi-helper.h
+        model/Wifi/vehicular-ngv-wifi.h
 
         helper/cooperativePerception-helper.h
         model/utilities/opencda-sensor.h
@@ -5853,6 +5857,7 @@ set_source_files_properties(
 
         PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 set(test_sources
+        test/vehicular-wifi-profile-test.cc
 )
 
 build_lib(

--- a/src/automotive/examples/CMakeLists.txt
+++ b/src/automotive/examples/CMakeLists.txt
@@ -132,6 +132,16 @@ build_lib_example(
 )
 
 build_lib_example(
+        NAME v2v-simple-cam-exchange-80211bd
+        SOURCE_FILES v2v-simple-cam-exchange-80211bd.cc
+        LIBRARIES_TO_LINK
+        ${libcarla}
+        ${libautomotive}
+        ${libwave}
+        ${libtraci}
+)
+
+build_lib_example(
         NAME v2v-foresee-mcm-80211p
         SOURCE_FILES v2v-foresee-mcm-80211p.cc
         LIBRARIES_TO_LINK
@@ -149,6 +159,72 @@ build_lib_example(
         ${libautomotive}
         ${libwave}
         ${libtraci}
+)
+
+build_lib_example(
+        NAME v2v-congestion-80211bd
+        SOURCE_FILES v2v-congestion-80211bd.cc
+        LIBRARIES_TO_LINK
+        ${libcarla}
+        ${libautomotive}
+        ${libwave}
+        ${libtraci}
+)
+
+build_lib_example(
+        NAME v2v-marginal-snr-80211bd
+        SOURCE_FILES v2v-marginal-snr-80211bd.cc
+        LIBRARIES_TO_LINK
+        ${libautomotive}
+        ${libwave}
+)
+
+build_lib_example(
+        NAME v2v-nss2-comparison-80211bd
+        SOURCE_FILES v2v-nss2-comparison-80211bd.cc
+        LIBRARIES_TO_LINK
+        ${libautomotive}
+        ${libwave}
+)
+
+build_lib_example(
+        NAME v2v-runtime-fallback-80211bd
+        SOURCE_FILES v2v-runtime-fallback-80211bd.cc
+        LIBRARIES_TO_LINK
+        ${libautomotive}
+        ${libwave}
+)
+
+build_lib_example(
+        NAME v2v-link-quality-fallback-80211bd
+        SOURCE_FILES v2v-link-quality-fallback-80211bd.cc
+        LIBRARIES_TO_LINK
+        ${libautomotive}
+        ${libwave}
+)
+
+build_lib_example(
+        NAME v2v-observed-fallback-80211bd
+        SOURCE_FILES v2v-observed-fallback-80211bd.cc
+        LIBRARIES_TO_LINK
+        ${libautomotive}
+        ${libwave}
+)
+
+build_lib_example(
+        NAME v2v-trace-observed-fallback-80211bd
+        SOURCE_FILES v2v-trace-observed-fallback-80211bd.cc
+        LIBRARIES_TO_LINK
+        ${libautomotive}
+        ${libwave}
+)
+
+build_lib_example(
+        NAME v2v-rate-control-80211bd
+        SOURCE_FILES v2v-rate-control-80211bd.cc
+        LIBRARIES_TO_LINK
+        ${libautomotive}
+        ${libwave}
 )
 
 #build_lib_example(
@@ -183,6 +259,13 @@ build_lib_example(
 build_lib_example(
        NAME v2v-coexistence-80211p-nrv2x
        SOURCE_FILES v2v-coexistence-80211p-nrv2x.cc
+       LIBRARIES_TO_LINK
+       ${libautomotive}
+)
+
+build_lib_example(
+       NAME v2v-coexistence-80211bd-nrv2x
+       SOURCE_FILES v2v-coexistence-80211bd-nrv2x.cc
        LIBRARIES_TO_LINK
        ${libautomotive}
 )

--- a/src/automotive/examples/v2v-coexistence-80211bd-nrv2x.cc
+++ b/src/automotive/examples/v2v-coexistence-80211bd-nrv2x.cc
@@ -1,0 +1,1166 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006,2007 INRIA
+ * Copyright (c) 2013 Dalian University of Technology
+ * Copyright (c) 2022 Politecnico di Torino
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+// 802.11bd
+#include <bitset>
+
+#include "ns3/vector.h"
+#include "ns3/string.h"
+#include "ns3/socket.h"
+#include "ns3/double.h"
+#include "ns3/config.h"
+#include "ns3/log.h"
+#include "ns3/command-line.h"
+#include "ns3/yans-wifi-helper.h"
+#include "ns3/spectrum-wifi-helper.h"
+#include "ns3/position-allocator.h"
+#include "ns3/mobility-helper.h"
+#include <iostream>
+#include "ns3/MetricSupervisor.h"
+#include "ns3/sumo_xml_parser.h"
+#include "ns3/BSMap.h"
+#include "ns3/caBasicService.h"
+#include "ns3/btp.h"
+#include "ns3/ocb-wifi-mac.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include <fstream>
+
+// NR-V2X
+#include "ns3/traci-module.h"
+#include "ns3/config-store.h"
+#include "ns3/internet-module.h"
+#include "ns3/mobility-module.h"
+#include "ns3/point-to-point-module.h"
+#include "ns3/nr-module.h"
+#include "ns3/lte-module.h"
+#include "ns3/stats-module.h"
+#include "ns3/config-store-module.h"
+#include "ns3/antenna-module.h"
+#include <iomanip>
+#include "ns3/vehicle-visualizer-module.h"
+#include <unistd.h>
+#include "ns3/core-module.h"
+
+#include "ns3/txTracker.h"
+
+#include "ns3/sionna-helper.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+// C-V2X
+/*#include "../../dsr/model/dsr-fs-header.h"
+#include "ns3/network-module.h"
+#include "ns3/internet-module.h"
+#include "ns3/applications-module.h"
+#include "ns3/mobility-module.h"
+#include "ns3/point-to-point-module.h"
+#include "ns3/stats-module.h"
+#include "ns3/config-store-module.h"
+#include "ns3/antenna-module.h"
+#include "ns3/cv2x_lte-v2x-helper.h"
+#include "ns3/internet-module.h"
+#include "ns3/cv2x-module.h"*/
+
+using namespace ns3;
+
+NS_LOG_COMPONENT_DEFINE ("V2VSimpleCAMExchange80211bdNrv2x");
+
+enum class NodeType
+{
+  NGV,
+  NR,
+  INTERFERING
+};
+
+std::vector<uint8_t> ngvVehicles;
+std::vector<uint8_t > nrv2xVehicles;
+static int packet_count = 0;
+static int counter = 0;
+BSMap basicServices; // Container for all ETSI Basic Services, installed on all vehicles
+bool phy_collection = true;
+bool use_sionna = false;
+static std::string g_signalCsvPath = "src/coexistence-80211bd-nrv2x-sinr.csv";
+static std::string g_prrCsv11bdPath = "src/coexistence-80211bd-nrv2x-prr-80211bd.csv";
+static std::string g_prrCsvNrPath = "src/coexistence-80211bd-nrv2x-prr-nrv2x.csv";
+
+static bool
+FileExists (const std::string& path)
+{
+  struct stat info;
+  return stat (path.c_str (), &info) == 0;
+}
+
+static void
+EnsureDirectory (const std::string& path)
+{
+  if (path.empty ())
+    {
+      return;
+    }
+
+  std::string current = path[0] == '/' ? "/" : "";
+  std::size_t start = path[0] == '/' ? 1 : 0;
+  while (start <= path.size ())
+    {
+      std::size_t end = path.find ('/', start);
+      std::string part = path.substr (start, end == std::string::npos ? std::string::npos : end - start);
+      if (!part.empty ())
+        {
+          if (!current.empty () && current.back () != '/')
+            {
+              current += "/";
+            }
+          current += part;
+          if (!FileExists (current) && mkdir (current.c_str (), 0775) != 0 && errno != EEXIST)
+            {
+              NS_FATAL_ERROR ("Unable to create output directory " << current << ": " << std::strerror (errno));
+            }
+        }
+      if (end == std::string::npos)
+        {
+          break;
+        }
+      start = end + 1;
+    }
+}
+
+static std::string
+JoinPath (const std::string& directory, const std::string& filename)
+{
+  if (directory.empty () || directory == ".")
+    {
+      return filename;
+    }
+  return directory.back () == '/' ? directory + filename : directory + "/" + filename;
+}
+
+static std::string
+GetStationTechnology (uint64_t stationId)
+{
+  return std::find (ngvVehicles.begin (), ngvVehicles.end (), static_cast<uint8_t> (stationId)) != ngvVehicles.end ()
+             ? "802.11bd"
+             : "NR-V2X";
+}
+
+static void
+WriteSignalSample (const std::string& messageType,
+                   uint64_t timeUs,
+                   uint64_t rxStationId,
+                   uint64_t txStationId,
+                   double rxLat,
+                   double rxLon,
+                   double txLat,
+                   double txLon,
+                   double distance,
+                   uint8_t los,
+                   double sinr,
+                   double snr,
+                   double rssi,
+                   double rsrp)
+{
+  bool writeHeader = !FileExists (g_signalCsvPath);
+  std::ofstream file (g_signalCsvPath, std::ios::out | std::ios::app);
+  if (!file.is_open ())
+    {
+      std::cerr << "Unable to create signal CSV: " << g_signalCsvPath << std::endl;
+      return;
+    }
+
+  if (writeHeader)
+    {
+      file << "message_type,time_us,rx,tx,rx_lat,rx_lon,tx_lat,tx_lon,rx_technology,distance_m,los,sinr_db,snr_db,rssi_dbm,rsrp_dbm" << std::endl;
+    }
+
+  file << messageType << "," << timeUs << "," << rxStationId << "," << txStationId << ","
+       << rxLat << "," << rxLon << "," << txLat << "," << txLon << ","
+       << GetStationTechnology (rxStationId) << "," << distance << "," << static_cast<uint32_t> (los)
+       << "," << sinr << "," << snr << "," << rssi << "," << rsrp << std::endl;
+}
+
+void
+GetSlBitmapFromString (std::string slBitMapString, std::vector <std::bitset<1> > &slBitMapVector)
+{
+  static std::unordered_map<std::string, uint8_t> lookupTable =
+      {
+          { "0", 0 },
+          { "1", 1 },
+      };
+
+  std::stringstream ss (slBitMapString);
+  std::string token;
+  std::vector<std::string> extracted;
+
+  while (std::getline (ss, token, '|'))
+    {
+      extracted.push_back (token);
+    }
+
+  for (const auto & v : extracted)
+    {
+      if (lookupTable.find (v) == lookupTable.end ())
+        {
+          NS_FATAL_ERROR ("Bit type " << v << " not valid. Valid values are: 0 and 1");
+        }
+      slBitMapVector.push_back (lookupTable[v] & 0x01);
+    }
+}
+
+void receiveCAM(asn1cpp::Seq<CAM> cam, Address from, StationId_t my_stationID, StationType_t my_StationType, SignalInfo phy_info)
+{
+  packet_count++;
+  if (!phy_collection)
+    {
+      return;
+    }
+
+  double snr = phy_info.snr;
+  double sinr = phy_info.sinr;
+  double rssi = phy_info.rssi;
+  double rsrp = phy_info.rsrp;
+  if (std::isnan(sinr) && !std::isnan(snr))
+    {
+      sinr = snr;
+    }
+  if (std::isnan(rssi) && !std::isnan(rsrp))
+    {
+      rssi = rsrp;
+    }
+
+  libsumo::TraCIPosition pos = basicServices.get(my_stationID)->getTraCIclient ()->TraCIAPI::vehicle.getPosition("veh" + std::to_string(my_stationID));
+  libsumo::TraCIPosition pos_lat_lon = basicServices.get(my_stationID)->getTraCIclient ()->TraCIAPI::simulation.convertXYtoLonLat(pos.x,pos.y);
+
+  // Get the position of the sender
+  double lat_sender = asn1cpp::getField(cam->cam.camParameters.basicContainer.referencePosition.latitude,double)/1e7;
+  double lon_sender = asn1cpp::getField(cam->cam.camParameters.basicContainer.referencePosition.longitude,double)/1e7;
+
+  libsumo::TraCIPosition pos_sender = basicServices.get(my_stationID)->getTraCIclient ()->TraCIAPI::vehicle.getPosition("veh" + std::to_string(cam->header.stationId));
+
+  // Compute the distance between the sender and the receiver
+  double distance = haversineDist (lat_sender, lon_sender, pos_lat_lon.y, pos_lat_lon.x);
+
+  ulong time = Simulator::Now().GetMicroSeconds();
+  uint8_t los;
+  Vector a_position = {pos.x, pos.y, pos.z};
+  Vector b_position = {pos_sender.x, pos_sender.y, 0};
+  if (use_sionna)
+  {
+    std::string los_str = getLOSStatusFromSionna(a_position, b_position);
+    if (los_str == "[False]")
+      {
+        los = 0;
+      }
+    else
+      {
+        los = 1;
+      }
+  }
+  else
+  {
+    los = 0; // Default, with ns-3 models we should check if the model used provides LOS/NLOS state and its current value
+  }
+
+  WriteSignalSample ("CAM",
+                     time,
+                     my_stationID,
+                     cam->header.stationId,
+                     pos_lat_lon.y,
+                     pos_lat_lon.x,
+                     lat_sender,
+                     lon_sender,
+                     distance,
+                     los,
+                     sinr,
+                     snr,
+                     rssi,
+                     rsrp);
+}
+
+void receiveCPM(asn1cpp::Seq<CollectivePerceptionMessage> cpm, Address from, StationId_t my_stationID, StationType_t my_StationType, SignalInfo phy_info)
+{
+  packet_count++;
+  if (!phy_collection)
+    {
+      return;
+    }
+
+  double snr = phy_info.snr;
+  double sinr = phy_info.sinr;
+  double rssi = phy_info.rssi;
+  double rsrp = phy_info.rsrp;
+  if (std::isnan(sinr) && !std::isnan(snr))
+    {
+      sinr = snr;
+    }
+  if (std::isnan(rssi) && !std::isnan(rsrp))
+    {
+      rssi = rsrp;
+    }
+  libsumo::TraCIPosition pos = basicServices.get(my_stationID)->getTraCIclient ()->TraCIAPI::vehicle.getPosition("veh" + std::to_string(my_stationID));
+  libsumo::TraCIPosition pos_lat_lon = basicServices.get(my_stationID)->getTraCIclient ()->TraCIAPI::simulation.convertXYtoLonLat(pos.x,pos.y);
+
+  // Get the position of the sender
+  double lat_sender = asn1cpp::getField(cpm->payload.managementContainer.referencePosition.latitude,double)/1e7;
+  double lon_sender = asn1cpp::getField(cpm->payload.managementContainer.referencePosition.longitude,double)/1e7;
+
+  libsumo::TraCIPosition pos_sender = basicServices.get(my_stationID)->getTraCIclient ()->TraCIAPI::vehicle.getPosition("veh" + std::to_string(cpm->header.stationId));
+
+  // Compute the distance between the sender and the receiver
+  double distance = haversineDist (lat_sender, lon_sender, pos_lat_lon.y, pos_lat_lon.x);
+
+  ulong time = Simulator::Now().GetMicroSeconds();
+  uint8_t los;
+  Vector a_position = {pos.x, pos.y, pos.z};
+  Vector b_position = {pos_sender.x, pos_sender.y, pos_sender.z};
+  if (use_sionna)
+  {
+    std::string los_str = getLOSStatusFromSionna(a_position, b_position);
+    if (los_str == "[False]")
+      {
+        los = 0;
+      }
+    else
+      {
+        los = 1;
+      }
+  }
+  else
+  {
+    los = 0; // Default, with ns-3 models we should check if the model used provides LOS/NLOS state and its current value
+  }
+  WriteSignalSample ("CPM",
+                     time,
+                     my_stationID,
+                     cpm->header.stationId,
+                     pos_lat_lon.y,
+                     pos_lat_lon.x,
+                     lat_sender,
+                     lon_sender,
+                     distance,
+                     los,
+                     sinr,
+                     snr,
+                     rssi,
+                     rsrp);
+}
+
+void savePRRs(Ptr<MetricSupervisor> metSup, std::vector<std::string> nodes, std::string type)
+{
+  std::string path = type == "nr" ? g_prrCsvNrPath : g_prrCsv11bdPath;
+  std::string technology = type == "nr" ? "NR-V2X" : "802.11bd";
+  bool writeHeader = !FileExists (path);
+  std::ofstream file (path, std::ios::out | std::ios::app);
+  if (!file.is_open ())
+    {
+      std::cerr << "Unable to create PRR CSV: " << path << std::endl;
+      return;
+    }
+  if (writeHeader)
+    {
+      file << "technology,node_id,prr,latency_ms" << std::endl;
+    }
+  for (const auto& node : nodes)
+    {
+      uint64_t stationId = std::stol (node.substr (3));
+      double prr = metSup->getAveragePRR_vehicle (stationId);
+      double latency = metSup->getAverageLatency_vehicle (stationId);
+      file << technology << "," << node << "," << prr << "," << latency << std::endl;
+    }
+}
+
+void txTrackerSetup(std::vector<std::string> wifiVehicles, NodeContainer wifiNodes, std::vector<std::string> nrVehicles, NetDeviceContainer nrDevices, bool ngv_interference, bool nr_interference)
+{
+  auto& tracker = TxTracker::GetInstance();
+
+  std::vector<std::tuple<std::string, uint8_t, Ptr<WifiNetDevice>>> wifiVehiclesList;
+  std::vector<std::tuple<std::string, uint8_t, Ptr<NrUeNetDevice>>> nrVehiclesList;
+
+  uint8_t i = ngv_interference ? 1 : 0; // Start from 1 because the first node is the interfering one
+  for (auto v : wifiVehicles)
+    {
+      uint8_t id = wifiNodes.Get(i)->GetId();
+      Ptr<WifiNetDevice> netDevice = DynamicCast<WifiNetDevice>(wifiNodes.Get(i)->GetDevice(0));
+      wifiVehiclesList.push_back (std::make_tuple (v, id, netDevice));
+      i++;
+    }
+  tracker.Insert11bdNodes (wifiVehiclesList);
+
+  i = nr_interference ? 1 : 0;
+  for (auto v : nrVehicles)
+    {
+      Ptr<NrUeNetDevice> netDevice = DynamicCast<NrUeNetDevice>(nrDevices.Get(i));
+      uint8_t id = nrDevices.Get (i)->GetNode()->GetId();
+      nrVehiclesList.push_back (std::make_tuple (v, id, netDevice));
+      i++;
+    }
+  tracker.InsertNrNodes (nrVehiclesList);
+}
+
+static void GenerateTraffic_interfering (Ptr<Socket> socket, uint32_t pktSize,
+                             uint32_t pktCount, Time pktInterval, uint8_t vehicles, Ptr<TraciClient> traci)
+{
+  uint8_t present = traci->GetVehicleMapSize();
+  if (present != vehicles)
+    {
+      Simulator::Schedule(pktInterval, &GenerateTraffic_interfering, socket, pktSize, pktCount, pktInterval, vehicles, traci);
+      return;
+    }
+  // Generate interfering traffic by sending pktCount packets (filled in with zeros), every pktInterval
+  if (pktCount > 0)
+    {
+      // "Create<Packet> (pktSize)" creates a new packet of size pktSize bytes, composed by default by all zero
+      // Populate the packet with random data
+      std::string data = "";
+      uint16_t packetSize = 1000;
+      for (int i = 0; i < packetSize; i++)
+        {
+          data += std::to_string (counter);
+          data += ",";
+          long long now = Simulator::Now().GetMicroSeconds();
+          data += std::to_string (now);
+          data += ",";
+        }
+      Ptr<Packet> packet = Create<Packet>((uint8_t*) data.c_str(), packetSize);
+      if (socket->Send (packet) != -1)
+        {
+          // std::cout << "Interfering packet sent" << std::endl;
+          counter ++;
+        }
+      // Schedule again the same function (to send the next packet), and decrease by one the packet count
+      Simulator::Schedule (pktInterval, &GenerateTraffic_interfering, socket, pktSize, pktCount, pktInterval, vehicles, traci);
+    }
+  else
+    {
+      socket->Close ();
+    }
+}
+
+int main (int argc, char *argv[])
+{
+  phy_collection = true;
+
+  std::string phyMode ("OfdmRate12MbpsBW10MHz");
+  int up = 0;
+  bool realtime = false;
+  bool verbose = false; // Set to true to get a lot of verbose output from the PHY model (leave this to false)
+  int numberOfNodes; // Total number of vehicles, automatically filled in by reading the XML file
+  double m_baseline_prr = 150.0; // PRR baseline value (default: 150 m)
+  int txPower = 30.0; // Transmission power in dBm (default: 23 dBm)
+  double sensitivity = -95.0;
+  double snr_threshold = 4.0;
+  double sinr_threshold = 10; // Default value
+  xmlDocPtr rou_xml_file;
+  double simTime = 50.0; // Total simulation time (default: 200 seconds)
+
+  // NR parameters. We will take the input from the command line, and then we
+  // will pass them inside the NR module.
+  double centralFrequencyBandSl = 5.89e9; // band n47  TDD //Here band is analogous to channel
+  // uint16_t bandwidthBandSl = 400;
+  uint16_t bandwidthBandSl = 100; // 10 MHz
+  std::string tddPattern = "UL|UL|UL|UL|UL|UL|UL|UL|UL|UL|";
+  std::string slBitMap = "1|1|1|1|1|1|1|1|1|1";
+  uint16_t numerologyBwpSl = 2;
+  // uint16_t numerologyBwpSl = 0;
+  uint16_t slSensingWindow = 100; // T0 in ms
+  uint16_t slSelectionWindow = 5; // T2min
+  uint16_t slSubchannelSize = 10;
+  uint16_t slMaxNumPerReserve = 3;
+  double slProbResourceKeep = 0.0;
+  uint16_t slMaxTxTransNumPssch = 5;
+  uint16_t reservationPeriod = 20; // in ms
+  bool enableSensing = false;
+  uint16_t t1 = 2;
+  uint16_t t2 = 81;
+  // uint16_t t2 = 21;
+  int slThresPsschRsrp = -128;
+  bool enableChannelRandomness = false;
+  uint16_t channelUpdatePeriod = 500; //ms
+  uint8_t mcs = 14;
+
+  bool m_metric_sup = true;
+
+  bool sionna = false;
+  std::string server_ip = "";
+  bool local_machine = false;
+  bool verb = false;
+
+  bool interference = false;
+  bool ngv_interference = false;
+  bool nr_interference = false;
+  std::string outputDir = "src";
+  std::string simTag = "coexistence-80211bd-nrv2x";
+
+  Time slBearersActivationTime = Seconds (2.0);
+
+  if ((ngv_interference && nr_interference) /*|| (interference && !(ngv_interference || nr_interference))*/)
+    {
+      NS_FATAL_ERROR ("Check the interference setup.");
+    }
+
+  // Set here the path to the SUMO XML files
+  std::string sumo_folder = "src/automotive/examples/sumo_files_v2v_map/";
+  std::string mob_trace = "cars.rou.xml";
+  std::string sumo_config ="src/automotive/examples/sumo_files_v2v_map/map.sumo.cfg";
+
+  // Read the command line options
+  CommandLine cmd (__FILE__);
+  cmd.AddValue ("phyMode", "Wifi Phy mode", phyMode);
+  cmd.AddValue ("verbose", "turn on all WifiNetDevice log components", verbose);
+  cmd.AddValue ("userpriority","EDCA User Priority for the ETSI messages",up);
+  cmd.AddValue ("baseline", "Baseline for PRR calculation", m_baseline_prr);
+  cmd.AddValue ("tx-power", "OBUs transmission power [dBm]", txPower);
+  cmd.AddValue ("rx-sensitivity", "802.11bd preamble-detection RSSI threshold [dBm]", sensitivity);
+  cmd.AddValue ("snr-threshold", "802.11bd preamble-detection SNR threshold [dB]", snr_threshold);
+  cmd.AddValue ("sim-time", "Total duration of the simulation [s]", simTime);
+  cmd.AddValue ("sionna", "Enable SIONNA usage", sionna);
+  cmd.AddValue ("sionna-server-ip", "SIONNA server IP address", server_ip);
+  cmd.AddValue ("sionna-local-machine", "SIONNA will be executed on local machine", local_machine);
+  cmd.AddValue ("sionna-verbose", "SIONNA server IP address", verb);
+  cmd.AddValue ("output-dir", "Directory for coexistence CSV outputs", outputDir);
+  cmd.AddValue ("sim-tag", "Tag used to name coexistence CSV outputs", simTag);
+  cmd.Parse (argc, argv);
+
+  if (simTag.empty ())
+    {
+      simTag = "coexistence-80211bd-nrv2x";
+    }
+  EnsureDirectory (outputDir);
+  g_signalCsvPath = JoinPath (outputDir, simTag + "-signal.csv");
+  g_prrCsv11bdPath = JoinPath (outputDir, simTag + "-prr-80211bd.csv");
+  g_prrCsvNrPath = JoinPath (outputDir, simTag + "-prr-nrv2x.csv");
+
+  VehicularWifiProfile wifiProfile =
+      VehicularWifiProfile::Ieee80211bd (phyMode, txPower, sensitivity, snr_threshold);
+
+  std::cout << "Start running v2v-simple-cam-exchange-80211bd-nrv2x simulation" << std::endl;
+
+  use_sionna = sionna;
+  SionnaHelper& sionnaHelper = SionnaHelper::GetInstance();
+  if (sionna)
+    {
+      sionnaHelper.SetSionna(sionna);
+      sionnaHelper.SetServerIp(server_ip);
+      sionnaHelper.SetLocalMachine(local_machine);
+      sionnaHelper.SetVerbose(verb);
+    }
+
+  /* Load the .rou.xml file (SUMO map and scenario) */
+  xmlInitParser();
+  std::string path = sumo_folder + mob_trace;
+  rou_xml_file = xmlParseFile(path.c_str ());
+  if (rou_xml_file == NULL)
+    {
+      NS_FATAL_ERROR("Error: unable to parse the specified XML file: "<<path);
+    }
+  numberOfNodes = XML_rou_count_vehicles(rou_xml_file);
+  /*if (interference)
+    {
+      numberOfNodes --;
+    }*/
+  xmlFreeDoc(rou_xml_file);
+  xmlCleanupParser();
+
+  // Check if there are enough nodes
+  // This application requires at least three vehicles (as vehicle 3 is the one generating interfering traffic, it should exist)
+  if(numberOfNodes==-1)
+    {
+      NS_FATAL_ERROR("Fatal error: cannot gather the number of vehicles from the specified XML file: "<<path<<". Please check if it is a correct SUMO file.");
+    }
+
+  Ptr<TraciClient> sumoClient = CreateObject<TraciClient> ();
+
+  if (sionna)
+    {
+      sumoClient->SetSionnaUp();
+    }
+
+  bool odd = false;
+  if (numberOfNodes%2 != 0)
+    {
+      odd = true;
+    }
+
+  std::vector<std::string> wifiVehicles;
+  std::vector<std::string> nrVehicles;
+
+  uint8_t i = 1;
+  if (ngv_interference || nr_interference)
+    {
+      i = 2;
+    }
+
+  for (; i <= numberOfNodes; i++)
+    {
+      if (i%2 == 0)
+        {
+          wifiVehicles.push_back ("veh" + std::to_string (i));
+          ngvVehicles.push_back (i);
+        }
+      else
+        {
+          nrVehicles.push_back("veh" + std::to_string (i));
+          nrv2xVehicles.push_back (i);
+        }
+    }
+
+  uint64_t numberOfNodes_11bd = wifiVehicles.size();
+  uint64_t numberOfNodes_nr = nrVehicles.size();
+
+  if (ngv_interference)
+    {
+      numberOfNodes_11bd ++;
+    }
+  else if (nr_interference)
+    {
+      numberOfNodes_nr ++;
+    }
+
+  Ptr<MetricSupervisor> metSup_11bd = NULL;
+  // Set a baseline for the PRR computation when creating a new Metricsupervisor object
+  MetricSupervisor metSupObj_11bd(m_baseline_prr);
+  metSup_11bd = &metSupObj_11bd;
+  metSup_11bd->setTraCIClient(sumoClient);
+  // This function enables printing the current and average latency and PRR for each received packet
+  // metSup_11bd->enablePRRVerboseOnStdout ();
+  wifiProfile.ConfigureMetricSupervisor (metSup_11bd);
+  metSup_11bd->setCBRWindowValue(200);
+  metSup_11bd->setCBRAlphaValue(0.1);
+  metSup_11bd->setSimulationTimeValue(simTime);
+
+  Ptr<MetricSupervisor> metSup_nr = NULL;
+  // Set a baseline for the PRR computation when creating a new Metricsupervisor object
+  MetricSupervisor metSupObj_nr(m_baseline_prr);
+  metSup_nr = &metSupObj_nr;
+  metSup_nr->setTraCIClient(sumoClient);
+  // metSup_nr->enablePRRVerboseOnStdout ();
+
+  MobilityHelper mobility;
+
+  /*
+   * Default values for the simulation.
+   */
+  Config::SetDefault ("ns3::LteRlcUm::MaxTxBufferSize", UintegerValue (999999999));
+
+
+  /* Use the realtime scheduler of ns3 */
+  if(realtime)
+    GlobalValue::Bind ("SimulatorImplementationType", StringValue ("ns3::RealtimeSimulatorImpl"));
+
+  Ptr<NrPointToPointEpcHelper> epcHelper = CreateObject<NrPointToPointEpcHelper> ();
+  Ptr<NrHelper> nrHelper = CreateObject<NrHelper> ();
+
+  NodeContainer nrNodes;
+  nrNodes.Create(numberOfNodes_nr);
+
+  mobility.Install (nrNodes);
+
+  // Put the pointers inside nrHelper
+  nrHelper->SetEpcHelper (epcHelper);
+
+  BandwidthPartInfoPtrVector allBwps;
+  CcBwpCreator ccBwpCreator;
+  const uint8_t numCcPerBand = 1;
+
+  CcBwpCreator::SimpleOperationBandConf bandConfSl (centralFrequencyBandSl, bandwidthBandSl, numCcPerBand, BandwidthPartInfo::V2V_Highway);
+  OperationBandInfo bandSl = ccBwpCreator.CreateOperationBandContiguousCc (bandConfSl);
+
+  if (enableChannelRandomness)
+    {
+      Config::SetDefault ("ns3::ThreeGppChannelModel::UpdatePeriod", TimeValue (MilliSeconds (channelUpdatePeriod)));
+      nrHelper->SetChannelConditionModelAttribute ("UpdatePeriod", TimeValue (MilliSeconds (channelUpdatePeriod)));
+      nrHelper->SetPathlossAttribute ("ShadowingEnabled", BooleanValue (true));
+    }
+  else
+    {
+      Config::SetDefault ("ns3::ThreeGppChannelModel::UpdatePeriod", TimeValue (MilliSeconds (0)));
+      nrHelper->SetChannelConditionModelAttribute ("UpdatePeriod", TimeValue (MilliSeconds (0)));
+      nrHelper->SetPathlossAttribute ("ShadowingEnabled", BooleanValue (false));
+    }
+
+  nrHelper->InitializeOperationBand (&bandSl);
+  allBwps = CcBwpCreator::GetAllBwps ({bandSl});
+
+
+  nrHelper->SetUeAntennaAttribute ("NumRows", UintegerValue (1));  //following parameter has no impact at the moment because:
+  nrHelper->SetUeAntennaAttribute ("NumColumns", UintegerValue (2));
+  nrHelper->SetUeAntennaAttribute ("AntennaElement", PointerValue (CreateObject<IsotropicAntennaModel> ()));
+
+  nrHelper->SetUePhyAttribute ("TxPower", DoubleValue (txPower));
+  nrHelper->SetUePhyAttribute ("RiSinrThreshold1", DoubleValue (sinr_threshold));
+  nrHelper->SetUePhyAttribute ("RiSinrThreshold2", DoubleValue (sinr_threshold));
+
+  // nrHelper->SetUeAntennaAttribute ();
+
+  nrHelper->SetUeMacAttribute ("EnableSensing", BooleanValue (enableSensing));
+  nrHelper->SetUeMacAttribute ("T1", UintegerValue (static_cast<uint8_t> (t1)));
+  nrHelper->SetUeMacAttribute ("T2", UintegerValue (t2));
+  nrHelper->SetUeMacAttribute ("ActivePoolId", UintegerValue (0));
+  nrHelper->SetUeMacAttribute ("ReservationPeriod", TimeValue (MilliSeconds (reservationPeriod)));
+  nrHelper->SetUeMacAttribute ("NumSidelinkProcess", UintegerValue (4));
+  nrHelper->SetUeMacAttribute ("EnableBlindReTx", BooleanValue (true));
+  nrHelper->SetUeMacAttribute ("SlThresPsschRsrp", IntegerValue (slThresPsschRsrp));
+
+  uint8_t bwpIdForGbrMcptt = 0;
+
+  nrHelper->SetBwpManagerTypeId (TypeId::LookupByName ("ns3::NrSlBwpManagerUe"));
+  nrHelper->SetUeBwpManagerAlgorithmAttribute ("GBR_MC_PUSH_TO_TALK", UintegerValue (bwpIdForGbrMcptt));
+
+  std::set<uint8_t> bwpIdContainer;
+  bwpIdContainer.insert (bwpIdForGbrMcptt);
+
+  NetDeviceContainer allSlUesNetDeviceContainer = nrHelper->InstallUeDevice (nrNodes, allBwps);
+
+  // When all the configuration is done, explicitly call UpdateConfig ()
+  for (auto it = allSlUesNetDeviceContainer.Begin (); it != allSlUesNetDeviceContainer.End (); ++it)
+    {
+      DynamicCast<NrUeNetDevice> (*it)->UpdateConfig ();
+    }
+
+  Ptr<NrSlHelper> nrSlHelper = CreateObject <NrSlHelper> ();
+  // Put the pointers inside NrSlHelper
+  nrSlHelper->SetEpcHelper (epcHelper);
+
+  std::string errorModel = "ns3::NrLteMiErrorModel";
+  nrSlHelper->SetSlErrorModel (errorModel);
+  nrSlHelper->SetUeSlAmcAttribute ("AmcModel", EnumValue (NrAmc::ErrorModel));
+
+  nrSlHelper->SetNrSlSchedulerTypeId (NrSlUeMacSchedulerSimple::GetTypeId());
+  nrSlHelper->SetUeSlSchedulerAttribute ("FixNrSlMcs", BooleanValue (true));
+  nrSlHelper->SetUeSlSchedulerAttribute ("InitialNrSlMcs", UintegerValue (mcs));
+
+  nrSlHelper->PrepareUeForSidelink (allSlUesNetDeviceContainer, bwpIdContainer);
+
+  LteRrcSap::SlResourcePoolNr slResourcePoolNr;
+  //get it from pool factory
+  Ptr<NrSlCommPreconfigResourcePoolFactory> ptrFactory = Create<NrSlCommPreconfigResourcePoolFactory> ();
+
+  std::vector <std::bitset<1> > slBitMapVector;
+  GetSlBitmapFromString (slBitMap, slBitMapVector);
+  NS_ABORT_MSG_IF (slBitMapVector.empty (), "GetSlBitmapFromString failed to generate SL bitmap");
+  ptrFactory->SetSlTimeResources (slBitMapVector);
+  ptrFactory->SetSlSensingWindow (slSensingWindow); // T0 in ms
+  ptrFactory->SetSlSelectionWindow (slSelectionWindow);
+  ptrFactory->SetSlFreqResourcePscch (10); // PSCCH RBs
+  ptrFactory->SetSlSubchannelSize (slSubchannelSize);
+  ptrFactory->SetSlMaxNumPerReserve (slMaxNumPerReserve);
+  //Once parameters are configured, we can create the pool
+  LteRrcSap::SlResourcePoolNr pool = ptrFactory->CreatePool ();
+  slResourcePoolNr = pool;
+
+  //Configure the SlResourcePoolConfigNr IE, which hold a pool and its id
+  LteRrcSap::SlResourcePoolConfigNr slresoPoolConfigNr;
+  slresoPoolConfigNr.haveSlResourcePoolConfigNr = true;
+  //Pool id, ranges from 0 to 15
+  uint16_t poolId = 0;
+  LteRrcSap::SlResourcePoolIdNr slResourcePoolIdNr;
+  slResourcePoolIdNr.id = poolId;
+  slresoPoolConfigNr.slResourcePoolId = slResourcePoolIdNr;
+  slresoPoolConfigNr.slResourcePool = slResourcePoolNr;
+
+  //Configure the SlBwpPoolConfigCommonNr IE, which hold an array of pools
+  LteRrcSap::SlBwpPoolConfigCommonNr slBwpPoolConfigCommonNr;
+  //Array for pools, we insert the pool in the array as per its poolId
+  slBwpPoolConfigCommonNr.slTxPoolSelectedNormal [slResourcePoolIdNr.id] = slresoPoolConfigNr;
+
+  LteRrcSap::Bwp bwp;
+  bwp.numerology = numerologyBwpSl;
+  bwp.symbolsPerSlots = 14;
+  bwp.rbPerRbg = 1;
+  bwp.bandwidth = bandwidthBandSl;
+
+  //Configure the SlBwpGeneric IE
+  LteRrcSap::SlBwpGeneric slBwpGeneric;
+  slBwpGeneric.bwp = bwp;
+  slBwpGeneric.slLengthSymbols = LteRrcSap::GetSlLengthSymbolsEnum (14);
+  slBwpGeneric.slStartSymbol = LteRrcSap::GetSlStartSymbolEnum (0);
+
+  //Configure the SlBwpConfigCommonNr IE
+  LteRrcSap::SlBwpConfigCommonNr slBwpConfigCommonNr;
+  slBwpConfigCommonNr.haveSlBwpGeneric = true;
+  slBwpConfigCommonNr.slBwpGeneric = slBwpGeneric;
+  slBwpConfigCommonNr.haveSlBwpPoolConfigCommonNr = true;
+  slBwpConfigCommonNr.slBwpPoolConfigCommonNr = slBwpPoolConfigCommonNr;
+
+  //Configure the SlFreqConfigCommonNr IE, which hold the array to store
+  //the configuration of all Sidelink BWP (s).
+  LteRrcSap::SlFreqConfigCommonNr slFreConfigCommonNr;
+  //Array for BWPs. Here we will iterate over the BWPs, which
+  //we want to use for SL.
+  for (const auto &it:bwpIdContainer)
+    {
+      // it is the BWP id
+      slFreConfigCommonNr.slBwpList [it] = slBwpConfigCommonNr;
+    }
+
+  //Configure the TddUlDlConfigCommon IE
+  LteRrcSap::TddUlDlConfigCommon tddUlDlConfigCommon;
+  tddUlDlConfigCommon.tddPattern = tddPattern;
+
+  //Configure the SlPreconfigGeneralNr IE
+  LteRrcSap::SlPreconfigGeneralNr slPreconfigGeneralNr;
+  slPreconfigGeneralNr.slTddConfig = tddUlDlConfigCommon;
+
+  //Configure the SlUeSelectedConfig IE
+  LteRrcSap::SlUeSelectedConfig slUeSelectedPreConfig;
+  NS_ABORT_MSG_UNLESS (slProbResourceKeep <= 1.0, "slProbResourceKeep value must be between 0 and 1");
+  slUeSelectedPreConfig.slProbResourceKeep = slProbResourceKeep;
+  //Configure the SlPsschTxParameters IE
+  LteRrcSap::SlPsschTxParameters psschParams;
+  psschParams.slMaxTxTransNumPssch = static_cast<uint8_t> (slMaxTxTransNumPssch);
+  //Configure the SlPsschTxConfigList IE
+  LteRrcSap::SlPsschTxConfigList pscchTxConfigList;
+  pscchTxConfigList.slPsschTxParameters [0] = psschParams;
+  slUeSelectedPreConfig.slPsschTxConfigList = pscchTxConfigList;
+
+  /*
+   * Finally, configure the SidelinkPreconfigNr. This is the main structure
+   * that needs to be communicated to NrSlUeRrc class
+   */
+  LteRrcSap::SidelinkPreconfigNr slPreConfigNr;
+  slPreConfigNr.slPreconfigGeneral = slPreconfigGeneralNr;
+  slPreConfigNr.slUeSelectedPreConfig = slUeSelectedPreConfig;
+  slPreConfigNr.slPreconfigFreqInfoList [0] = slFreConfigCommonNr;
+
+  //Communicate the above pre-configuration to the NrSlHelper
+  nrSlHelper->InstallNrSlPreConfiguration (allSlUesNetDeviceContainer, slPreConfigNr);
+
+  int64_t stream = 1;
+  stream += nrHelper->AssignStreams (allSlUesNetDeviceContainer, stream);
+  stream += nrSlHelper->AssignStreams (allSlUesNetDeviceContainer, stream);
+
+  NodeContainer txSlUes;
+  NodeContainer rxSlUes;
+  NetDeviceContainer txSlUesNetDevice;
+  NetDeviceContainer rxSlUesNetDevice;
+  txSlUes.Add (nrNodes);
+  rxSlUes.Add (nrNodes);
+  txSlUesNetDevice.Add (allSlUesNetDeviceContainer);
+  rxSlUesNetDevice.Add (allSlUesNetDeviceContainer);
+
+  InternetStackHelper internet;
+  internet.Install (nrNodes);
+  uint32_t dstL2Id = 255;
+  Ipv4Address groupAddress4 ("225.0.0.0");     //use multicast address as destination
+
+  Address remoteAddress;
+  Address localAddress;
+  uint16_t port = 8000;
+  Ptr<LteSlTft> tft;
+
+  Ipv4InterfaceContainer ueIpIface;
+  ueIpIface = epcHelper->AssignUeIpv4Address (allSlUesNetDeviceContainer);
+
+  // set the default gateway for the UE
+  Ipv4StaticRoutingHelper ipv4RoutingHelper;
+  for (uint32_t u = 0; u < nrNodes.GetN (); ++u)
+    {
+      Ptr<Node> ueNode = nrNodes.Get (u);
+      // Set the default gateway for the UE
+      Ptr<Ipv4StaticRouting> ueStaticRouting = ipv4RoutingHelper.GetStaticRouting (ueNode->GetObject<Ipv4> ());
+      ueStaticRouting->SetDefaultRoute (epcHelper->GetUeDefaultGatewayAddress (), 1);
+    }
+  remoteAddress = InetSocketAddress (groupAddress4, port);
+  localAddress = InetSocketAddress (Ipv4Address::GetAny (), port);
+
+  tft = Create<LteSlTft> (LteSlTft::Direction::TRANSMIT, LteSlTft::CommType::GroupCast, groupAddress4, dstL2Id);
+  //Set Sidelink bearers
+  nrSlHelper->ActivateNrSlBearer (slBearersActivationTime, allSlUesNetDeviceContainer, tft);
+
+  tft = Create<LteSlTft> (LteSlTft::Direction::RECEIVE, LteSlTft::CommType::GroupCast, groupAddress4, dstL2Id);
+  //Set Sidelink bearers
+  nrSlHelper->ActivateNrSlBearer (slBearersActivationTime, allSlUesNetDeviceContainer, tft);
+
+  // Create numberOfNodes nodes
+  NodeContainer wifiNodes;
+  wifiNodes.Create (numberOfNodes_11bd);
+
+  YansWifiPhyHelper wifiPhy;
+  wifiProfile.ConfigurePhy (wifiPhy);
+  YansWifiChannelHelper wifiChannel = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = wifiChannel.Create ();
+  channel->SetAttribute ("PropagationLossModel", StringValue ("ns3::CniUrbanmicrocellPropagationLossModel"));
+  wifiPhy.SetChannel (channel);
+
+  // ns-3 supports generating a pcap trace, to be later analyzed in Wireshark
+  wifiPhy.SetPcapDataLinkType (WifiPhyHelper::DLT_IEEE802_11);
+
+  // We need a QosWaveMac, as we need to enable QoS and EDCA
+  QosWaveMacHelper wifi80211bdMac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi80211bd = Wifi80211pHelper::Default ();
+  if (verbose)
+    {
+      wifi80211bd.EnableLogComponents ();      // Turn on all Wifi 802.11bd logging, only if verbose is true
+    }
+
+  wifiProfile.ConfigureRemoteStationManager (wifi80211bd);
+  NetDeviceContainer devices = wifi80211bd.Install (wifiPhy, wifi80211bdMac, wifiNodes);
+
+  // metSup_11bd->setNodeContainer(wifiNodes);
+  // metSup_11bd->startCheckCBR();
+
+  // Enable saving to Wireshark PCAP traces
+  // wifiPhy.EnablePcap ("v2v-80211bd-student-application", devices);
+
+  // Set up the link between SUMO and ns-3, to make each node "mobile" (i.e., linking each ns-3 node to each moving vehicle in ns-3,
+  // which corresponds to installing the network stack to each SUMO vehicle)
+  mobility.Install (wifiNodes);
+
+  PacketSocketHelper packetSocket;
+  packetSocket.Install(wifiNodes);
+
+  sumoClient->SetAttribute ("SumoConfigPath", StringValue (sumo_config));
+  sumoClient->SetAttribute ("SumoBinaryPath", StringValue (""));    // use system installation of sumo
+  sumoClient->SetAttribute ("SynchInterval", TimeValue (Seconds (0.01)));
+  sumoClient->SetAttribute ("StartTime", TimeValue (Seconds (0.0)));
+  sumoClient->SetAttribute ("SumoGUI", BooleanValue (false));
+  sumoClient->SetAttribute ("SumoPort", UintegerValue (3400));
+  sumoClient->SetAttribute ("PenetrationRate", DoubleValue (1.0));
+  sumoClient->SetAttribute ("SumoLogFile", BooleanValue (false));
+  sumoClient->SetAttribute ("SumoStepLog", BooleanValue (false));
+  sumoClient->SetAttribute ("SumoSeed", IntegerValue (10));
+  sumoClient->SetAttribute ("SumoWaitForSocket", TimeValue (Seconds (1.0)));
+
+  if (interference)
+  {
+    std::cout << "Interference mode enabled" << std::endl;
+    auto& tracker = TxTracker::GetInstance();
+    tracker.SetCentralFrequencies(centralFrequencyBandSl, centralFrequencyBandSl, centralFrequencyBandSl);
+    tracker.SetBandwidths(wifiProfile.GetChannelWidthMHz () * 1e6, bandwidthBandSl/10 * 1e6, 0.0);
+    txTrackerSetup(wifiVehicles, wifiNodes, nrVehicles, allSlUesNetDeviceContainer, ngv_interference, nr_interference);
+  }
+
+  uint8_t node11bdCounter = 0;
+  if (ngv_interference)
+    {
+      node11bdCounter = 1;
+    }
+
+  uint8_t nodeNrCounter = 0;
+  if (nr_interference)
+    {
+      nodeNrCounter = 1;
+    }
+
+  std::cout << "802.11bd profile: dataMode=" << wifiProfile.GetDataMode ()
+            << ", controlMode=" << wifiProfile.GetControlMode ()
+            << ", ppduFormat=" << wifiProfile.GetPpduFormatName ()
+            << ", ngvMcs=" << static_cast<uint32_t> (wifiProfile.GetNgvMcsIndex ())
+            << ", channelWidth=" << wifiProfile.GetChannelWidthMHz () << " MHz"
+            << ", txPower=" << wifiProfile.GetTxPowerDbm () << " dBm"
+            << ", rxSensitivity=" << wifiProfile.GetRxSensitivityDbm () << " dBm"
+            << std::endl;
+
+  std::cout << "Starting simulation... " << std::endl;
+
+  STARTUP_FCN setupNewWifiNode = [&] (std::string vehicleID, TraciClient::StationTypeTraCI_t stationType) -> Ptr<Node>
+  {
+    NodeType type;
+    unsigned long vehID = std::stol(vehicleID.substr (3));
+    unsigned long nodeID;
+
+    std::cout << "Vehicle entering in the simulation: " << vehicleID << " at time " << Simulator::Now().GetMicroSeconds() << std::endl;
+
+    if (std::find(wifiVehicles.begin(), wifiVehicles.end(), vehicleID) != wifiVehicles.end())
+      {
+        type = NodeType::NGV;
+        nodeID = node11bdCounter;
+        node11bdCounter++;
+      }
+    else if (std::find(nrVehicles.begin(), nrVehicles.end(), vehicleID) != nrVehicles.end())
+      {
+        type = NodeType::NR;
+        nodeID = nodeNrCounter;
+        nodeNrCounter++;
+      }
+    else
+      {
+        type = NodeType::INTERFERING;
+      }
+
+    Ptr<NetDevice> netDevice;
+    Ptr<Socket> sock;
+    Ptr<WifiNetDevice> wifiDevice;
+    Ptr<Node> includedNode;
+    Ipv4Address groupAddress4 ("225.0.0.0");
+    Ptr<NrUeNetDevice> nrDevice;
+    TypeId tid = TypeId::LookupByName ("ns3::UdpSocketFactory");
+    std::ofstream file;
+    switch (type)
+      {
+      case NodeType::NGV:
+        sock = GeoNet::createGNPacketSocket (wifiNodes.Get (nodeID));
+        netDevice = wifiNodes.Get (nodeID)->GetDevice (0);
+        wifiDevice = DynamicCast<WifiNetDevice> (netDevice);
+        wifiDevice->GetPhy ()->SetRxSensitivity (wifiProfile.GetRxSensitivityDbm ());
+        metSup_nr->addExcludedID (vehID);
+        break;
+      case NodeType::NR:
+        includedNode = nrNodes.Get (nodeID);
+        sock = Socket::CreateSocket (includedNode, tid);
+        if (sock->Bind (InetSocketAddress (Ipv4Address::GetAny (), 19)) == -1)
+          {
+            NS_FATAL_ERROR ("Failed to bind client socket for NR-V2X");
+          }
+        sock->Connect (InetSocketAddress (groupAddress4, 19));
+        netDevice = nrNodes.Get (nodeID)->GetDevice (0);
+        nrDevice = DynamicCast<NrUeNetDevice> (netDevice);
+        nrDevice->GetPhy(0)->GetSpectrumPhy ()->GetSpectrumChannel()->SetAttribute ("MaxLossDb", DoubleValue(120.0));
+        // nrHelper->GetUePhy (netDevice, 0)->SetRiSinrThreshold1 (snr_threshold);
+        // nrHelper->GetUePhy (netDevice, 0)->SetRiSinrThreshold2 (snr_threshold);
+        metSup_11bd->addExcludedID (vehID);
+        break;
+      case NodeType::INTERFERING:
+        metSup_11bd->addExcludedID (vehID);
+        metSup_nr->addExcludedID (vehID);
+        if (ngv_interference)
+          {
+            Ptr<Socket> socket = Socket::CreateSocket (wifiNodes.Get (0), TypeId::LookupByName ("ns3::PacketSocketFactory"));
+            PacketSocketAddress local_source_interfering;
+            local_source_interfering.SetSingleDevice (wifiNodes.Get (0)->GetDevice(0)->GetIfIndex ());
+            local_source_interfering.SetPhysicalAddress (wifiNodes.Get (0)->GetDevice(0)->GetAddress());
+            local_source_interfering.SetProtocol (0x88B5);
+            if (socket->Bind (local_source_interfering) == -1)
+              {
+                NS_FATAL_ERROR ("Failed to bind client socket for BTP + GeoNetworking (802.11bd)");
+              }
+            PacketSocketAddress remote_source_interfering;
+            remote_source_interfering.SetSingleDevice (wifiNodes.Get (0)->GetDevice(0)->GetIfIndex());
+            remote_source_interfering.SetPhysicalAddress (wifiNodes.Get (0)->GetDevice(0)->GetBroadcast());
+            remote_source_interfering.SetProtocol (0x88B5);
+            socket->Connect (remote_source_interfering);
+            socket->SetPriority (0);
+            Simulator::ScheduleWithContext (0,
+                                            Seconds (1.0), &GenerateTraffic_interfering,
+                                            socket, 1000, simTime*2000, MilliSeconds (5),
+                                            numberOfNodes, sumoClient);
+          }
+        else if (nr_interference)
+          {
+            // Da testare
+            Ptr<Socket> socket = Socket::CreateSocket (nrNodes.Get (0), tid);
+            if (socket->Bind (InetSocketAddress (Ipv4Address::GetAny (), 19)) == -1)
+              {
+                NS_FATAL_ERROR ("Failed to bind client socket for NR-V2X");
+              }
+            socket->Connect (InetSocketAddress (groupAddress4, 19));
+            socket->SetPriority (0);
+            Simulator::ScheduleWithContext (0,
+                                            Seconds (3.0), &GenerateTraffic_interfering,
+                                            socket, 1000, simTime*2000, MilliSeconds (5),
+                                            numberOfNodes, sumoClient);
+          }
+        break;
+      default:
+        NS_FATAL_ERROR ("No technology recognized.");
+      }
+
+    if (type != NodeType::INTERFERING)
+      {
+        Ptr<BSContainer> bs_container = CreateObject<BSContainer>(vehID,StationType_passengerCar,sumoClient,false,sock);
+        bs_container->addCAMRxCallback (std::bind(&receiveCAM, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5));
+        bs_container->addCPMRxCallback (std::bind(&receiveCPM, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5));
+        switch (type)
+          {
+          case NodeType::NGV:
+            bs_container->linkMetricSupervisor (metSup_11bd);
+            break;
+          case NodeType::NR:
+            bs_container->linkMetricSupervisor (metSup_nr);
+            break;
+          }
+        bs_container->disablePRRSupervisorForGNBeacons();
+        bs_container->setupContainer(true,false,false,true,false,false);
+        basicServices.add(bs_container);
+        std::srand(Simulator::Now().GetNanoSeconds ()*2); // Seed based on the simulation time to give each vehicle a different random seed
+        bs_container->getCABasicService ()->startCamDissemination ();
+        bs_container->getCPBasicService ()->startCpmDissemination ();
+      }
+
+    switch (type)
+      {
+      case NodeType::NGV:
+        return wifiNodes.Get(nodeID);
+      case NodeType::NR:
+        return nrNodes.Get(nodeID);
+      case NodeType::INTERFERING:
+        return wifiNodes.Get(0);
+      }
+  };
+
+  // Important: what you write here is called every time a node exits the simulation in SUMO
+  // You can safely keep this function as it is, and ignore it
+  SHUTDOWN_FCN shutdownWifiNode = [] (Ptr<Node> exNode, std::string vehicleID)
+  {
+    /* Set position outside communication range */
+    Ptr<ConstantPositionMobilityModel> mob = exNode->GetObject<ConstantPositionMobilityModel>();
+    mob->SetPosition(Vector(-1000.0+(rand()%25),320.0+(rand()%25),250.0));
+    unsigned long intVehicleID = std::stol(vehicleID.substr (3));
+
+    Ptr<BSContainer> bsc = basicServices.get(intVehicleID);
+    bsc->cleanup();
+  };
+
+  // Link ns-3 and SUMO
+  sumoClient->SumoSetup (setupNewWifiNode, shutdownWifiNode);
+
+  // Start simulation, which will last for simTime seconds
+  Simulator::Stop (Seconds(simTime));
+
+  auto start_time = std::chrono::high_resolution_clock::now();
+
+  Simulator::Run ();
+
+  // When the simulation is terminated, gather the most relevant metrics from the PRRsupervisor
+  std::cout << "Run terminated..." << std::endl;
+
+  std::cout << "\nTotal number of packets received: " << packet_count << std::endl;
+
+  std::cout << "\nMetric Supervisor statistics for 802.11bd" << std::endl;
+  std::cout << "Average PRR: " << metSup_11bd->getAveragePRR_overall () << std::endl;
+  std::cout << "Average latency (ms): " << metSup_11bd->getAverageLatency_overall () << std::endl;
+  std::cout << "RX packet count (from PRR Supervisor): " << metSup_11bd->getNumberRx_overall () << std::endl;
+  std::cout << "TX packet count (from PRR Supervisor): " << metSup_11bd->getNumberTx_overall () << std::endl;
+  // std::cout << "Average number of vehicle within the " << m_baseline_prr << " m baseline: " << metSup_11bd->getAverageNumberOfVehiclesInBaseline_overall () << std::endl;
+
+  std::cout << "\nMetric Supervisor statistics for NR-V2X" << std::endl;
+  std::cout << "Average PRR: " << metSup_nr->getAveragePRR_overall () << std::endl;
+  std::cout << "Average latency (ms): " << metSup_nr->getAverageLatency_overall () << std::endl;
+  std::cout << "RX packet count (from PRR Supervisor): " << metSup_nr->getNumberRx_overall () << std::endl;
+  std::cout << "TX packet count (from PRR Supervisor): " << metSup_nr->getNumberTx_overall () << std::endl;
+  // std::cout << "Average number of vehicle within the " << m_baseline_prr << " m baseline: " << metSup_nr->getAverageNumberOfVehiclesInBaseline_overall () << std::endl;
+
+  Simulator::Destroy ();
+
+  savePRRs(metSup_11bd, wifiVehicles, "11bd");
+  savePRRs(metSup_nr, nrVehicles, "nr");
+
+  auto end_time = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end_time - start_time;
+  std::cout << "\nSimulation time: " << elapsed.count() << " seconds" << std::endl;
+
+  return 0;
+}

--- a/src/automotive/examples/v2v-congestion-80211bd.cc
+++ b/src/automotive/examples/v2v-congestion-80211bd.cc
@@ -1,0 +1,402 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006,2007 INRIA
+ * Copyright (c) 2013 Dalian University of Technology
+ * Copyright (c) 2022 Politecnico di Torino
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage <mathieu.lacage@sophia.inria.fr> (initial IEEE 802.11bd example)
+ * Author: Junling Bu <linlinjavaer@gmail.com> (initial IEEE 802.11bd example)
+ * Author: Francesco Raviglione <francescorav.es483@gmail.com> (IEEE 802.11bd simple CAM exchange application)
+ *
+ * This is a simple example of a ms-van3t V2V communication scenario configured with a single .cc file,
+ * where vehicles exchange Cooperative Awareness Messages (CAMs) using the IEEE 802.11bd standard.
+ * The user can specify several parameters, including the priority (Access Category) for the transmission
+ * of CAMs. BSContainers are used to simplify the configuration of the ETSI C-ITS stack of each vehicle.
+ * In this scenario, all vehicles transmit CAMs according to the ETSI standards, and one vehicle (vehicle 3)
+ * sends a heavy interfering traffic, without useful informative content, to simulate a congested channel.
+ * Through the --interfering-userpriority option, the user can specify the Access Category (AC) for the
+ * interfering traffic, which is broadcasted by vehicle 3.
+ * When a new CAM is received by one of the vehicles, the callback "receiveCAM()" is called, and the stationID of
+ * the received is available in "my_stationID".
+ * Currently, the function just counts the total number of CAMs, but it can be customized to impement more complex
+ * approaches.
+ * As output, the simulation provides, thanks to the PRRSupervisor module, the average latency and PRR over the
+ * whole simulation, and the average one-way latency for each vehicle up to vehicle 4.
+ * The reported latency of vehicle 3 is expected to be 0 as it transmits interfering traffic (so, no ETSI-compliant
+ * message is transmitted), that is not considered by the PRRSupervisor.
+ */
+#include "ns3/carla-module.h"
+#include "ns3/vector.h"
+#include "ns3/string.h"
+#include "ns3/socket.h"
+#include "ns3/double.h"
+#include "ns3/config.h"
+#include "ns3/log.h"
+#include "ns3/command-line.h"
+#include "ns3/yans-wifi-helper.h"
+#include "ns3/position-allocator.h"
+#include "ns3/mobility-helper.h"
+#include <cstdint>
+#include <iostream>
+#include "ns3/sumo_xml_parser.h"
+#include "ns3/BSMap.h"
+#include "ns3/caBasicService.h"
+#include "ns3/btp.h"
+#include "ns3/ocb-wifi-mac.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/packet-socket-helper.h"
+#include "ns3/gn-utils.h"
+#include "ns3/MetricSupervisor.h"
+#include "ns3/DCC.h"
+
+using namespace ns3;
+
+NS_LOG_COMPONENT_DEFINE ("V2VCAMCongestion80211bd");
+
+// ******* DEFINE HERE ANY LOCAL GLOBAL VARIABLE, ACCESSIBLE FROM ANY FUNCTION IN THIS FILE *******
+// Variables defined here should always be "static"
+static int cam_packet_count=0;
+static int cpm_packet_count=0;
+BSMap basicServices; // Container for all ETSI Basic Services, installed on all vehicles
+// ************************************************************************************************
+
+// If you want to make a comparison with a received CAM MAC address, you can use:
+// from == getGNAddress (0,Mac48Address(comparison_string)), where "comparison_string" is something like "00:00:00:00:00:09"
+
+// Useful tip: you can get the latitude and longitude position of a given vehicle at any time with:
+//   libsumo::TraCIPosition pos=<MobilityClient>->TraCIAPI::vehicle.getPosition(<string ID of the vehicle>);
+//   pos=<MobilityClient>->TraCIAPI::simulation.convertXYtoLonLat(pos.x,pos.y);
+// <MobilityClient> should be the right Ptr<TraciClient> for the current vehicle, which can be retrieved from the
+//   global Basic Services container with basicServices.get(my_stationID)->getTraCIclient ()
+// The string ID of the vehicle should match the one in the XML file, i.e., for vehicle 7, the string id should be "veh7"
+// After these two lines, pos.y will contain the latitude of the vehicle, while pos.x the longitude of the vehicle
+void receiveCAM(asn1cpp::Seq<CAM> cam, Address from, StationID_t my_stationID, StationType_t my_StationType, SignalInfo phy_info)
+{
+  cam_packet_count++;
+}
+
+void receiveCPM(asn1cpp::Seq<CollectivePerceptionMessage> cpm, Address from, StationID_t my_stationID, StationType_t my_StationType, SignalInfo phy_info)
+{
+  cpm_packet_count++;
+}
+
+static void GenerateTraffic_interfering (Ptr<Socket> socket, uint32_t pktSize,
+                             uint32_t pktCount, Time pktInterval )
+{
+  // Generate interfering traffic by sending pktCount packets (filled in with zeros), every pktInterval
+  if (pktCount > 0)
+    {
+      // "Create<Packet> (pktSize)" creates a new packet of size pktSize bytes, composed by default by all zeros
+      if (socket->Send (Create<Packet> (pktSize)) != -1 && pktCount%100==0)
+        {
+          // std::cout << "Interfering packet sent" << std::endl;
+        }
+      // Schedule again the same function (to send the next packet), and decrease by one the packet count
+      Simulator::Schedule (pktInterval, &GenerateTraffic_interfering,
+                           socket, pktSize, pktCount - 1, pktInterval);
+    }
+  else
+    {
+      socket->Close ();
+    }
+}
+
+int main (int argc, char *argv[])
+{
+  std::string phyMode ("OfdmRate12MbpsBW10MHz"); // Default IEEE 802.11bd data rate profile
+  int up=0;
+  int interfering_up=0;
+  bool verbose = false; // Set to true to get a lot of verbose output from the IEEE 802.11bd PHY model (leave this to false)
+  int numberOfNodes; // Total number of vehicles, automatically filled in by reading the XML file
+  double m_baseline_prr = 150.0; // PRR baseline value (default: 150 m)
+  int txPower = 33.0; // IEEE 802.11bd transmission power in dBm
+  double sensitivity = -95.0;
+  double snr_threshold = 4.0;
+  xmlDocPtr rou_xml_file;
+  double simTime = 150.0; // Total simulation time (default: 100 seconds)
+  int dcc_nodes = 7;
+
+  // Set here the path to the SUMO XML files
+  std::string sumo_folder = "src/automotive/examples/sumo_files_v2v_map/";
+  std::string mob_trace = "cars_7.rou.xml";
+  std::string sumo_config ="src/automotive/examples/sumo_files_v2v_map/map_7.sumo.cfg";
+
+  // Read the command line options
+  CommandLine cmd (__FILE__);
+
+  // Syntax to add new options: cmd.addValue (<option>,<brief description>,<destination variable>)
+  cmd.AddValue ("phyMode", "Wifi Phy mode", phyMode);
+  cmd.AddValue ("verbose", "turn on all WifiNetDevice log components", verbose);
+  cmd.AddValue ("userpriority","EDCA User Priority for the ETSI messages",up);
+  cmd.AddValue ("interfering-userpriority","User Priority for interfering traffic (default: 0, i.e., AC_BE)",interfering_up);
+  cmd.AddValue ("baseline", "Baseline for PRR calculation", m_baseline_prr);
+  cmd.AddValue ("tx-power", "OBUs transmission power [dBm]", txPower);
+  cmd.AddValue ("rx-sensitivity", "802.11bd preamble-detection RSSI threshold [dBm]", sensitivity);
+  cmd.AddValue ("snr-threshold", "802.11bd preamble-detection SNR threshold [dB]", snr_threshold);
+  cmd.AddValue ("sim-time", "Total duration of the simulation [s]", simTime);
+  cmd.Parse (argc, argv);
+
+  VehicularWifiProfile wifiProfile =
+      VehicularWifiProfile::Ieee80211bd (phyMode, txPower, sensitivity, snr_threshold);
+
+  /* Load the .rou.xml file (SUMO map and scenario) */
+  xmlInitParser();
+  std::string path = sumo_folder + mob_trace;
+  rou_xml_file = xmlParseFile(path.c_str ());
+  if (rou_xml_file == NULL)
+    {
+      NS_FATAL_ERROR("Error: unable to parse the specified XML file: "<<path);
+    }
+  numberOfNodes = XML_rou_count_vehicles(rou_xml_file);
+  xmlFreeDoc(rou_xml_file);
+  xmlCleanupParser();
+
+  // Check if there are enough nodes
+  // This application requires at least three vehicles (as vehicle 3 is the one generating interfering traffic, it should exist)
+  if(numberOfNodes==-1)
+    {
+      NS_FATAL_ERROR("Fatal error: cannot gather the number of vehicles from the specified XML file: "<<path<<". Please check if it is a correct SUMO file.");
+    }
+
+  if(numberOfNodes<3)
+    {
+      NS_FATAL_ERROR("Fatal error: at least three vehicles are required.");
+    }
+
+  // Create numberOfNodes nodes
+  NodeContainer c;
+  c.Create (numberOfNodes);
+
+  // The below set of helpers will help us to put together the wifi NICs we want
+  // Set up the IEEE 802.11bd model and PHY layer
+  YansWifiPhyHelper wifiPhy;
+  wifiProfile.ConfigurePhy (wifiPhy);
+  YansWifiChannelHelper wifiChannel = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = wifiChannel.Create ();
+  wifiPhy.SetChannel (channel);
+  // ns-3 supports generating a pcap trace, to be later analyzed in Wireshark
+  wifiPhy.SetPcapDataLinkType (WifiPhyHelper::DLT_IEEE802_11);
+
+  // We need a QosWaveMac, as we need to enable QoS and EDCA
+  QosWaveMacHelper wifi80211bdMac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi80211bd = Wifi80211pHelper::Default ();
+  if (verbose)
+    {
+      wifi80211bd.EnableLogComponents ();      // Turn on all Wifi 802.11bd logging, only if verbose is true
+    }
+
+  wifiProfile.ConfigureRemoteStationManager (wifi80211bd);
+  NetDeviceContainer devices = wifi80211bd.Install (wifiPhy, wifi80211bdMac, c);
+
+  // Enable saving to Wireshark PCAP traces
+  wifiPhy.EnablePcap ("v2v-congestion-80211bd", devices);
+
+  // Set up the link between SUMO and ns-3, to make each node "mobile" (i.e., linking each ns-3 node to each moving vehicle in ns-3,
+  // which corresponds to installing the network stack to each SUMO vehicle)
+  MobilityHelper mobility;
+  mobility.Install (c);
+  // Set up the TraCI interface and start SUMO with the default parameters
+  // The simulation time step can be tuned by changing "SynchInterval"
+  Ptr<TraciClient> sumoClient = CreateObject<TraciClient> ();
+  sumoClient->SetAttribute ("SumoConfigPath", StringValue (sumo_config));
+  sumoClient->SetAttribute ("SumoBinaryPath", StringValue (""));    // use system installation of sumo
+  sumoClient->SetAttribute ("SynchInterval", TimeValue (Seconds (0.01)));
+  sumoClient->SetAttribute ("StartTime", TimeValue (Seconds (0.0)));
+  sumoClient->SetAttribute ("SumoGUI", BooleanValue (false));
+  sumoClient->SetAttribute ("SumoPort", UintegerValue (3400));
+  sumoClient->SetAttribute ("PenetrationRate", DoubleValue (1.0));
+  sumoClient->SetAttribute ("SumoLogFile", BooleanValue (false));
+  sumoClient->SetAttribute ("SumoStepLog", BooleanValue (false));
+  sumoClient->SetAttribute ("SumoSeed", IntegerValue (10));
+  sumoClient->SetAttribute ("SumoWaitForSocket", TimeValue (Seconds (1.5)));
+
+  // Set up a Metricsupervisor
+  // This module enables a trasparent and seamless collection of one-way latency (in ms) and PRR metrics
+  Ptr<MetricSupervisor> metSup = NULL;
+  // Set a baseline for the PRR computation when creating a new PRRsupervisor object
+  MetricSupervisor metSupObj(m_baseline_prr);
+  metSup = &metSupObj;
+  metSup->setTraCIClient(sumoClient);
+  // This function enables printing the current and average latency and PRR for each received packet
+  wifiProfile.ConfigureMetricSupervisor (metSup);
+  metSup->enableCBRVerboseOnStdout();
+  metSup->enableCBRWriteToFile();
+  metSup->setCBRWindowValue(100);
+  metSup->setCBRAlphaValue(0.1);
+  metSup->setSimulationTimeValue(simTime);
+  metSup->setNodeContainer(c);
+  metSup->startCheckCBR(dcc_nodes);
+
+  // Create a new socket for the generation of broadcast interfering traffic
+  // With the aim of sending generic broadcast packets, we use a PacketSocket
+  // This kind of facility enables the transmission of data with a customizable
+  // Ethertype, and no specific stack for the higher layers
+  // As we are just sending interfering traffic (without any useful informative content),
+  // we can use the local experimental Ethertype (0x88B5)
+  PacketSocketHelper packetSocket;
+  packetSocket.Install(c);
+  TypeId tid = TypeId::LookupByName ("ns3::PacketSocketFactory");
+  std::unordered_map<uint32_t, Ptr<Socket>> source_interfering;
+  uint32_t number = c.GetN();
+  for(uint32_t i = 0; i < number; i++)
+    {
+      Ptr<Socket> socket = Socket::CreateSocket (c.Get (i), tid);
+      PacketSocketAddress local_source_interfering;
+      local_source_interfering.SetSingleDevice (c.Get(i)->GetDevice(0)->GetIfIndex ());
+      local_source_interfering.SetPhysicalAddress (c.Get(i)->GetDevice(0)->GetAddress());
+      local_source_interfering.SetProtocol (0x88B5); // Setting the "Local Experimental Ethertype 1" to send interfering traffic
+      if (socket->Bind (local_source_interfering) == -1)
+        {
+          NS_FATAL_ERROR ("Failed to bind client socket for BTP + GeoNetworking (802.11bd)");
+        }
+      PacketSocketAddress remote_source_interfering;
+      remote_source_interfering.SetSingleDevice (c.Get(i)->GetDevice(0)->GetIfIndex());
+      // Set the broadcast MAC address as interfering traffic will be broadcasted by vehicle 3
+      remote_source_interfering.SetPhysicalAddress (c.Get(i)->GetDevice(0)->GetBroadcast());
+      remote_source_interfering.SetProtocol (0x88B5); // Setting the "Local Experimental Ethertype 1" to send interfering traffic
+      socket->Connect (remote_source_interfering);
+      // Important: this line lets you set the AC of the interfering traffic, through a User Priority (UP) value, like in real Linux kernels/OS
+      socket->SetPriority (interfering_up); // Setting the priority of the interfering traffic from vehicle 0
+      source_interfering[i] = socket;
+    }
+
+  std::unordered_map<Ptr<Node>, Ptr<DCC>> dcc_per_node;
+  for (uint8_t i = 0; i < dcc_nodes; i++)
+  {
+    dcc_per_node[c.Get(i)] = CreateObject<DCC>();
+  }
+
+  std::cout << "802.11bd profile: dataMode=" << wifiProfile.GetDataMode ()
+            << ", controlMode=" << wifiProfile.GetControlMode ()
+            << ", ppduFormat=" << wifiProfile.GetPpduFormatName ()
+            << ", ngvMcs=" << static_cast<uint32_t> (wifiProfile.GetNgvMcsIndex ())
+            << ", channelWidth=" << wifiProfile.GetChannelWidthMHz () << " MHz"
+            << ", txPower=" << wifiProfile.GetTxPowerDbm () << " dBm"
+            << ", rxSensitivity=" << wifiProfile.GetRxSensitivityDbm () << " dBm"
+            << ", dccBitRate=" << wifiProfile.GetDccBitRate () << " bit/s"
+            << std::endl;
+
+  std::cout << "Starting simulation... " << std::endl;
+
+  // Important: what you write inside setupNewWifiNode() will be executed every time a new vehicle enters the simulation in SUMO
+  // This kind of "std::function" is called lambda function, and it can access all variables outside its scope, thanks to the [&] capture
+  // We setup here the ETSI stack for each vehicle (except the one generating interfering traffic), thanks to the BSContainer object
+  STARTUP_FCN setupNewWifiNode = [&] (std::string vehicleID,TraciClient::StationTypeTraCI_t stationType) -> Ptr<Node>
+    {
+      std::cout << "Setting up the ETSI ITS-G5 stack for vehicle " << vehicleID << std::endl;
+      unsigned long nodeID = std::stol(vehicleID.substr (3))-1;
+      uint32_t id = source_interfering[nodeID]->GetNode()->GetId();
+      if (nodeID == 2)
+        Simulator::ScheduleWithContext (id,
+                                      Seconds (1.0), &GenerateTraffic_interfering,
+                                      source_interfering[nodeID], 2250, simTime*2000, MilliSeconds (2));
+
+      // Create a new ETSI GeoNetworking socket, thanks to the GeoNet::createGNPacketSocket() function, accepting as argument a pointer to the current node
+      Ptr<Socket> sock;
+      sock=GeoNet::createGNPacketSocket(c.Get(nodeID));
+      // Set the proper AC, through the specified UP
+      sock->SetPriority (up);
+
+      // Create a new Basic Service Container object, which includes, for the current vehicle, both the ETSI CA Basic Service, for the transmission/reception
+      // of periodic CAMs, and the ETSI DEN Basic Service, for the transmission/reception of event-based DENMs
+      // An ETSI Basic Services container is a wrapper class to enable easy handling of both CAMs and DENMs
+      // The station ID is set to be equal to the SUMO ID without "veh" (i.e., the station ID of "veh1" will be "1")
+      Ptr<BSContainer> bs_container = CreateObject<BSContainer>(std::stol(vehicleID.substr(3)),StationType_passengerCar,sumoClient,false,sock);
+      // Setup the Metricupervisor inside the BSContainer, to make each vehicle collect latency and Metric metrics
+      bs_container->linkMetricSupervisor(metSup);
+      // This is needed just to simplify the whole application
+      bs_container->disablePRRSupervisorForGNBeacons ();
+
+      // Set the function which will be called every time a CAM is received, i.e., receiveCAM()
+      bs_container->addCAMRxCallback (std::bind(&receiveCAM,std::placeholders::_1,std::placeholders::_2,std::placeholders::_3,std::placeholders::_4,std::placeholders::_5));
+      // Setup the new ETSI Basic Services container
+      // The first parameter is true is you want to setup a CA Basic Service (for sending/receiving CAMs)
+      // The second parameter should be true if you want to setup a DEN Basic Service (for sending/receiving DENMs)
+      // The third parameter should be true if you want to setup a VRU Basic Service (for sending/receiving VAMs)
+
+      bs_container->addCPMRxCallback (std::bind(&receiveCPM,std::placeholders::_1,std::placeholders::_2,std::placeholders::_3,std::placeholders::_4,std::placeholders::_5));
+      bs_container->setupContainer(true,false,false,false,false,false);
+      Ptr<GeoNet> gn = bs_container->getGeoNet();
+
+      // Store the container for this vehicle inside a local global BSMap, i.e., a structure (similar to a hash table) which allows you to easily
+      // retrieve the right BSContainer given a vehicle ID
+      basicServices.add(bs_container);
+
+      // Setup DCC for both internal behavior and GeoNet link
+      if (dcc_per_node.find(c.Get(nodeID))!=dcc_per_node.end())
+        {
+          std::cout << "DCC enabled for vehicle " << vehicleID << std::endl;
+          dcc_per_node[c.Get(nodeID)]->SetupDCC(vehicleID, metSup, c.Get(nodeID), "adaptive", 200);
+          dcc_per_node[c.Get(nodeID)]->setBitRate (wifiProfile.GetDccBitRate ());
+          gn->setDCC (dcc_per_node[c.Get(nodeID)]);
+          dcc_per_node[c.Get(nodeID)]->StartDCC();
+        }
+
+      // Start transmitting CAMs
+      // We randomize the instant in time in which the CAM dissemination is going to start
+      // This simulates different startup times for the OBUs of the different vehicles, and
+      // reduces the risk of multiple vehicles trying to send CAMs are the same time (causing more collisions);
+      // "desync" is a value between 0 and 1 (seconds) after which the CAM dissemination should start
+      std::srand(Simulator::Now().GetNanoSeconds ()*2); // Seed based on the simulation time to give each vehicle a different random seed
+      double desync = ((double)std::rand()/RAND_MAX);
+      bs_container->getCABasicService ()->startCamDissemination (desync);
+      // bs_container->getCPBasicService()->startCpmDissemination();
+
+      return c.Get(nodeID);
+    };
+
+  // Important: what you write here is called every time a node exits the simulation in SUMO
+  // You can safely keep this function as it is, and ignore it
+  SHUTDOWN_FCN shutdownWifiNode = [&] (Ptr<Node> exNode, std::string vehicleID)
+    {
+      /* Set position outside communication range */
+      Ptr<ConstantPositionMobilityModel> mob = exNode->GetObject<ConstantPositionMobilityModel>();
+      mob->SetPosition(Vector(-1000.0+(rand()%25),320.0+(rand()%25),250.0));
+
+      // Turn off the Basic Services and the ETSI ITS-G5 stack for the vehicle
+      // which has exited from the simulated scenario, and should be thus no longer considered
+      // We need to get the right Ptr<BSContainer> based on the station ID (not the nodeID used
+      // as index for the nodeContainer), so we don't use "-1" to compute "intVehicleID" here
+      unsigned long intVehicleID = std::stol(vehicleID.substr (3));
+      Ptr<BSContainer> bsc = basicServices.get(intVehicleID);
+      bsc->cleanup();
+    };
+
+  // Link ns-3 and SUMO
+  sumoClient->SumoSetup (setupNewWifiNode, shutdownWifiNode);
+
+  metSup->startChannelOccupationBytesPerSecondsPerSquareMeter();
+
+  // Start simulation, which will last for simTime seconds
+  Simulator::Stop (Seconds(simTime));
+  Simulator::Run ();
+
+  // When the simulation is terminated, gather the most relevant metrics from the Metricsupervisor
+  std::cout << "Run terminated..." << std::endl;
+
+  std::cout << "Average CBR: " << metSup->getAverageCBROverall() << std::endl;
+  std::cout << "Average PRR: " << metSup->getAveragePRR_overall () << std::endl;
+  std::cout << "Average latency (ms): " << metSup->getAverageLatency_overall () << std::endl;
+  std::cout << "TX overall: " << metSup->getNumberTx_overall() << std::endl;
+  std::cout << "RX overall: " << cam_packet_count + cpm_packet_count << std::endl;
+
+
+  Simulator::Destroy ();
+
+  return 0;
+}

--- a/src/automotive/examples/v2v-link-quality-fallback-80211bd.cc
+++ b/src/automotive/examples/v2v-link-quality-fallback-80211bd.cc
@@ -1,0 +1,238 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ns3/abort.h"
+#include "ns3/command-line.h"
+#include "ns3/mac48-address.h"
+#include "ns3/mobility-helper.h"
+#include "ns3/net-device.h"
+#include "ns3/node-container.h"
+#include "ns3/packet.h"
+#include "ns3/position-allocator.h"
+#include "ns3/simulator.h"
+#include "ns3/vector.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-psdu.h"
+#include "ns3/wifi-tx-vector.h"
+#include "ns3/yans-wifi-helper.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace ns3;
+
+namespace
+{
+
+static constexpr uint16_t POLICY_PROTOCOL = 0x88D4;
+
+struct CaseConfig
+{
+  std::string label;
+  VehicularWifiFallbackController::LinkQualityPolicy policy;
+};
+
+struct CaseResult
+{
+  std::string label;
+  VehicularWifiFallbackMode mode = VehicularWifiFallbackMode::NGV_20;
+  uint32_t txAttempts = 0;
+  uint32_t txSucceeded = 0;
+  uint32_t rxPackets = 0;
+  uint32_t ngvPpdus = 0;
+  uint32_t duplicatePpdus = 0;
+  uint32_t nonNgv10Ppdus = 0;
+};
+
+NetDeviceContainer
+InstallVehicularDevice (NodeContainer nodes,
+                        Ptr<YansWifiChannel> channel,
+                        const VehicularWifiProfile& profile)
+{
+  YansWifiPhyHelper phy;
+  profile.ConfigurePhy (phy);
+  phy.SetChannel (channel);
+
+  QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+  profile.ConfigureRemoteStationManager (wifi);
+  return wifi.Install (phy, mac, nodes);
+}
+
+VehicularWifiProfile
+MakeReceiverProfile (VehicularWifiFallbackMode mode, bool legacyReceiverPresent)
+{
+  if (legacyReceiverPresent)
+    {
+      return VehicularWifiProfile::Ieee80211p ();
+    }
+  if (mode == VehicularWifiFallbackMode::NGV_20 ||
+      mode == VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE)
+    {
+      return VehicularWifiProfile::Ieee80211bd20 ();
+    }
+  return VehicularWifiProfile::Ieee80211bdNonNgv10 ();
+}
+
+bool
+ReceivePacket (CaseResult* result,
+               Ptr<NetDevice> dev,
+               Ptr<const Packet> pkt,
+               uint16_t protocol,
+               const Address& sender)
+{
+  if (protocol == POLICY_PROTOCOL)
+    {
+      result->rxPackets++;
+    }
+  return true;
+}
+
+void
+NotifyTxPsduBegin (CaseResult* result,
+                   WifiConstPsduMap psduMap,
+                   WifiTxVector txVector,
+                   double txPowerW)
+{
+  if (txVector.IsNgv ())
+    {
+      result->ngvPpdus++;
+    }
+  else if (txVector.IsNonNgv20Duplicate ())
+    {
+      result->duplicatePpdus++;
+    }
+  else if (txVector.IsNonNgv10 ())
+    {
+      result->nonNgv10Ppdus++;
+    }
+}
+
+void
+SendPacket (CaseResult* result, Ptr<NetDevice> sender, uint32_t payloadBytes)
+{
+  result->txAttempts++;
+  if (sender->Send (Create<Packet> (payloadBytes), Mac48Address::GetBroadcast (), POLICY_PROTOCOL))
+    {
+      result->txSucceeded++;
+    }
+}
+
+CaseResult
+RunCase (const CaseConfig& config, uint32_t payloadBytes, double distanceMeters)
+{
+  CaseResult result;
+  result.label = config.label;
+  result.mode = VehicularWifiFallbackController::SelectForLinkQuality (config.policy);
+
+  NodeContainer nodes;
+  nodes.Create (2);
+
+  Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+  positions->Add (Vector (0.0, 0.0, 0.0));
+  positions->Add (Vector (distanceMeters, 0.0, 0.0));
+  MobilityHelper mobility;
+  mobility.SetPositionAllocator (positions);
+  mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  mobility.Install (nodes);
+
+  YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+  NodeContainer senderNode;
+  senderNode.Add (nodes.Get (0));
+  NodeContainer receiverNode;
+  receiverNode.Add (nodes.Get (1));
+
+  NetDeviceContainer senderDevices =
+      InstallVehicularDevice (senderNode,
+                              channel,
+                              VehicularWifiFallbackController::MakeProfile (result.mode));
+  NetDeviceContainer receiverDevices =
+      InstallVehicularDevice (receiverNode,
+                              channel,
+                              MakeReceiverProfile (result.mode, config.policy.legacyReceiverPresent));
+
+  receiverDevices.Get (0)->SetReceiveCallback (MakeBoundCallback (&ReceivePacket, &result));
+
+  Ptr<WifiNetDevice> senderWifi = DynamicCast<WifiNetDevice> (senderDevices.Get (0));
+  NS_ABORT_MSG_IF (senderWifi == nullptr, "Expected an installed sender Wi-Fi device");
+  const bool traceConnected = senderWifi->GetPhy ()->TraceConnectWithoutContext (
+      "PhyTxPsduBegin",
+      MakeBoundCallback (&NotifyTxPsduBegin, &result));
+  NS_ABORT_MSG_IF (!traceConnected, "Unable to connect PhyTxPsduBegin trace");
+
+  Simulator::Schedule (MilliSeconds (100), &SendPacket, &result, senderDevices.Get (0), payloadBytes);
+  Simulator::Stop (MilliSeconds (500));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  return result;
+}
+
+CaseConfig
+MakeCase (const std::string& label, bool legacyReceiverPresent, double estimatedSnrDb)
+{
+  CaseConfig config;
+  config.label = label;
+  config.policy.legacyReceiverPresent = legacyReceiverPresent;
+  config.policy.estimatedSnrDb = estimatedSnrDb;
+  return config;
+}
+
+} // namespace
+
+int
+main (int argc, char* argv[])
+{
+  uint32_t payloadBytes = 256;
+  double distanceMeters = 5.0;
+
+  CommandLine cmd (__FILE__);
+  cmd.AddValue ("payload-bytes", "Payload size used by each link-quality policy case", payloadBytes);
+  cmd.AddValue ("distance-m", "Distance between sender and receiver", distanceMeters);
+  cmd.Parse (argc, argv);
+
+  NS_ABORT_MSG_IF (payloadBytes == 0, "payload-bytes must be greater than zero");
+
+  const std::vector<CaseConfig> cases = {
+      MakeCase ("High no-legacy", false, 25.0),
+      MakeCase ("Mid no-legacy", false, 12.0),
+      MakeCase ("Low no-legacy", false, 2.0),
+      MakeCase ("High legacy", true, 25.0),
+      MakeCase ("Low legacy", true, 2.0),
+  };
+
+  uint32_t totalRxPackets = 0;
+  uint32_t totalNgvPpdus = 0;
+  uint32_t totalDuplicatePpdus = 0;
+  uint32_t totalNonNgv10Ppdus = 0;
+
+  for (const auto& testCase : cases)
+    {
+      const CaseResult result = RunCase (testCase, payloadBytes, distanceMeters);
+      totalRxPackets += result.rxPackets;
+      totalNgvPpdus += result.ngvPpdus;
+      totalDuplicatePpdus += result.duplicatePpdus;
+      totalNonNgv10Ppdus += result.nonNgv10Ppdus;
+
+      std::cout << result.label << " selected mode: "
+                << VehicularWifiFallbackModeName (result.mode) << std::endl;
+      std::cout << result.label << " RX packets: " << result.rxPackets << std::endl;
+    }
+
+  std::cout << "Link-quality policy cases: " << cases.size () << std::endl;
+  std::cout << "Link-quality policy RX packets: " << totalRxPackets << std::endl;
+  std::cout << "Link-quality policy NGV PPDU count: " << totalNgvPpdus << std::endl;
+  std::cout << "Link-quality policy NON_NGV_20_DUPLICATE PPDU count: " << totalDuplicatePpdus
+            << std::endl;
+  std::cout << "Link-quality policy NON_NGV_10 PPDU count: " << totalNonNgv10Ppdus
+            << std::endl;
+
+  return 0;
+}

--- a/src/automotive/examples/v2v-marginal-snr-80211bd.cc
+++ b/src/automotive/examples/v2v-marginal-snr-80211bd.cc
@@ -1,0 +1,274 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ns3/abort.h"
+#include "ns3/command-line.h"
+#include "ns3/error-rate-model.h"
+#include "ns3/mac48-address.h"
+#include "ns3/mobility-helper.h"
+#include "ns3/net-device.h"
+#include "ns3/node-container.h"
+#include "ns3/ofdm-phy.h"
+#include "ns3/packet.h"
+#include "ns3/position-allocator.h"
+#include "ns3/simulator.h"
+#include "ns3/uinteger.h"
+#include "ns3/vector.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wifi-mac-header.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-remote-station-manager.h"
+#include "ns3/wifi-tx-vector.h"
+#include "ns3/yans-error-rate-model.h"
+#include "ns3/yans-wifi-helper.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+using namespace ns3;
+
+namespace
+{
+
+class LinearSnrErrorRateModel : public ErrorRateModel
+{
+private:
+  double DoGetChunkSuccessRate (WifiMode mode,
+                                const WifiTxVector& txVector,
+                                double snr,
+                                uint64_t nbits,
+                                uint8_t numRxAntennas,
+                                WifiPpduField field,
+                                uint16_t staId) const override
+  {
+    return snr >= 1.0 ? 1.0 : snr;
+  }
+};
+
+struct DeliveryStats
+{
+  uint32_t rxPackets = 0;
+  uint32_t txAttempts = 0;
+  uint32_t txSucceeded = 0;
+};
+
+NetDeviceContainer
+InstallVehicularDevice (NodeContainer nodes,
+                        Ptr<YansWifiChannel> channel,
+                        const VehicularWifiProfile& profile)
+{
+  YansWifiPhyHelper phy;
+  profile.ConfigurePhy (phy);
+  phy.SetChannel (channel);
+
+  QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+  profile.ConfigureRemoteStationManager (wifi);
+  return wifi.Install (phy, mac, nodes);
+}
+
+WifiMacHeader
+MakeBroadcastDataHeader ()
+{
+  WifiMacHeader broadcastData;
+  broadcastData.SetType (WIFI_MAC_DATA);
+  broadcastData.SetAddr1 (Mac48Address::GetBroadcast ());
+  broadcastData.SetAddr2 (Mac48Address ("00:00:00:00:00:01"));
+  broadcastData.SetAddr3 (Mac48Address::GetBroadcast ());
+  return broadcastData;
+}
+
+bool
+ReceivePacket (DeliveryStats* stats, Ptr<NetDevice> dev, Ptr<const Packet> pkt, uint16_t protocol, const Address& sender)
+{
+  stats->rxPackets++;
+  return true;
+}
+
+void
+SendPacket (DeliveryStats* stats, Ptr<NetDevice> device, uint32_t bytes)
+{
+  static constexpr uint16_t wsmpProtocol = 0x88DC;
+  stats->txAttempts++;
+  if (device->Send (Create<Packet> (bytes), Mac48Address::GetBroadcast (), wsmpProtocol))
+    {
+      stats->txSucceeded++;
+    }
+}
+
+WifiTxVector
+GetDataTxVector (const VehicularWifiProfile& profile, uint16_t midamblePeriodicity = 0)
+{
+  NodeContainer nodes;
+  nodes.Create (1);
+  MobilityHelper mobility;
+  mobility.Install (nodes);
+
+  YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = channelHelper.Create ();
+  NetDeviceContainer devices = InstallVehicularDevice (nodes, channel, profile);
+  Ptr<WifiNetDevice> device = DynamicCast<WifiNetDevice> (devices.Get (0));
+  NS_ABORT_MSG_IF (device == nullptr, "Expected an installed Wi-Fi device");
+
+  if (profile.GetPpduFormat () == VehicularWifiPpduFormat::NGV && midamblePeriodicity != 0)
+    {
+      device->GetRemoteStationManager ()->SetAttribute ("NgvMidamblePeriodicity",
+                                                        UintegerValue (midamblePeriodicity));
+    }
+
+  WifiTxVector txVector =
+      device->GetRemoteStationManager ()->GetDataTxVector (MakeBroadcastDataHeader ());
+  Simulator::Destroy ();
+  return txVector;
+}
+
+double
+GetPer (Ptr<ErrorRateModel> errorModel,
+        const WifiTxVector& txVector,
+        double snrDb,
+        uint32_t bytes,
+        WifiPpduField field = WIFI_PPDU_FIELD_DATA)
+{
+  const double snr = std::pow (10.0, snrDb / 10.0);
+  const double psr = errorModel->GetChunkSuccessRate (txVector.GetMode (),
+                                                      txVector,
+                                                      snr,
+                                                      bytes * 8,
+                                                      1,
+                                                      field);
+  return 1.0 - psr;
+}
+
+DeliveryStats
+RunDeliverySmoke (const VehicularWifiProfile& senderProfile,
+                  const VehicularWifiProfile& receiverProfile,
+                  uint16_t senderMidamblePeriodicity,
+                  uint32_t bytes)
+{
+  DeliveryStats stats;
+
+  NodeContainer nodes;
+  nodes.Create (2);
+
+  Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+  positions->Add (Vector (0.0, 0.0, 0.0));
+  positions->Add (Vector (5.0, 0.0, 0.0));
+  MobilityHelper mobility;
+  mobility.SetPositionAllocator (positions);
+  mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  mobility.Install (nodes);
+
+  YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+  NodeContainer senderNode;
+  senderNode.Add (nodes.Get (0));
+  NodeContainer receiverNode;
+  receiverNode.Add (nodes.Get (1));
+
+  NetDeviceContainer senderDevices = InstallVehicularDevice (senderNode, channel, senderProfile);
+  NetDeviceContainer receiverDevices = InstallVehicularDevice (receiverNode, channel, receiverProfile);
+
+  Ptr<WifiNetDevice> senderWifi = DynamicCast<WifiNetDevice> (senderDevices.Get (0));
+  NS_ABORT_MSG_IF (senderWifi == nullptr, "Expected an installed sender Wi-Fi device");
+  if (senderProfile.GetPpduFormat () == VehicularWifiPpduFormat::NGV && senderMidamblePeriodicity != 0)
+    {
+      senderWifi->GetRemoteStationManager ()->SetAttribute ("NgvMidamblePeriodicity",
+                                                            UintegerValue (senderMidamblePeriodicity));
+    }
+
+  receiverDevices.Get (0)->SetReceiveCallback (MakeBoundCallback (&ReceivePacket, &stats));
+
+  Simulator::Schedule (MilliSeconds (100), &SendPacket, &stats, senderDevices.Get (0), bytes);
+  Simulator::Stop (MilliSeconds (500));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  return stats;
+}
+
+} // namespace
+
+int
+main (int argc, char* argv[])
+{
+  uint32_t payloadBytes = 1024;
+  double ngvSnrDb = 20.0;
+  double nonNgvSnrDb = -6.9897;
+  uint16_t ngvMidamblePeriodicity = 4;
+  uint8_t nonNgvRepetitions = 2;
+
+  CommandLine cmd (__FILE__);
+  cmd.AddValue ("payload-bytes", "Payload size used by the smoke scenario", payloadBytes);
+  cmd.AddValue ("ngv-snr-db", "SNR used for native NGV PER comparison", ngvSnrDb);
+  cmd.AddValue ("non-ngv-snr-db", "SNR used for NON_NGV_10 PER comparison", nonNgvSnrDb);
+  cmd.AddValue ("ngv-midamble-periodicity", "Native NGV midamble periodicity to exercise", ngvMidamblePeriodicity);
+  cmd.AddValue ("non-ngv-repetitions", "NON_NGV_10 N_PPDU_REP value to exercise", nonNgvRepetitions);
+  cmd.Parse (argc, argv);
+
+  Ptr<ErrorRateModel> yansErrorModel = CreateObject<YansErrorRateModel> ();
+  Ptr<ErrorRateModel> linearErrorModel = CreateObject<LinearSnrErrorRateModel> ();
+
+  const WifiTxVector ngvNoMidamble = GetDataTxVector (VehicularWifiProfile::Ieee80211bd ());
+  const WifiTxVector ngvWithMidamble =
+      GetDataTxVector (VehicularWifiProfile::Ieee80211bd (), ngvMidamblePeriodicity);
+  const double ngvNoMidamblePer = GetPer (yansErrorModel, ngvNoMidamble, ngvSnrDb, payloadBytes);
+  const double ngvMidamblePer = GetPer (yansErrorModel, ngvWithMidamble, ngvSnrDb, payloadBytes);
+
+  const WifiTxVector nonNgvNoRepeat =
+      GetDataTxVector (VehicularWifiProfile::Ieee80211bdNonNgv10 ());
+  const WifiTxVector nonNgvRepeated =
+      GetDataTxVector (VehicularWifiProfile::Ieee80211bdNonNgv10 ("OfdmRate6MbpsBW10MHz",
+                                                                  23.0,
+                                                                  -93.0,
+                                                                  4.0,
+                                                                  nonNgvRepetitions));
+  const double nonNgvNoRepeatPer = GetPer (linearErrorModel, nonNgvNoRepeat, nonNgvSnrDb, payloadBytes);
+  const double nonNgvRepeatedPer = GetPer (linearErrorModel, nonNgvRepeated, nonNgvSnrDb, payloadBytes);
+  const double nonNgvNoRepeatHeaderPer =
+      GetPer (linearErrorModel, nonNgvNoRepeat, nonNgvSnrDb, payloadBytes, WIFI_PPDU_FIELD_NON_HT_HEADER);
+  const double nonNgvRepeatedHeaderPer =
+      GetPer (linearErrorModel, nonNgvRepeated, nonNgvSnrDb, payloadBytes, WIFI_PPDU_FIELD_NON_HT_HEADER);
+
+  DeliveryStats ngvDelivery = RunDeliverySmoke (VehicularWifiProfile::Ieee80211bd (),
+                                                VehicularWifiProfile::Ieee80211bd (),
+                                                ngvMidamblePeriodicity,
+                                                128);
+  DeliveryStats nonNgvDelivery =
+      RunDeliverySmoke (VehicularWifiProfile::Ieee80211bdNonNgv10 ("OfdmRate6MbpsBW10MHz",
+                                                                   23.0,
+                                                                   -93.0,
+                                                                   4.0,
+                                                                   nonNgvRepetitions),
+                        VehicularWifiProfile::Ieee80211bdNonNgv10 (),
+                        0,
+                        128);
+
+  std::cout << "NGV no-midamble PER: " << ngvNoMidamblePer << std::endl;
+  std::cout << "NGV midamble PER: " << ngvMidamblePer << std::endl;
+  std::cout << "NON_NGV_10 no-repeat PER: " << nonNgvNoRepeatPer << std::endl;
+  std::cout << "NON_NGV_10 repeated PER: " << nonNgvRepeatedPer << std::endl;
+  std::cout << "NON_NGV_10 no-repeat header PER: " << nonNgvNoRepeatHeaderPer << std::endl;
+  std::cout << "NON_NGV_10 repeated header PER: " << nonNgvRepeatedHeaderPer << std::endl;
+  std::cout << "NGV smoke RX packets: " << ngvDelivery.rxPackets << std::endl;
+  std::cout << "NGV smoke TX succeeded: " << ngvDelivery.txSucceeded << std::endl;
+  std::cout << "NON_NGV_10 smoke RX packets: " << nonNgvDelivery.rxPackets << std::endl;
+  std::cout << "NON_NGV_10 smoke TX succeeded: " << nonNgvDelivery.txSucceeded << std::endl;
+
+  NS_ABORT_MSG_IF (ngvMidamblePer >= ngvNoMidamblePer,
+                   "Expected native NGV midambles to improve marginal-SNR PER");
+  NS_ABORT_MSG_IF (nonNgvRepeatedPer >= nonNgvNoRepeatPer,
+                   "Expected repeated NON_NGV_10 to improve marginal-SNR PER");
+  NS_ABORT_MSG_IF (std::abs (nonNgvRepeatedHeaderPer - nonNgvNoRepeatHeaderPer) > 1e-12,
+                   "Expected NON_NGV_10 combining to leave header PER unchanged");
+  NS_ABORT_MSG_IF (ngvDelivery.rxPackets == 0 || ngvDelivery.txSucceeded == 0,
+                   "Expected native NGV smoke delivery to receive packets");
+  NS_ABORT_MSG_IF (nonNgvDelivery.rxPackets == 0 || nonNgvDelivery.txSucceeded == 0,
+                   "Expected repeated NON_NGV_10 smoke delivery to receive packets");
+
+  return 0;
+}

--- a/src/automotive/examples/v2v-nss2-comparison-80211bd.cc
+++ b/src/automotive/examples/v2v-nss2-comparison-80211bd.cc
@@ -1,0 +1,315 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ns3/abort.h"
+#include "ns3/command-line.h"
+#include "ns3/mac48-address.h"
+#include "ns3/mobility-helper.h"
+#include "ns3/net-device.h"
+#include "ns3/node-container.h"
+#include "ns3/packet.h"
+#include "ns3/position-allocator.h"
+#include "ns3/simulator.h"
+#include "ns3/vector.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wifi-mac-header.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-psdu.h"
+#include "ns3/wifi-remote-station-manager.h"
+#include "ns3/wifi-tx-vector.h"
+#include "ns3/yans-wifi-helper.h"
+
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace ns3;
+
+namespace
+{
+
+struct ScenarioResult
+{
+  std::string label;
+  uint8_t nss = 1;
+  uint8_t ngvMcs = 3;
+  uint16_t channelWidthMHz = 10;
+  uint32_t payloadBytes = 0;
+  uint32_t txAttempts = 0;
+  uint32_t txSucceeded = 0;
+  uint32_t rxPackets = 0;
+  Time nominalTxDuration;
+  Time observedTxAirtime;
+  std::vector<Time> observedTxDurations;
+};
+
+NetDeviceContainer
+InstallVehicularDevice (NodeContainer nodes,
+                        Ptr<YansWifiChannel> channel,
+                        const VehicularWifiProfile& profile)
+{
+  YansWifiPhyHelper phy;
+  profile.ConfigurePhy (phy);
+  phy.SetChannel (channel);
+
+  QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+  profile.ConfigureRemoteStationManager (wifi);
+  return wifi.Install (phy, mac, nodes);
+}
+
+WifiMacHeader
+MakeBroadcastDataHeader ()
+{
+  WifiMacHeader header;
+  header.SetType (WIFI_MAC_DATA);
+  header.SetAddr1 (Mac48Address::GetBroadcast ());
+  header.SetAddr2 (Mac48Address ("00:00:00:00:00:01"));
+  header.SetAddr3 (Mac48Address::GetBroadcast ());
+  return header;
+}
+
+VehicularWifiProfile
+MakeNgvProfile (uint16_t channelWidthMHz, uint8_t ngvMcs, uint8_t nss)
+{
+  if (channelWidthMHz == 20)
+    {
+      return VehicularWifiProfile::Ieee80211bd20 ("OfdmRate24Mbps",
+                                                  23.0,
+                                                  -92.0,
+                                                  4.0,
+                                                  ngvMcs,
+                                                  nss);
+    }
+
+  NS_ABORT_MSG_IF (channelWidthMHz != 10, "Only 10 MHz and 20 MHz 802.11bd profiles are supported");
+  return VehicularWifiProfile::Ieee80211bd ("OfdmRate12MbpsBW10MHz",
+                                            23.0,
+                                            -95.0,
+                                            4.0,
+                                            ngvMcs,
+                                            nss,
+                                            channelWidthMHz);
+}
+
+bool
+ReceivePacket (ScenarioResult* result,
+               Ptr<NetDevice> dev,
+               Ptr<const Packet> pkt,
+               uint16_t protocol,
+               const Address& sender)
+{
+  result->rxPackets++;
+  return true;
+}
+
+void
+SendPacket (ScenarioResult* result, Ptr<NetDevice> device, uint32_t payloadBytes)
+{
+  static constexpr uint16_t wsmpProtocol = 0x88DC;
+  result->txAttempts++;
+  if (device->Send (Create<Packet> (payloadBytes), Mac48Address::GetBroadcast (), wsmpProtocol))
+    {
+      result->txSucceeded++;
+    }
+}
+
+void
+NotifyTxPsduBegin (ScenarioResult* result,
+                   Ptr<WifiPhy> phy,
+                   WifiConstPsduMap psduMap,
+                   WifiTxVector txVector,
+                   double txPowerW)
+{
+  const Time duration = WifiPhy::CalculateTxDuration (psduMap, txVector, phy->GetPhyBand ());
+  result->observedTxDurations.push_back (duration);
+  result->observedTxAirtime += duration;
+}
+
+double
+TimeToMicroseconds (Time value)
+{
+  return static_cast<double> (value.GetNanoSeconds ()) / 1000.0;
+}
+
+double
+TimeToMilliseconds (Time value)
+{
+  return static_cast<double> (value.GetNanoSeconds ()) / 1000000.0;
+}
+
+double
+AverageObservedDurationUs (const ScenarioResult& result)
+{
+  if (result.observedTxDurations.empty ())
+    {
+      return 0.0;
+    }
+
+  return TimeToMicroseconds (result.observedTxAirtime) / result.observedTxDurations.size ();
+}
+
+double
+AirtimeGoodputMbps (const ScenarioResult& result)
+{
+  const double airtimeSeconds = result.observedTxAirtime.GetSeconds ();
+  if (airtimeSeconds <= 0.0)
+    {
+      return 0.0;
+    }
+  return (result.rxPackets * result.payloadBytes * 8.0) / airtimeSeconds / 1e6;
+}
+
+ScenarioResult
+RunScenario (const std::string& label,
+             const VehicularWifiProfile& profile,
+             uint32_t payloadBytes,
+             uint32_t packetCount,
+             uint32_t packetIntervalUs,
+             double distanceMeters)
+{
+  ScenarioResult result;
+  result.label = label;
+  result.nss = profile.GetNgvSpatialStreams ();
+  result.ngvMcs = profile.GetNgvMcsIndex ();
+  result.channelWidthMHz = profile.GetChannelWidthMHz ();
+  result.payloadBytes = payloadBytes;
+
+  NodeContainer nodes;
+  nodes.Create (2);
+
+  Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+  positions->Add (Vector (0.0, 0.0, 0.0));
+  positions->Add (Vector (distanceMeters, 0.0, 0.0));
+  MobilityHelper mobility;
+  mobility.SetPositionAllocator (positions);
+  mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  mobility.Install (nodes);
+
+  YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+  NodeContainer senderNode;
+  senderNode.Add (nodes.Get (0));
+  NodeContainer receiverNode;
+  receiverNode.Add (nodes.Get (1));
+
+  NetDeviceContainer senderDevices = InstallVehicularDevice (senderNode, channel, profile);
+  NetDeviceContainer receiverDevices = InstallVehicularDevice (receiverNode, channel, profile);
+  receiverDevices.Get (0)->SetReceiveCallback (MakeBoundCallback (&ReceivePacket, &result));
+
+  Ptr<WifiNetDevice> senderWifi = DynamicCast<WifiNetDevice> (senderDevices.Get (0));
+  NS_ABORT_MSG_IF (senderWifi == nullptr, "Expected an installed sender Wi-Fi device");
+  Ptr<WifiPhy> senderPhy = senderWifi->GetPhy ();
+
+  const WifiTxVector dataTxVector =
+      senderWifi->GetRemoteStationManager ()->GetDataTxVector (MakeBroadcastDataHeader ());
+  result.nominalTxDuration =
+      WifiPhy::CalculateTxDuration (payloadBytes, dataTxVector, senderPhy->GetPhyBand ());
+
+  const bool traceConnected = senderPhy->TraceConnectWithoutContext (
+      "PhyTxPsduBegin",
+      MakeBoundCallback (&NotifyTxPsduBegin, &result, senderPhy));
+  NS_ABORT_MSG_IF (!traceConnected, "Unable to connect PhyTxPsduBegin trace");
+
+  const Time firstTransmission = MilliSeconds (100);
+  for (uint32_t i = 0; i < packetCount; ++i)
+    {
+      Simulator::Schedule (firstTransmission + MicroSeconds (static_cast<uint64_t> (i) * packetIntervalUs),
+                           &SendPacket,
+                           &result,
+                           senderDevices.Get (0),
+                           payloadBytes);
+    }
+
+  Simulator::Stop (firstTransmission + MicroSeconds (static_cast<uint64_t> (packetCount) * packetIntervalUs)
+                   + MilliSeconds (100));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  return result;
+}
+
+void
+PrintScenarioResult (const ScenarioResult& result)
+{
+  const std::string prefix = result.label;
+  std::cout << prefix << " NGV-MCS: " << static_cast<uint32_t> (result.ngvMcs) << std::endl;
+  std::cout << prefix << " channel width MHz: " << result.channelWidthMHz << std::endl;
+  std::cout << prefix << " spatial streams: " << static_cast<uint32_t> (result.nss) << std::endl;
+  std::cout << prefix << " nominal TX duration us: " << TimeToMicroseconds (result.nominalTxDuration)
+            << std::endl;
+  std::cout << prefix << " observed average TX duration us: " << AverageObservedDurationUs (result)
+            << std::endl;
+  std::cout << prefix << " total TX airtime ms: " << TimeToMilliseconds (result.observedTxAirtime)
+            << std::endl;
+  std::cout << prefix << " TX attempts: " << result.txAttempts << std::endl;
+  std::cout << prefix << " TX succeeded: " << result.txSucceeded << std::endl;
+  std::cout << prefix << " RX packets: " << result.rxPackets << std::endl;
+  std::cout << prefix << " airtime goodput Mbps: " << AirtimeGoodputMbps (result) << std::endl;
+}
+
+} // namespace
+
+int
+main (int argc, char* argv[])
+{
+  uint32_t payloadBytes = 1024;
+  uint32_t packetCount = 20;
+  uint32_t packetIntervalUs = 2000;
+  uint32_t ngvMcs = 3;
+  uint32_t channelWidthMHz = 10;
+  double distanceMeters = 5.0;
+
+  CommandLine cmd (__FILE__);
+  cmd.AddValue ("payload-bytes", "Payload size used for each broadcast packet", payloadBytes);
+  cmd.AddValue ("packet-count", "Number of packets sent in each NSS scenario", packetCount);
+  cmd.AddValue ("packet-interval-us", "Inter-packet interval in microseconds", packetIntervalUs);
+  cmd.AddValue ("ngv-mcs", "NGV-MCS index used for both NSS=1 and NSS=2", ngvMcs);
+  cmd.AddValue ("channel-width-mhz", "802.11bd channel width, 10 or 20 MHz", channelWidthMHz);
+  cmd.AddValue ("distance-m", "Distance between sender and receiver", distanceMeters);
+  cmd.Parse (argc, argv);
+
+  NS_ABORT_MSG_IF (packetCount == 0, "packet-count must be greater than zero");
+  NS_ABORT_MSG_IF (packetIntervalUs == 0, "packet-interval-us must be greater than zero");
+  NS_ABORT_MSG_IF (ngvMcs > 255, "ngv-mcs must fit in uint8_t");
+  NS_ABORT_MSG_IF (channelWidthMHz != 10 && channelWidthMHz != 20,
+                   "channel-width-mhz must be 10 or 20");
+
+  std::cout << std::fixed << std::setprecision (6);
+
+  const ScenarioResult nss1 = RunScenario ("NSS1",
+                                           MakeNgvProfile (channelWidthMHz,
+                                                           static_cast<uint8_t> (ngvMcs),
+                                                           1),
+                                           payloadBytes,
+                                           packetCount,
+                                           packetIntervalUs,
+                                           distanceMeters);
+  const ScenarioResult nss2 = RunScenario ("NSS2",
+                                           MakeNgvProfile (channelWidthMHz,
+                                                           static_cast<uint8_t> (ngvMcs),
+                                                           2),
+                                           payloadBytes,
+                                           packetCount,
+                                           packetIntervalUs,
+                                           distanceMeters);
+
+  PrintScenarioResult (nss1);
+  PrintScenarioResult (nss2);
+
+  const double durationRatio = AverageObservedDurationUs (nss2) / AverageObservedDurationUs (nss1);
+  const double airtimeRatio =
+      TimeToMicroseconds (nss2.observedTxAirtime) / TimeToMicroseconds (nss1.observedTxAirtime);
+  const double goodputRatio = AirtimeGoodputMbps (nss2) / AirtimeGoodputMbps (nss1);
+
+  std::cout << "NSS2/NSS1 average TX duration ratio: " << durationRatio << std::endl;
+  std::cout << "NSS2/NSS1 total TX airtime ratio: " << airtimeRatio << std::endl;
+  std::cout << "NSS2/NSS1 airtime goodput ratio: " << goodputRatio << std::endl;
+
+  return 0;
+}

--- a/src/automotive/examples/v2v-observed-fallback-80211bd.cc
+++ b/src/automotive/examples/v2v-observed-fallback-80211bd.cc
@@ -1,0 +1,259 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ns3/abort.h"
+#include "ns3/command-line.h"
+#include "ns3/mac48-address.h"
+#include "ns3/mobility-helper.h"
+#include "ns3/net-device.h"
+#include "ns3/node-container.h"
+#include "ns3/packet.h"
+#include "ns3/position-allocator.h"
+#include "ns3/simulator.h"
+#include "ns3/vector.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-psdu.h"
+#include "ns3/wifi-tx-vector.h"
+#include "ns3/yans-wifi-helper.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace ns3;
+
+namespace
+{
+
+static constexpr uint16_t OBSERVED_POLICY_PROTOCOL = 0x88D5;
+
+struct ObservationSample
+{
+  std::string label;
+  double observedSnrDb = 30.0;
+  bool deliverySucceeded = true;
+  bool legacyReceiverPresent = false;
+};
+
+struct CaseResult
+{
+  std::string label;
+  VehicularWifiFallbackMode mode = VehicularWifiFallbackMode::NGV_20;
+  double ewmaSnrDb = 0.0;
+  uint32_t sampleCount = 0;
+  uint32_t consecutiveFailures = 0;
+  uint32_t txAttempts = 0;
+  uint32_t txSucceeded = 0;
+  uint32_t rxPackets = 0;
+  uint32_t ngvPpdus = 0;
+  uint32_t duplicatePpdus = 0;
+  uint32_t nonNgv10Ppdus = 0;
+};
+
+NetDeviceContainer
+InstallVehicularDevice (NodeContainer nodes,
+                        Ptr<YansWifiChannel> channel,
+                        const VehicularWifiProfile& profile)
+{
+  YansWifiPhyHelper phy;
+  profile.ConfigurePhy (phy);
+  phy.SetChannel (channel);
+
+  QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+  profile.ConfigureRemoteStationManager (wifi);
+  return wifi.Install (phy, mac, nodes);
+}
+
+VehicularWifiProfile
+MakeReceiverProfile (VehicularWifiFallbackMode mode, bool legacyReceiverPresent)
+{
+  if (legacyReceiverPresent)
+    {
+      return VehicularWifiProfile::Ieee80211p ();
+    }
+  if (mode == VehicularWifiFallbackMode::NGV_20 ||
+      mode == VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE)
+    {
+      return VehicularWifiProfile::Ieee80211bd20 ();
+    }
+  return VehicularWifiProfile::Ieee80211bdNonNgv10 ();
+}
+
+bool
+ReceivePacket (CaseResult* result,
+               Ptr<NetDevice> dev,
+               Ptr<const Packet> pkt,
+               uint16_t protocol,
+               const Address& sender)
+{
+  if (protocol == OBSERVED_POLICY_PROTOCOL)
+    {
+      result->rxPackets++;
+    }
+  return true;
+}
+
+void
+NotifyTxPsduBegin (CaseResult* result,
+                   WifiConstPsduMap psduMap,
+                   WifiTxVector txVector,
+                   double txPowerW)
+{
+  if (txVector.IsNgv ())
+    {
+      result->ngvPpdus++;
+    }
+  else if (txVector.IsNonNgv20Duplicate ())
+    {
+      result->duplicatePpdus++;
+    }
+  else if (txVector.IsNonNgv10 ())
+    {
+      result->nonNgv10Ppdus++;
+    }
+}
+
+void
+SendPacket (CaseResult* result, Ptr<NetDevice> sender, uint32_t payloadBytes)
+{
+  result->txAttempts++;
+  if (sender->Send (Create<Packet> (payloadBytes),
+                    Mac48Address::GetBroadcast (),
+                    OBSERVED_POLICY_PROTOCOL))
+    {
+      result->txSucceeded++;
+    }
+}
+
+CaseResult
+RunCase (const ObservationSample& sample,
+         VehicularWifiFallbackController::ObservationState& state,
+         uint32_t payloadBytes,
+         double distanceMeters)
+{
+  CaseResult result;
+  result.label = sample.label;
+  result.mode = VehicularWifiFallbackController::UpdateFromObservation (
+      state,
+      sample.observedSnrDb,
+      sample.deliverySucceeded,
+      sample.legacyReceiverPresent);
+  result.ewmaSnrDb = state.ewmaSnrDb;
+  result.sampleCount = state.sampleCount;
+  result.consecutiveFailures = state.consecutiveFailures;
+
+  NodeContainer nodes;
+  nodes.Create (2);
+
+  Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+  positions->Add (Vector (0.0, 0.0, 0.0));
+  positions->Add (Vector (distanceMeters, 0.0, 0.0));
+  MobilityHelper mobility;
+  mobility.SetPositionAllocator (positions);
+  mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  mobility.Install (nodes);
+
+  YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+  NodeContainer senderNode;
+  senderNode.Add (nodes.Get (0));
+  NodeContainer receiverNode;
+  receiverNode.Add (nodes.Get (1));
+
+  NetDeviceContainer senderDevices =
+      InstallVehicularDevice (senderNode,
+                              channel,
+                              VehicularWifiFallbackController::MakeProfile (result.mode));
+  NetDeviceContainer receiverDevices =
+      InstallVehicularDevice (receiverNode,
+                              channel,
+                              MakeReceiverProfile (result.mode, sample.legacyReceiverPresent));
+
+  receiverDevices.Get (0)->SetReceiveCallback (MakeBoundCallback (&ReceivePacket, &result));
+
+  Ptr<WifiNetDevice> senderWifi = DynamicCast<WifiNetDevice> (senderDevices.Get (0));
+  NS_ABORT_MSG_IF (senderWifi == nullptr, "Expected an installed sender Wi-Fi device");
+  const bool traceConnected = senderWifi->GetPhy ()->TraceConnectWithoutContext (
+      "PhyTxPsduBegin",
+      MakeBoundCallback (&NotifyTxPsduBegin, &result));
+  NS_ABORT_MSG_IF (!traceConnected, "Unable to connect PhyTxPsduBegin trace");
+
+  Simulator::Schedule (MilliSeconds (100), &SendPacket, &result, senderDevices.Get (0), payloadBytes);
+  Simulator::Stop (MilliSeconds (500));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  return result;
+}
+
+} // namespace
+
+int
+main (int argc, char* argv[])
+{
+  uint32_t payloadBytes = 256;
+  double distanceMeters = 5.0;
+  double ewmaAlpha = 0.5;
+
+  CommandLine cmd (__FILE__);
+  cmd.AddValue ("payload-bytes", "Payload size used by each observed-policy case", payloadBytes);
+  cmd.AddValue ("distance-m", "Distance between sender and receiver", distanceMeters);
+  cmd.AddValue ("ewma-alpha", "EWMA alpha applied to explicit SNR observations", ewmaAlpha);
+  cmd.Parse (argc, argv);
+
+  NS_ABORT_MSG_IF (payloadBytes == 0, "payload-bytes must be greater than zero");
+
+  VehicularWifiFallbackController::ObservationState state;
+  state.ewmaAlpha = ewmaAlpha;
+  state.policy.minNgv20SnrDb = 18.0;
+  state.policy.minDuplicate20SnrDb = 6.0;
+  state.failureThreshold = 2;
+
+  const std::vector<ObservationSample> samples = {
+      {"Observed high", 25.0, true, false},
+      {"Observed mid", 9.0, true, false},
+      {"Observed low-fail-1", 2.0, false, false},
+      {"Observed low-fail-2", 2.0, false, false},
+      {"Observed legacy-high", 25.0, true, true},
+  };
+
+  uint32_t totalRxPackets = 0;
+  uint32_t totalNgvPpdus = 0;
+  uint32_t totalDuplicatePpdus = 0;
+  uint32_t totalNonNgv10Ppdus = 0;
+
+  for (const auto& sample : samples)
+    {
+      const CaseResult result = RunCase (sample, state, payloadBytes, distanceMeters);
+      totalRxPackets += result.rxPackets;
+      totalNgvPpdus += result.ngvPpdus;
+      totalDuplicatePpdus += result.duplicatePpdus;
+      totalNonNgv10Ppdus += result.nonNgv10Ppdus;
+
+      std::cout << result.label << " selected mode: "
+                << VehicularWifiFallbackModeName (result.mode) << std::endl;
+      std::cout << result.label << " EWMA SNR dB: " << result.ewmaSnrDb << std::endl;
+      std::cout << result.label << " consecutive failures: " << result.consecutiveFailures
+                << std::endl;
+      std::cout << result.label << " RX packets: " << result.rxPackets << std::endl;
+    }
+
+  std::cout << "Observed fallback policy cases: " << samples.size () << std::endl;
+  std::cout << "Observed fallback policy RX packets: " << totalRxPackets << std::endl;
+  std::cout << "Observed fallback policy NGV PPDU count: " << totalNgvPpdus << std::endl;
+  std::cout << "Observed fallback policy NON_NGV_20_DUPLICATE PPDU count: "
+            << totalDuplicatePpdus << std::endl;
+  std::cout << "Observed fallback policy NON_NGV_10 PPDU count: " << totalNonNgv10Ppdus
+            << std::endl;
+  std::cout << "Observed fallback policy final EWMA SNR dB: " << state.ewmaSnrDb << std::endl;
+  std::cout << "Observed fallback policy final consecutive failures: " << state.consecutiveFailures
+            << std::endl;
+
+  return 0;
+}

--- a/src/automotive/examples/v2v-rate-control-80211bd.cc
+++ b/src/automotive/examples/v2v-rate-control-80211bd.cc
@@ -1,0 +1,286 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ns3/abort.h"
+#include "ns3/command-line.h"
+#include "ns3/mac48-address.h"
+#include "ns3/mobility-helper.h"
+#include "ns3/net-device.h"
+#include "ns3/node-container.h"
+#include "ns3/packet.h"
+#include "ns3/position-allocator.h"
+#include "ns3/simulator.h"
+#include "ns3/vector.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-psdu.h"
+#include "ns3/wifi-tx-vector.h"
+#include "ns3/yans-wifi-helper.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace ns3;
+
+namespace
+{
+
+static constexpr uint16_t RATE_CONTROL_PROTOCOL = 0x88D7;
+
+struct CaseConfig
+{
+  std::string label;
+  VehicularWifiRateController::Policy policy;
+};
+
+struct CaseResult
+{
+  std::string label;
+  VehicularWifiRateController::Decision decision;
+  uint32_t txAttempts = 0;
+  uint32_t txSucceeded = 0;
+  uint32_t rxPackets = 0;
+  uint32_t ngvPpdus = 0;
+  uint32_t mcs0Ppdus = 0;
+  uint32_t mcs3Ppdus = 0;
+  uint32_t mcs7Ppdus = 0;
+  uint32_t otherMcsPpdus = 0;
+  uint32_t duplicatePpdus = 0;
+  uint32_t nonNgv10Ppdus = 0;
+};
+
+NetDeviceContainer
+InstallVehicularDevice (NodeContainer nodes,
+                        Ptr<YansWifiChannel> channel,
+                        const VehicularWifiProfile& profile)
+{
+  YansWifiPhyHelper phy;
+  profile.ConfigurePhy (phy);
+  phy.SetChannel (channel);
+
+  QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+  profile.ConfigureRemoteStationManager (wifi);
+  return wifi.Install (phy, mac, nodes);
+}
+
+VehicularWifiProfile
+MakeReceiverProfile (const VehicularWifiRateController::Decision& decision,
+                     bool legacyReceiverPresent)
+{
+  if (legacyReceiverPresent)
+    {
+      return VehicularWifiProfile::Ieee80211p ();
+    }
+  if (decision.fallbackMode == VehicularWifiFallbackMode::NGV_20 ||
+      decision.fallbackMode == VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE)
+    {
+      return VehicularWifiProfile::Ieee80211bd20 ();
+    }
+  return VehicularWifiProfile::Ieee80211bdNonNgv10 ();
+}
+
+bool
+ReceivePacket (CaseResult* result,
+               Ptr<NetDevice> dev,
+               Ptr<const Packet> pkt,
+               uint16_t protocol,
+               const Address& sender)
+{
+  if (protocol == RATE_CONTROL_PROTOCOL)
+    {
+      result->rxPackets++;
+    }
+  return true;
+}
+
+void
+NotifyTxPsduBegin (CaseResult* result,
+                   WifiConstPsduMap psduMap,
+                   WifiTxVector txVector,
+                   double txPowerW)
+{
+  if (txVector.IsNgv ())
+    {
+      result->ngvPpdus++;
+      if (txVector.GetNgvMcs () == 0)
+        {
+          result->mcs0Ppdus++;
+        }
+      else if (txVector.GetNgvMcs () == 3)
+        {
+          result->mcs3Ppdus++;
+        }
+      else if (txVector.GetNgvMcs () == 7)
+        {
+          result->mcs7Ppdus++;
+        }
+      else
+        {
+          result->otherMcsPpdus++;
+        }
+    }
+  else if (txVector.IsNonNgv20Duplicate ())
+    {
+      result->duplicatePpdus++;
+    }
+  else if (txVector.IsNonNgv10 ())
+    {
+      result->nonNgv10Ppdus++;
+    }
+}
+
+void
+SendPacket (CaseResult* result, Ptr<NetDevice> sender, uint32_t payloadBytes)
+{
+  result->txAttempts++;
+  if (sender->Send (Create<Packet> (payloadBytes),
+                    Mac48Address::GetBroadcast (),
+                    RATE_CONTROL_PROTOCOL))
+    {
+      result->txSucceeded++;
+    }
+}
+
+CaseResult
+RunCase (const CaseConfig& config, uint32_t payloadBytes, double distanceMeters)
+{
+  CaseResult result;
+  result.label = config.label;
+  result.decision = VehicularWifiRateController::Select (config.policy);
+
+  NodeContainer nodes;
+  nodes.Create (2);
+
+  Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+  positions->Add (Vector (0.0, 0.0, 0.0));
+  positions->Add (Vector (distanceMeters, 0.0, 0.0));
+  MobilityHelper mobility;
+  mobility.SetPositionAllocator (positions);
+  mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  mobility.Install (nodes);
+
+  YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+  NodeContainer senderNode;
+  senderNode.Add (nodes.Get (0));
+  NodeContainer receiverNode;
+  receiverNode.Add (nodes.Get (1));
+
+  NetDeviceContainer senderDevices =
+      InstallVehicularDevice (senderNode,
+                              channel,
+                              VehicularWifiRateController::MakeProfile (result.decision));
+  NetDeviceContainer receiverDevices =
+      InstallVehicularDevice (receiverNode,
+                              channel,
+                              MakeReceiverProfile (result.decision,
+                                                   config.policy.linkQuality.legacyReceiverPresent));
+
+  receiverDevices.Get (0)->SetReceiveCallback (MakeBoundCallback (&ReceivePacket, &result));
+
+  Ptr<WifiNetDevice> senderWifi = DynamicCast<WifiNetDevice> (senderDevices.Get (0));
+  NS_ABORT_MSG_IF (senderWifi == nullptr, "Expected an installed sender Wi-Fi device");
+  const bool traceConnected = senderWifi->GetPhy ()->TraceConnectWithoutContext (
+      "PhyTxPsduBegin",
+      MakeBoundCallback (&NotifyTxPsduBegin, &result));
+  NS_ABORT_MSG_IF (!traceConnected, "Unable to connect PhyTxPsduBegin trace");
+
+  Simulator::Schedule (MilliSeconds (100), &SendPacket, &result, senderDevices.Get (0), payloadBytes);
+  Simulator::Stop (MilliSeconds (500));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  return result;
+}
+
+CaseConfig
+MakeCase (const std::string& label, bool legacyReceiverPresent, double estimatedSnrDb)
+{
+  CaseConfig config;
+  config.label = label;
+  config.policy.standard = VehicularWifiProfile::Standard::IEEE_80211BD;
+  config.policy.linkQuality.legacyReceiverPresent = legacyReceiverPresent;
+  config.policy.linkQuality.estimatedSnrDb = estimatedSnrDb;
+  return config;
+}
+
+} // namespace
+
+int
+main (int argc, char* argv[])
+{
+  uint32_t payloadBytes = 256;
+  double distanceMeters = 5.0;
+
+  CommandLine cmd (__FILE__);
+  cmd.AddValue ("payload-bytes", "Payload size used by each rate-control case", payloadBytes);
+  cmd.AddValue ("distance-m", "Distance between sender and receiver", distanceMeters);
+  cmd.Parse (argc, argv);
+
+  NS_ABORT_MSG_IF (payloadBytes == 0, "payload-bytes must be greater than zero");
+
+  const std::vector<CaseConfig> cases = {
+      MakeCase ("High no-legacy", false, 35.0),
+      MakeCase ("Medium no-legacy", false, 22.0),
+      MakeCase ("Low no-legacy", false, 14.0),
+      MakeCase ("Sub-NGV no-legacy", false, 8.0),
+      MakeCase ("High legacy", true, 35.0),
+      MakeCase ("Very low no-legacy", false, 2.0),
+  };
+
+  uint32_t totalTxAttempts = 0;
+  uint32_t totalTxSucceeded = 0;
+  uint32_t totalRxPackets = 0;
+  uint32_t totalNgvPpdus = 0;
+  uint32_t totalMcs0Ppdus = 0;
+  uint32_t totalMcs3Ppdus = 0;
+  uint32_t totalMcs7Ppdus = 0;
+  uint32_t totalOtherMcsPpdus = 0;
+  uint32_t totalDuplicatePpdus = 0;
+  uint32_t totalNonNgv10Ppdus = 0;
+
+  for (const auto& testCase : cases)
+    {
+      const CaseResult result = RunCase (testCase, payloadBytes, distanceMeters);
+      totalTxAttempts += result.txAttempts;
+      totalTxSucceeded += result.txSucceeded;
+      totalRxPackets += result.rxPackets;
+      totalNgvPpdus += result.ngvPpdus;
+      totalMcs0Ppdus += result.mcs0Ppdus;
+      totalMcs3Ppdus += result.mcs3Ppdus;
+      totalMcs7Ppdus += result.mcs7Ppdus;
+      totalOtherMcsPpdus += result.otherMcsPpdus;
+      totalDuplicatePpdus += result.duplicatePpdus;
+      totalNonNgv10Ppdus += result.nonNgv10Ppdus;
+
+      std::cout << result.label << " selected decision: "
+                << VehicularWifiRateController::DecisionName (result.decision) << std::endl;
+      std::cout << result.label << " RX packets: " << result.rxPackets << std::endl;
+    }
+
+  std::cout << "Rate-control 802.11bd cases: " << cases.size () << std::endl;
+  std::cout << "Rate-control 802.11bd TX attempts: " << totalTxAttempts << std::endl;
+  std::cout << "Rate-control 802.11bd TX succeeded: " << totalTxSucceeded << std::endl;
+  std::cout << "Rate-control 802.11bd RX packets: " << totalRxPackets << std::endl;
+  std::cout << "Rate-control 802.11bd NGV PPDU count: " << totalNgvPpdus << std::endl;
+  std::cout << "Rate-control 802.11bd NGV-MCS0 PPDU count: " << totalMcs0Ppdus
+            << std::endl;
+  std::cout << "Rate-control 802.11bd NGV-MCS3 PPDU count: " << totalMcs3Ppdus
+            << std::endl;
+  std::cout << "Rate-control 802.11bd NGV-MCS7 PPDU count: " << totalMcs7Ppdus
+            << std::endl;
+  std::cout << "Rate-control 802.11bd other NGV-MCS PPDU count: " << totalOtherMcsPpdus
+            << std::endl;
+  std::cout << "Rate-control 802.11bd NON_NGV_20_DUPLICATE PPDU count: "
+            << totalDuplicatePpdus << std::endl;
+  std::cout << "Rate-control 802.11bd NON_NGV_10 PPDU count: " << totalNonNgv10Ppdus
+            << std::endl;
+
+  return 0;
+}

--- a/src/automotive/examples/v2v-runtime-fallback-80211bd.cc
+++ b/src/automotive/examples/v2v-runtime-fallback-80211bd.cc
@@ -1,0 +1,267 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ns3/abort.h"
+#include "ns3/command-line.h"
+#include "ns3/mac48-address.h"
+#include "ns3/mobility-helper.h"
+#include "ns3/net-device.h"
+#include "ns3/node-container.h"
+#include "ns3/packet.h"
+#include "ns3/position-allocator.h"
+#include "ns3/simulator.h"
+#include "ns3/vector.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wifi-mac-header.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-psdu.h"
+#include "ns3/wifi-remote-station-manager.h"
+#include "ns3/wifi-tx-vector.h"
+#include "ns3/yans-wifi-helper.h"
+
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+
+using namespace ns3;
+
+namespace
+{
+
+static constexpr uint16_t NGV_PROTOCOL = 0x88D1;
+static constexpr uint16_t FALLBACK_PROTOCOL = 0x88D2;
+
+struct ReceiverStats
+{
+  uint32_t ngvPackets = 0;
+  uint32_t fallbackPackets = 0;
+};
+
+struct TxStats
+{
+  uint32_t ngvPpdus = 0;
+  uint32_t duplicatePpdus = 0;
+  Time ngvAirtime;
+  Time duplicateAirtime;
+};
+
+struct SendStats
+{
+  uint32_t ngvAttempts = 0;
+  uint32_t ngvSucceeded = 0;
+  uint32_t fallbackAttempts = 0;
+  uint32_t fallbackSucceeded = 0;
+};
+
+NetDeviceContainer
+InstallVehicularDevice (NodeContainer nodes,
+                        Ptr<YansWifiChannel> channel,
+                        const VehicularWifiProfile& profile)
+{
+  YansWifiPhyHelper phy;
+  profile.ConfigurePhy (phy);
+  phy.SetChannel (channel);
+
+  QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+  profile.ConfigureRemoteStationManager (wifi);
+  return wifi.Install (phy, mac, nodes);
+}
+
+bool
+ReceivePacket (ReceiverStats* stats,
+               Ptr<NetDevice> dev,
+               Ptr<const Packet> pkt,
+               uint16_t protocol,
+               const Address& sender)
+{
+  if (protocol == NGV_PROTOCOL)
+    {
+      stats->ngvPackets++;
+    }
+  else if (protocol == FALLBACK_PROTOCOL)
+    {
+      stats->fallbackPackets++;
+    }
+  return true;
+}
+
+void
+NotifyTxPsduBegin (TxStats* stats,
+                   Ptr<WifiPhy> phy,
+                   WifiConstPsduMap psduMap,
+                   WifiTxVector txVector,
+                   double txPowerW)
+{
+  const Time duration = WifiPhy::CalculateTxDuration (psduMap, txVector, phy->GetPhyBand ());
+  if (txVector.IsNgv ())
+    {
+      stats->ngvPpdus++;
+      stats->ngvAirtime += duration;
+    }
+  else if (txVector.IsNonNgv20Duplicate ())
+    {
+      stats->duplicatePpdus++;
+      stats->duplicateAirtime += duration;
+    }
+}
+
+void
+ConfigureRuntimeFormat (Ptr<WifiRemoteStationManager> manager, bool fallback)
+{
+  const VehicularWifiFallbackMode mode =
+      VehicularWifiFallbackController::Select (fallback, true, false);
+  VehicularWifiFallbackController::ConfigureRemoteStationManager (manager, mode);
+}
+
+void
+SendRuntimePhase (SendStats* stats,
+                  Ptr<NetDevice> sender,
+                  Ptr<WifiRemoteStationManager> manager,
+                  bool fallback,
+                  uint32_t payloadBytes)
+{
+  ConfigureRuntimeFormat (manager, fallback);
+  if (fallback)
+    {
+      stats->fallbackAttempts++;
+      if (sender->Send (Create<Packet> (payloadBytes),
+                        Mac48Address::GetBroadcast (),
+                        FALLBACK_PROTOCOL))
+        {
+          stats->fallbackSucceeded++;
+        }
+    }
+  else
+    {
+      stats->ngvAttempts++;
+      if (sender->Send (Create<Packet> (payloadBytes), Mac48Address::GetBroadcast (), NGV_PROTOCOL))
+        {
+          stats->ngvSucceeded++;
+        }
+    }
+}
+
+double
+TimeToMicroseconds (Time value)
+{
+  return static_cast<double> (value.GetNanoSeconds ()) / 1000.0;
+}
+
+double
+AverageDurationUs (Time airtime, uint32_t count)
+{
+  if (count == 0)
+    {
+      return 0.0;
+    }
+  return TimeToMicroseconds (airtime) / count;
+}
+
+} // namespace
+
+int
+main (int argc, char* argv[])
+{
+  uint32_t payloadBytes = 256;
+  double distanceMeters = 5.0;
+
+  CommandLine cmd (__FILE__);
+  cmd.AddValue ("payload-bytes", "Payload size used for each runtime fallback phase", payloadBytes);
+  cmd.AddValue ("distance-m", "Distance between sender and receivers", distanceMeters);
+  cmd.Parse (argc, argv);
+
+  NS_ABORT_MSG_IF (payloadBytes == 0, "payload-bytes must be greater than zero");
+
+  ReceiverStats receiver11bd;
+  ReceiverStats receiver11p;
+  TxStats txStats;
+  SendStats sendStats;
+
+  NodeContainer nodes;
+  nodes.Create (3);
+
+  Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+  positions->Add (Vector (0.0, 0.0, 0.0));
+  positions->Add (Vector (distanceMeters, 0.0, 0.0));
+  positions->Add (Vector (distanceMeters + 1.0, 0.0, 0.0));
+  MobilityHelper mobility;
+  mobility.SetPositionAllocator (positions);
+  mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  mobility.Install (nodes);
+
+  YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+  NodeContainer senderNode;
+  senderNode.Add (nodes.Get (0));
+  NodeContainer receiver11bdNode;
+  receiver11bdNode.Add (nodes.Get (1));
+  NodeContainer receiver11pNode;
+  receiver11pNode.Add (nodes.Get (2));
+
+  NetDeviceContainer senderDevices =
+      InstallVehicularDevice (senderNode, channel, VehicularWifiProfile::Ieee80211bd20 ());
+  NetDeviceContainer receiver11bdDevices =
+      InstallVehicularDevice (receiver11bdNode, channel, VehicularWifiProfile::Ieee80211bd20 ());
+  NetDeviceContainer receiver11pDevices =
+      InstallVehicularDevice (receiver11pNode, channel, VehicularWifiProfile::Ieee80211p ());
+
+  receiver11bdDevices.Get (0)->SetReceiveCallback (
+      MakeBoundCallback (&ReceivePacket, &receiver11bd));
+  receiver11pDevices.Get (0)->SetReceiveCallback (
+      MakeBoundCallback (&ReceivePacket, &receiver11p));
+
+  Ptr<WifiNetDevice> senderWifi = DynamicCast<WifiNetDevice> (senderDevices.Get (0));
+  NS_ABORT_MSG_IF (senderWifi == nullptr, "Expected an installed sender Wi-Fi device");
+  Ptr<WifiPhy> senderPhy = senderWifi->GetPhy ();
+  Ptr<WifiRemoteStationManager> senderManager = senderWifi->GetRemoteStationManager ();
+  NS_ABORT_MSG_IF (senderManager == nullptr, "Expected an installed sender remote station manager");
+
+  const bool traceConnected = senderPhy->TraceConnectWithoutContext (
+      "PhyTxPsduBegin",
+      MakeBoundCallback (&NotifyTxPsduBegin, &txStats, senderPhy));
+  NS_ABORT_MSG_IF (!traceConnected, "Unable to connect PhyTxPsduBegin trace");
+
+  Simulator::Schedule (MilliSeconds (100),
+                       &SendRuntimePhase,
+                       &sendStats,
+                       senderDevices.Get (0),
+                       senderManager,
+                       false,
+                       payloadBytes);
+  Simulator::Schedule (MilliSeconds (200),
+                       &SendRuntimePhase,
+                       &sendStats,
+                       senderDevices.Get (0),
+                       senderManager,
+                       true,
+                       payloadBytes);
+  Simulator::Stop (MilliSeconds (500));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  const double ngvDurationUs = AverageDurationUs (txStats.ngvAirtime, txStats.ngvPpdus);
+  const double duplicateDurationUs =
+      AverageDurationUs (txStats.duplicateAirtime, txStats.duplicatePpdus);
+  const double durationRatio = ngvDurationUs > 0.0 ? duplicateDurationUs / ngvDurationUs : 0.0;
+
+  std::cout << std::fixed << std::setprecision (6);
+  std::cout << "TX NGV attempts: " << sendStats.ngvAttempts << std::endl;
+  std::cout << "TX NGV succeeded: " << sendStats.ngvSucceeded << std::endl;
+  std::cout << "TX fallback attempts: " << sendStats.fallbackAttempts << std::endl;
+  std::cout << "TX fallback succeeded: " << sendStats.fallbackSucceeded << std::endl;
+  std::cout << "TX NGV PPDU count: " << txStats.ngvPpdus << std::endl;
+  std::cout << "TX NON_NGV_20_DUPLICATE PPDU count: " << txStats.duplicatePpdus << std::endl;
+  std::cout << "TX NGV average duration us: " << ngvDurationUs << std::endl;
+  std::cout << "TX NON_NGV_20_DUPLICATE average duration us: " << duplicateDurationUs << std::endl;
+  std::cout << "NON_NGV_20_DUPLICATE/NGV duration ratio: " << durationRatio << std::endl;
+  std::cout << "802.11bd receiver NGV RX packets: " << receiver11bd.ngvPackets << std::endl;
+  std::cout << "802.11bd receiver fallback RX packets: " << receiver11bd.fallbackPackets << std::endl;
+  std::cout << "802.11p receiver NGV RX packets: " << receiver11p.ngvPackets << std::endl;
+  std::cout << "802.11p receiver fallback RX packets: " << receiver11p.fallbackPackets << std::endl;
+
+  return 0;
+}

--- a/src/automotive/examples/v2v-simple-cam-exchange-80211bd.cc
+++ b/src/automotive/examples/v2v-simple-cam-exchange-80211bd.cc
@@ -1,0 +1,394 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006,2007 INRIA
+ * Copyright (c) 2013 Dalian University of Technology
+ * Copyright (c) 2022 Politecnico di Torino
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage <mathieu.lacage@sophia.inria.fr> (initial IEEE 802.11bd example)
+ * Author: Junling Bu <linlinjavaer@gmail.com> (initial IEEE 802.11bd example)
+ * Author: Francesco Raviglione <francescorav.es483@gmail.com> (IEEE 802.11bd simple CAM exchange application)
+ *
+ * This is a simple example of a ms-van3t V2V communication scenario configured with a single .cc file,
+ * where vehicles exchange Cooperative Awareness Messages (CAMs) using the IEEE 802.11bd standard.
+ * The user can specify several parameters, including the priority (Access Category) for the transmission
+ * of CAMs. BSContainers are used to simplify the configuration of the ETSI C-ITS stack of each vehicle.
+ * In this scenario, all vehicles transmit CAMs according to the ETSI standards, and one vehicle (vehicle 3)
+ * sends a heavy interfering traffic, without useful informative content, to simulate a congested channel.
+ * Through the --interfering-userpriority option, the user can specify the Access Category (AC) for the
+ * interfering traffic, which is broadcasted by vehicle 3.
+ * When a new CAM is received by one of the vehicles, the callback "receiveCAM()" is called, and the stationID of
+ * the received is available in "my_stationID".
+ * Currently, the function just counts the total number of CAMs, but it can be customized to impement more complex
+ * approaches.
+ * As output, the simulation provides, thanks to the PRRSupervisor module, the average latency and PRR over the
+ * whole simulation, and the average one-way latency for each vehicle up to vehicle 4.
+ * The reported latency of vehicle 3 is expected to be 0 as it transmits interfering traffic (so, no ETSI-compliant
+ * message is transmitted), that is not considered by the PRRSupervisor.
+ */
+#include "ns3/carla-module.h"
+
+#include "ns3/vector.h"
+#include "ns3/string.h"
+#include "ns3/socket.h"
+#include "ns3/double.h"
+#include "ns3/config.h"
+#include "ns3/log.h"
+#include "ns3/command-line.h"
+#include "ns3/yans-wifi-helper.h"
+#include "ns3/position-allocator.h"
+#include "ns3/mobility-helper.h"
+#include <cstdint>
+#include <iostream>
+#include "ns3/MetricSupervisor.h"
+#include "ns3/sumo_xml_parser.h"
+#include "ns3/BSMap.h"
+#include "ns3/caBasicService.h"
+#include "ns3/btp.h"
+#include "ns3/ocb-wifi-mac.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/packet-socket-helper.h"
+#include "ns3/gn-utils.h"
+#include "ns3/csv-utils.h"
+
+using namespace ns3;
+
+NS_LOG_COMPONENT_DEFINE ("V2VSimpleCAMExchange80211bd");
+
+// ******* DEFINE HERE ANY LOCAL GLOBAL VARIABLE, ACCESSIBLE FROM ANY FUNCTION IN THIS FILE *******
+// Variables defined here should always be "static"
+static int packet_count=0;
+BSMap basicServices; // Container for all ETSI Basic Services, installed on all vehicles
+// ************************************************************************************************
+
+// If you want to make a comparison with a received CAM MAC address, you can use:
+// from == getGNAddress (0,Mac48Address(comparison_string)), where "comparison_string" is something like "00:00:00:00:00:09"
+
+// Useful tip: you can get the latitude and longitude position of a given vehicle at any time with:
+//   libsumo::TraCIPosition pos=<MobilityClient>->TraCIAPI::vehicle.getPosition(<string ID of the vehicle>);
+//   pos=<MobilityClient>->TraCIAPI::simulation.convertXYtoLonLat(pos.x,pos.y);
+// <MobilityClient> should be the right Ptr<TraciClient> for the current vehicle, which can be retrieved from the
+//   global Basic Services container with basicServices.get(my_stationID)->getTraCIclient ()
+// The string ID of the vehicle should match the one in the XML file, i.e., for vehicle 7, the string id should be "veh7"
+// After these two lines, pos.y will contain the latitude of the vehicle, while pos.x the longitude of the vehicle
+void receiveCAM(asn1cpp::Seq<CAM> cam, Address from, StationID_t my_stationID, StationType_t my_StationType, SignalInfo phy_info)
+{
+  packet_count++;
+  // Logging the distance with respect to the RSSI
+  double lat_sender=asn1cpp::getField(cam->cam.camParameters.basicContainer.referencePosition.latitude,double)/1e7;
+  double lon_sender=asn1cpp::getField(cam->cam.camParameters.basicContainer.referencePosition.longitude,double)/1e7;
+  //
+  libsumo::TraCIPosition pos=basicServices.get(my_stationID)->getTraCIclient ()->TraCIAPI::vehicle.getPosition("veh" + std::to_string(my_stationID));
+  pos=basicServices.get(my_stationID)->getTraCIclient ()->TraCIAPI::simulation.convertXYtoLonLat(pos.x,pos.y);
+  //
+  double distance=haversineDist (lat_sender, lon_sender, pos.y, pos.x);
+  //
+  writeDataToCSV("distance_rssi_int_extra.csv","distance_m,rssi",distance,phy_info.rssi);
+}
+
+static void GenerateTraffic_interfering (Ptr<Socket> socket, uint32_t pktSize,
+                             uint32_t pktCount, Time pktInterval )
+{
+  // Generate interfering traffic by sending pktCount packets (filled in with zeros), every pktInterval
+  if (pktCount > 0)
+    {
+      // "Create<Packet> (pktSize)" creates a new packet of size pktSize bytes, composed by default by all zeros
+      socket->Send (Create<Packet> (pktSize));
+      // Schedule again the same function (to send the next packet), and decrease by one the packet count
+      Simulator::Schedule (pktInterval, &GenerateTraffic_interfering,
+                           socket, pktSize,pktCount - 1, pktInterval);
+    }
+  else
+    {
+      socket->Close ();
+    }
+}
+
+int main (int argc, char *argv[])
+{
+  std::string phyMode ("OfdmRate12MbpsBW10MHz"); // Default IEEE 802.11bd data rate profile
+  int up=0;
+  int interfering_up=0;
+  bool verbose = false; // Set to true to get a lot of verbose output from the IEEE 802.11bd PHY model (leave this to false)
+  int numberOfNodes; // Total number of vehicles, automatically filled in by reading the XML file
+  double m_baseline_prr = 150.0; // PRR baseline value (default: 150 m)
+  int txPower = 23.0; // IEEE 802.11bd transmission power in dBm (default: 23 dBm)
+  double sensitivity = -95.0;
+  double snr_threshold = 4.0;
+  xmlDocPtr rou_xml_file;
+  double simTime = 100.0; // Total simulation time (default: 100 seconds)
+  bool security_enabled = false; // V2X security is disabled by default
+  bool sumo_gui = true;
+
+  // Set here the path to the SUMO XML files
+  std::string sumo_folder = "src/automotive/examples/sumo_files_v2v_map/";
+  std::string mob_trace = "cars.rou.xml";
+  std::string sumo_config ="src/automotive/examples/sumo_files_v2v_map/map.sumo.cfg";
+
+  // Read the command line options
+  CommandLine cmd (__FILE__);
+
+  // Syntax to add new options: cmd.addValue (<option>,<brief description>,<destination variable>)
+  cmd.AddValue ("phyMode", "Wifi Phy mode", phyMode);
+  cmd.AddValue ("verbose", "turn on all WifiNetDevice log components", verbose);
+  cmd.AddValue ("userpriority","EDCA User Priority for the ETSI messages",up);
+  cmd.AddValue ("interfering-userpriority","User Priority for interfering traffic (default: 0, i.e., AC_BE)",interfering_up);
+  cmd.AddValue ("baseline", "Baseline for PRR calculation", m_baseline_prr);
+  cmd.AddValue ("tx-power", "OBUs transmission power [dBm]", txPower);
+  cmd.AddValue ("rx-sensitivity", "802.11bd preamble-detection RSSI threshold [dBm]", sensitivity);
+  cmd.AddValue ("snr-threshold", "802.11bd preamble-detection SNR threshold [dB]", snr_threshold);
+  cmd.AddValue ("sim-time", "Total duration of the simulation [s]", simTime);
+  cmd.AddValue ("sumo-gui", "Use SUMO gui or not", sumo_gui);
+  cmd.AddValue("enable-security","Enable the transmission of secured V2X packets",security_enabled);
+  cmd.Parse (argc, argv);
+
+  VehicularWifiProfile wifiProfile =
+      VehicularWifiProfile::Ieee80211bd (phyMode, txPower, sensitivity, snr_threshold);
+
+  /* Load the .rou.xml file (SUMO map and scenario) */
+  xmlInitParser();
+  std::string path = sumo_folder + mob_trace;
+  rou_xml_file = xmlParseFile(path.c_str ());
+  if (rou_xml_file == NULL)
+    {
+      NS_FATAL_ERROR("Error: unable to parse the specified XML file: "<<path);
+    }
+  numberOfNodes = XML_rou_count_vehicles(rou_xml_file);
+  xmlFreeDoc(rou_xml_file);
+  xmlCleanupParser();
+
+  // Check if there are enough nodes
+  // This application requires at least three vehicles (as vehicle 3 is the one generating interfering traffic, it should exist)
+  if(numberOfNodes==-1)
+    {
+      NS_FATAL_ERROR("Fatal error: cannot gather the number of vehicles from the specified XML file: "<<path<<". Please check if it is a correct SUMO file.");
+    }
+
+  if(numberOfNodes<3)
+    {
+      NS_FATAL_ERROR("Fatal error: at least three vehicles are required.");
+    }
+
+  // Create numberOfNodes nodes
+  NodeContainer c;
+  c.Create (numberOfNodes);
+
+  // The below set of helpers will help us to put together the wifi NICs we want
+  // Set up the IEEE 802.11bd model and PHY layer
+  YansWifiPhyHelper wifiPhy;
+  wifiProfile.ConfigurePhy (wifiPhy);
+  YansWifiChannelHelper wifiChannel = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = wifiChannel.Create ();
+  wifiPhy.SetChannel (channel);
+  // ns-3 supports generating a pcap trace, to be later analyzed in Wireshark
+  wifiPhy.SetPcapDataLinkType (WifiPhyHelper::DLT_IEEE802_11);
+
+  // We need a QosWaveMac, as we need to enable QoS and EDCA
+  QosWaveMacHelper wifi80211bdMac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi80211bd = Wifi80211pHelper::Default ();
+  if (verbose)
+    {
+      wifi80211bd.EnableLogComponents ();      // Turn on all Wifi 802.11bd logging, only if verbose is true
+    }
+
+  wifiProfile.ConfigureRemoteStationManager (wifi80211bd);
+  NetDeviceContainer devices = wifi80211bd.Install (wifiPhy, wifi80211bdMac, c);
+
+  // Enable saving to Wireshark PCAP traces
+  wifiPhy.EnablePcap ("v2v-80211bd-student-application", devices);
+
+  // Set up the link between SUMO and ns-3, to make each node "mobile" (i.e., linking each ns-3 node to each moving vehicle in ns-3,
+  // which corresponds to installing the network stack to each SUMO vehicle)
+  MobilityHelper mobility;
+  mobility.Install (c);
+  // Set up the TraCI interface and start SUMO with the default parameters
+  // The simulation time step can be tuned by changing "SynchInterval"
+  Ptr<TraciClient> sumoClient = CreateObject<TraciClient> ();
+  sumoClient->SetAttribute ("SumoConfigPath", StringValue (sumo_config));
+  sumoClient->SetAttribute ("SumoBinaryPath", StringValue (""));    // use system installation of sumo
+  sumoClient->SetAttribute ("SynchInterval", TimeValue (Seconds (0.01)));
+  sumoClient->SetAttribute ("StartTime", TimeValue (Seconds (0.0)));
+  sumoClient->SetAttribute ("SumoGUI", BooleanValue (sumo_gui));
+  sumoClient->SetAttribute ("SumoPort", UintegerValue (3400));
+  sumoClient->SetAttribute ("PenetrationRate", DoubleValue (1.0));
+  sumoClient->SetAttribute ("SumoLogFile", BooleanValue (false));
+  sumoClient->SetAttribute ("SumoStepLog", BooleanValue (false));
+  sumoClient->SetAttribute ("SumoSeed", IntegerValue (10));
+  sumoClient->SetAttribute ("SumoWaitForSocket", TimeValue (Seconds (1.0)));
+
+  // Set up a Metricsupervisor
+  // This module enables a trasparent and seamless collection of one-way latency (in ms) and PRR metrics
+  Ptr<MetricSupervisor> metSup = NULL;
+  // Set a baseline for the PRR computation when creating a new Metricsupervisor object
+  MetricSupervisor metSupObj(m_baseline_prr);
+  metSup = &metSupObj;
+  metSup->setTraCIClient(sumoClient);
+  wifiProfile.ConfigureMetricSupervisor (metSup);
+  // Vehicle 3 should *not* be considered in the computation of latency and PRR, as it generates only interfering traffic
+  metSup->addExcludedID(3);
+  // This function enables printing the current and average latency and PRR for each received packet
+  // metSup->enablePRRVerboseOnStdout ();
+
+  // Create a new socket for the generation of broadcast interfering traffic
+  // With the aim of sending generic broadcast packets, we use a PacketSocket
+  // This kind of facility enables the transmission of data with a customizable
+  // Ethertype, and no specific stack for the higher layers
+  // As we are just sending interfering traffic (without any useful informative content),
+  // we can use the local experimental Ethertype (0x88B5)
+  PacketSocketHelper packetSocket;
+  packetSocket.Install(c);
+  TypeId tid = TypeId::LookupByName ("ns3::PacketSocketFactory");
+  Ptr<Socket> source_interfering = Socket::CreateSocket (c.Get (2), tid);
+  PacketSocketAddress local_source_interfering;
+  local_source_interfering.SetSingleDevice (c.Get(2)->GetDevice(0)->GetIfIndex ());
+  local_source_interfering.SetPhysicalAddress (c.Get(2)->GetDevice(0)->GetAddress());
+  local_source_interfering.SetProtocol (0x88B5); // Setting the "Local Experimental Ethertype 1" to send interfering traffic
+  if (source_interfering->Bind (local_source_interfering) == -1)
+  {
+    NS_FATAL_ERROR ("Failed to bind client socket for BTP + GeoNetworking (802.11bd)");
+  }
+  PacketSocketAddress remote_source_interfering;
+  remote_source_interfering.SetSingleDevice (c.Get(2)->GetDevice(0)->GetIfIndex());
+  // Set the broadcast MAC address as interfering traffic will be broadcasted by vehicle 3
+  remote_source_interfering.SetPhysicalAddress (c.Get(2)->GetDevice(0)->GetBroadcast());
+  remote_source_interfering.SetProtocol (0x88B5); // Setting the "Local Experimental Ethertype 1" to send interfering traffic
+  source_interfering->Connect (remote_source_interfering);
+   // Important: this line lets you set the AC of the interfering traffic, through a User Priority (UP) value, like in real Linux kernels/OS
+  source_interfering->SetPriority (interfering_up); // Setting the priority of the interfering traffic from vehicle 3
+
+  std::cout << "802.11bd profile: dataMode=" << wifiProfile.GetDataMode ()
+            << ", controlMode=" << wifiProfile.GetControlMode ()
+            << ", ppduFormat=" << wifiProfile.GetPpduFormatName ()
+            << ", ngvMcs=" << static_cast<uint32_t> (wifiProfile.GetNgvMcsIndex ())
+            << ", channelWidth=" << wifiProfile.GetChannelWidthMHz () << " MHz"
+            << ", txPower=" << wifiProfile.GetTxPowerDbm () << " dBm"
+            << ", rxSensitivity=" << wifiProfile.GetRxSensitivityDbm () << " dBm"
+            << std::endl;
+
+  std::cout << "Starting simulation... " << std::endl;
+
+  // Important: what you write inside setupNewWifiNode() will be executed every time a new vehicle enters the simulation in SUMO
+  // This kind of "std::function" is called lambda function, and it can access all variables outside its scope, thanks to the [&] capture
+  // We setup here the ETSI stack for each vehicle (except the one generating interfering traffic), thanks to the BSContainer object
+  // Furthermore, we schedule the transmission of interfering traffic for vehicle 3 only ("veh3")
+  STARTUP_FCN setupNewWifiNode = [&] (std::string vehicleID,TraciClient::StationTypeTraCI_t stationType) -> Ptr<Node>
+    {
+      unsigned long nodeID = std::stol(vehicleID.substr (3))-1;
+
+      if(vehicleID=="veh3")
+      {
+        // The interfering traffic generation will start after 1 second ("Seconds (1.0)"), by calling the "GenerateTraffic_interfering" function
+        // Then:
+        // - the socket which will be used for the transmission of interfering traffic is pointed by "source_interfering"
+        // - each interfering traffic packet will be quite large (2000 Bytes)
+        // - interfering traffic is set to last for "simTime*1000" packets, as we send each interfering packet every 1 ms and simTime is specified in seconds
+        // - interfering packets will be sent every 1 ms ("MilliSeconds (1)"), to analyse a scenario with a relatively congested channel
+        Simulator::ScheduleWithContext (source_interfering->GetNode ()->GetId (),
+                                        Seconds (1.0), &GenerateTraffic_interfering,
+                                        source_interfering, 2000, simTime*1000.0, MilliSeconds (1));
+      }
+      else
+      {
+          // Create a new ETSI GeoNetworking socket, thanks to the GeoNet::createGNPacketSocket() function, accepting as argument a pointer to the current node
+          Ptr<Socket> sock;
+          sock=GeoNet::createGNPacketSocket(c.Get(nodeID));
+          // Set the proper AC, through the specified UP
+          sock->SetPriority (up);
+
+          // Create a new Basic Service Container object, which includes, for the current vehicle, both the ETSI CA Basic Service, for the transmission/reception
+          // of periodic CAMs, and the ETSI DEN Basic Service, for the transmission/reception of event-based DENMs
+          // An ETSI Basic Services container is a wrapper class to enable easy handling of both CAMs and DENMs
+          // The station ID is set to be equal to the SUMO ID without "veh" (i.e., the station ID of "veh1" will be "1")
+          Ptr<BSContainer> bs_container = CreateObject<BSContainer>(std::stol(vehicleID.substr(3)),StationType_passengerCar,sumoClient,false,sock);
+          // Setup the PRRsupervisor inside the BSContainer, to make each vehicle collect latency and PRR metrics
+          bs_container->linkMetricSupervisor(metSup);
+          // This is needed just to simplify the whole application
+          bs_container->disablePRRSupervisorForGNBeacons ();
+
+          // Set the function which will be called every time a CAM is received, i.e., receiveCAM()
+          bs_container->addCAMRxCallback (std::bind(&receiveCAM,std::placeholders::_1,std::placeholders::_2,std::placeholders::_3,std::placeholders::_4,std::placeholders::_5));
+          // Setup the new ETSI Basic Services container
+          // The first parameter is true is you want to setup a CA Basic Service (for sending/receiving CAMs)
+          // The second parameter should be true if you want to setup a DEN Basic Service (for sending/receiving DENMs)
+          // The third parameter should be true if you want to setup a VRU Basic Service (for sending/receiving VAMs)
+          // The fourth parameter should be true if you want to setup a CP Service (for sending/receiving CPMs)
+          // The fifth parameter should be true if you want to setup a MC Service (for sending/receiving MCMs)
+          // The sixth parameter should be true if you want to enable V2X security
+          bs_container->setupContainer(true,false,false,false,false,security_enabled);
+
+          // Store the container for this vehicle inside a local global BSMap, i.e., a structure (similar to a hash table) which allows you to easily
+          // retrieve the right BSContainer given a vehicle ID
+          basicServices.add(bs_container);
+
+          // Start transmitting CAMs
+          // We randomize the instant in time in which the CAM dissemination is going to start
+          // This simulates different startup times for the OBUs of the different vehicles, and
+          // reduces the risk of multiple vehicles trying to send CAMs are the same time (causing more collisions);
+          // "desync" is a value between 0 and 1 (seconds) after which the CAM dissemination should start
+          std::srand(Simulator::Now().GetNanoSeconds ()*2); // Seed based on the simulation time to give each vehicle a different random seed
+          double desync = ((double)std::rand()/RAND_MAX);
+          bs_container->getCABasicService ()->startCamDissemination (desync);
+      }
+
+      return c.Get(nodeID);
+    };
+
+  // Important: what you write here is called every time a node exits the simulation in SUMO
+  // You can safely keep this function as it is, and ignore it
+  SHUTDOWN_FCN shutdownWifiNode = [] (Ptr<Node> exNode, std::string vehicleID)
+    {
+      /* Set position outside communication range */
+      Ptr<ConstantPositionMobilityModel> mob = exNode->GetObject<ConstantPositionMobilityModel>();
+      mob->SetPosition(Vector(-1000.0+(rand()%25),320.0+(rand()%25),250.0));
+
+      // Turn off the Basic Services and the ETSI ITS-G5 stack for the vehicle
+      // which has exited from the simulated scenario, and should be thus no longer considered
+      // We need to get the right Ptr<BSContainer> based on the station ID (not the nodeID used
+      // as index for the nodeContainer), so we don't use "-1" to compute "intVehicleID" here
+      unsigned long intVehicleID = std::stol(vehicleID.substr (3));
+
+      Ptr<BSContainer> bsc = basicServices.get(intVehicleID);
+      bsc->cleanup();
+    };
+
+  // Link ns-3 and SUMO
+  sumoClient->SumoSetup (setupNewWifiNode, shutdownWifiNode);
+
+  // Start simulation, which will last for simTime seconds
+  Simulator::Stop (Seconds(simTime));
+  Simulator::Run ();
+
+  // When the simulation is terminated, gather the most relevant metrics from the PRRsupervisor
+  std::cout << "Run terminated..." << std::endl;
+
+  std::cout << "Average PRR: " << metSup->getAveragePRR_overall () << std::endl;
+  std::cout << "Average latency (ms): " << metSup->getAverageLatency_overall () << std::endl;
+
+  std::cout << "Average latency veh 1 (ms): " << metSup->getAverageLatency_vehicle (1) << std::endl;
+  std::cout << "Average latency veh 2 (ms): " << metSup->getAverageLatency_vehicle (2) << std::endl;
+  std::cout << "Average latency veh 3 (ms): " << metSup->getAverageLatency_vehicle (3) << std::endl; // Should return 0, as this vehicle generated only interfering traffic, and it is ignored by the PRRsupervisor
+  std::cout << "Average latency veh 4 (ms): " << metSup->getAverageLatency_vehicle (4) << std::endl;
+
+  std::cout << "RX packet count: " << packet_count << std::endl;
+  std::cout << "RX packet count (from PRR Supervisor): " << metSup->getNumberRx_overall () << std::endl;
+  std::cout << "TX packet count (from PRR Supervisor): " << metSup->getNumberTx_overall () << std::endl;
+  std::cout << "Average number of vehicle within the " << m_baseline_prr << " m baseline: " << metSup->getAverageNumberOfVehiclesInBaseline_overall () << std::endl;
+
+  Simulator::Destroy ();
+
+  return 0;
+}

--- a/src/automotive/examples/v2v-trace-observed-fallback-80211bd.cc
+++ b/src/automotive/examples/v2v-trace-observed-fallback-80211bd.cc
@@ -1,0 +1,283 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ns3/abort.h"
+#include "ns3/command-line.h"
+#include "ns3/mac48-address.h"
+#include "ns3/mobility-helper.h"
+#include "ns3/net-device.h"
+#include "ns3/node-container.h"
+#include "ns3/packet.h"
+#include "ns3/position-allocator.h"
+#include "ns3/simulator.h"
+#include "ns3/vector.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-psdu.h"
+#include "ns3/wifi-remote-station-manager.h"
+#include "ns3/wifi-tx-vector.h"
+#include "ns3/yans-wifi-helper.h"
+
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+
+using namespace ns3;
+
+namespace
+{
+
+static constexpr uint16_t TRACE_INITIAL_PROTOCOL = 0x88D6;
+static constexpr uint16_t TRACE_ADAPTED_PROTOCOL = 0x88D7;
+
+struct ReceiverStats
+{
+  uint32_t initialPackets = 0;
+  uint32_t adaptedPackets = 0;
+};
+
+struct TxStats
+{
+  uint32_t ngvPpdus = 0;
+  uint32_t duplicatePpdus = 0;
+  uint32_t nonNgv10Ppdus = 0;
+};
+
+struct SendStats
+{
+  uint32_t attempts = 0;
+  uint32_t succeeded = 0;
+};
+
+struct TracePolicyState
+{
+  VehicularWifiFallbackController::ObservationState observationState;
+  VehicularWifiFallbackMode currentMode = VehicularWifiFallbackMode::NGV_20;
+  bool legacyNeighborPresent = true;
+  uint32_t traceSamples = 0;
+  uint32_t policyUpdates = 0;
+  double lastSnrDb = 0.0;
+};
+
+NetDeviceContainer
+InstallVehicularDevice (NodeContainer nodes,
+                        Ptr<YansWifiChannel> channel,
+                        const VehicularWifiProfile& profile)
+{
+  YansWifiPhyHelper phy;
+  profile.ConfigurePhy (phy);
+  phy.SetChannel (channel);
+
+  QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+  Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+  profile.ConfigureRemoteStationManager (wifi);
+  return wifi.Install (phy, mac, nodes);
+}
+
+bool
+ReceivePacket (ReceiverStats* stats,
+               Ptr<NetDevice> dev,
+               Ptr<const Packet> pkt,
+               uint16_t protocol,
+               const Address& sender)
+{
+  if (protocol == TRACE_INITIAL_PROTOCOL)
+    {
+      stats->initialPackets++;
+    }
+  else if (protocol == TRACE_ADAPTED_PROTOCOL)
+    {
+      stats->adaptedPackets++;
+    }
+  return true;
+}
+
+void
+NotifyTxPsduBegin (TxStats* stats,
+                   WifiConstPsduMap psduMap,
+                   WifiTxVector txVector,
+                   double txPowerW)
+{
+  if (txVector.IsNgv ())
+    {
+      stats->ngvPpdus++;
+    }
+  else if (txVector.IsNonNgv20Duplicate ())
+    {
+      stats->duplicatePpdus++;
+    }
+  else if (txVector.IsNonNgv10 ())
+    {
+      stats->nonNgv10Ppdus++;
+    }
+}
+
+void
+NotifyMonitorSniffRx (TracePolicyState* traceState,
+                      Ptr<WifiRemoteStationManager> senderManager,
+                      Ptr<const Packet> packet,
+                      uint16_t channelFreqMhz,
+                      WifiTxVector txVector,
+                      MpduInfo aMpdu,
+                      SignalNoiseDbm signalNoise,
+                      uint16_t staId)
+{
+  traceState->traceSamples++;
+  traceState->lastSnrDb =
+      VehicularWifiFallbackController::EstimateSnrDb (signalNoise.signal, signalNoise.noise);
+  traceState->currentMode = VehicularWifiFallbackController::UpdateFromSignalNoise (
+      traceState->observationState,
+      signalNoise.signal,
+      signalNoise.noise,
+      true,
+      traceState->legacyNeighborPresent);
+  traceState->policyUpdates++;
+  VehicularWifiFallbackController::ConfigureRemoteStationManager (senderManager,
+                                                                  traceState->currentMode);
+}
+
+void
+SendPacket (SendStats* sendStats, Ptr<NetDevice> sender, uint16_t protocol, uint32_t payloadBytes)
+{
+  sendStats->attempts++;
+  if (sender->Send (Create<Packet> (payloadBytes), Mac48Address::GetBroadcast (), protocol))
+    {
+      sendStats->succeeded++;
+    }
+}
+
+uint32_t
+TotalRx (const ReceiverStats& stats)
+{
+  return stats.initialPackets + stats.adaptedPackets;
+}
+
+} // namespace
+
+int
+main (int argc, char* argv[])
+{
+  uint32_t payloadBytes = 256;
+  double distanceMeters = 5.0;
+  bool legacyNeighborPresent = true;
+
+  CommandLine cmd (__FILE__);
+  cmd.AddValue ("payload-bytes", "Payload size used for each trace-observed fallback phase", payloadBytes);
+  cmd.AddValue ("distance-m", "Distance between sender and receivers", distanceMeters);
+  cmd.AddValue ("legacy-neighbor-present",
+                "Whether trace observations should trigger legacy-compatible fallback",
+                legacyNeighborPresent);
+  cmd.Parse (argc, argv);
+
+  NS_ABORT_MSG_IF (payloadBytes == 0, "payload-bytes must be greater than zero");
+
+  ReceiverStats receiver11bd;
+  ReceiverStats receiver11p;
+  TxStats txStats;
+  SendStats sendStats;
+  TracePolicyState traceState;
+  traceState.legacyNeighborPresent = legacyNeighborPresent;
+  traceState.observationState.policy.minNgv20SnrDb = 18.0;
+  traceState.observationState.policy.minDuplicate20SnrDb = 6.0;
+
+  NodeContainer nodes;
+  nodes.Create (3);
+
+  Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+  positions->Add (Vector (0.0, 0.0, 0.0));
+  positions->Add (Vector (distanceMeters, 0.0, 0.0));
+  positions->Add (Vector (distanceMeters + 1.0, 0.0, 0.0));
+  MobilityHelper mobility;
+  mobility.SetPositionAllocator (positions);
+  mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+  mobility.Install (nodes);
+
+  YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+  Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+  NodeContainer senderNode;
+  senderNode.Add (nodes.Get (0));
+  NodeContainer receiver11bdNode;
+  receiver11bdNode.Add (nodes.Get (1));
+  NodeContainer receiver11pNode;
+  receiver11pNode.Add (nodes.Get (2));
+
+  NetDeviceContainer senderDevices =
+      InstallVehicularDevice (senderNode, channel, VehicularWifiProfile::Ieee80211bd20 ());
+  NetDeviceContainer receiver11bdDevices =
+      InstallVehicularDevice (receiver11bdNode, channel, VehicularWifiProfile::Ieee80211bd20 ());
+  NetDeviceContainer receiver11pDevices =
+      InstallVehicularDevice (receiver11pNode, channel, VehicularWifiProfile::Ieee80211p ());
+
+  receiver11bdDevices.Get (0)->SetReceiveCallback (
+      MakeBoundCallback (&ReceivePacket, &receiver11bd));
+  receiver11pDevices.Get (0)->SetReceiveCallback (
+      MakeBoundCallback (&ReceivePacket, &receiver11p));
+
+  Ptr<WifiNetDevice> senderWifi = DynamicCast<WifiNetDevice> (senderDevices.Get (0));
+  Ptr<WifiNetDevice> receiver11bdWifi = DynamicCast<WifiNetDevice> (receiver11bdDevices.Get (0));
+  NS_ABORT_MSG_IF (senderWifi == nullptr, "Expected an installed sender Wi-Fi device");
+  NS_ABORT_MSG_IF (receiver11bdWifi == nullptr, "Expected an installed 802.11bd receiver device");
+
+  Ptr<WifiRemoteStationManager> senderManager = senderWifi->GetRemoteStationManager ();
+  NS_ABORT_MSG_IF (senderManager == nullptr, "Expected an installed sender remote station manager");
+  VehicularWifiFallbackController::ConfigureRemoteStationManager (senderManager,
+                                                                  traceState.currentMode);
+
+  const bool txTraceConnected = senderWifi->GetPhy ()->TraceConnectWithoutContext (
+      "PhyTxPsduBegin",
+      MakeBoundCallback (&NotifyTxPsduBegin, &txStats));
+  NS_ABORT_MSG_IF (!txTraceConnected, "Unable to connect sender PhyTxPsduBegin trace");
+
+  const bool rxTraceConnected = receiver11bdWifi->GetPhy ()->TraceConnectWithoutContext (
+      "MonitorSnifferRx",
+      MakeBoundCallback (&NotifyMonitorSniffRx, &traceState, senderManager));
+  NS_ABORT_MSG_IF (!rxTraceConnected, "Unable to connect receiver MonitorSnifferRx trace");
+
+  Simulator::Schedule (MilliSeconds (100),
+                       &SendPacket,
+                       &sendStats,
+                       senderDevices.Get (0),
+                       TRACE_INITIAL_PROTOCOL,
+                       payloadBytes);
+  Simulator::Schedule (MilliSeconds (300),
+                       &SendPacket,
+                       &sendStats,
+                       senderDevices.Get (0),
+                       TRACE_ADAPTED_PROTOCOL,
+                       payloadBytes);
+  Simulator::Stop (MilliSeconds (700));
+  Simulator::Run ();
+  Simulator::Destroy ();
+
+  std::cout << std::fixed << std::setprecision (6);
+  std::cout << "Trace-observed fallback legacy neighbor present: " << legacyNeighborPresent
+            << std::endl;
+  std::cout << "Trace-observed fallback initial mode: NGV_20" << std::endl;
+  std::cout << "Trace-observed fallback final mode: "
+            << VehicularWifiFallbackModeName (traceState.currentMode) << std::endl;
+  std::cout << "Trace-observed fallback trace samples: " << traceState.traceSamples
+            << std::endl;
+  std::cout << "Trace-observed fallback policy updates: " << traceState.policyUpdates
+            << std::endl;
+  std::cout << "Trace-observed fallback last SNR dB: " << traceState.lastSnrDb << std::endl;
+  std::cout << "Trace-observed fallback send attempts: " << sendStats.attempts << std::endl;
+  std::cout << "Trace-observed fallback send succeeded: " << sendStats.succeeded << std::endl;
+  std::cout << "Trace-observed fallback 802.11bd RX packets: " << TotalRx (receiver11bd)
+            << std::endl;
+  std::cout << "Trace-observed fallback 802.11p RX packets: " << TotalRx (receiver11p)
+            << std::endl;
+  std::cout << "Trace-observed fallback 802.11p initial RX packets: "
+            << receiver11p.initialPackets << std::endl;
+  std::cout << "Trace-observed fallback 802.11p adapted RX packets: "
+            << receiver11p.adaptedPackets << std::endl;
+  std::cout << "Trace-observed fallback NGV PPDU count: " << txStats.ngvPpdus << std::endl;
+  std::cout << "Trace-observed fallback NON_NGV_20_DUPLICATE PPDU count: "
+            << txStats.duplicatePpdus << std::endl;
+  std::cout << "Trace-observed fallback NON_NGV_10 PPDU count: " << txStats.nonNgv10Ppdus
+            << std::endl;
+
+  return 0;
+}

--- a/src/automotive/helper/vehicular-wifi-helper.cc
+++ b/src/automotive/helper/vehicular-wifi-helper.cc
@@ -1,0 +1,687 @@
+#include "vehicular-wifi-helper.h"
+
+#include "ns3/double.h"
+#include "ns3/string.h"
+#include "ns3/uinteger.h"
+#include "ns3/wifi-mode.h"
+#include "ns3/wifi-remote-station-manager.h"
+
+#include <utility>
+
+namespace ns3
+{
+
+VehicularWifiProfile::VehicularWifiProfile (Standard standard,
+                                            std::string dataMode,
+                                            std::string controlMode,
+                                            uint16_t channelWidthMHz,
+                                            double txPowerDbm,
+                                            double rxSensitivityDbm,
+                                            double snrThresholdDb,
+                                            double dccBitRate,
+                                            VehicularWifiPpduFormat ppduFormat,
+                                            uint8_t ngvMcsIndex,
+                                            uint8_t ngvSpatialStreams,
+                                            uint8_t nonNgvRepetitions)
+  : m_standard (standard),
+    m_dataMode (std::move (dataMode)),
+    m_controlMode (std::move (controlMode)),
+    m_channelWidthMHz (channelWidthMHz),
+    m_txPowerDbm (txPowerDbm),
+    m_rxSensitivityDbm (rxSensitivityDbm),
+    m_snrThresholdDb (snrThresholdDb),
+    m_dccBitRate (dccBitRate),
+    m_ppduFormat (ppduFormat),
+    m_ngvMcsIndex (ngvMcsIndex),
+    m_ngvSpatialStreams (ngvSpatialStreams),
+    m_nonNgvRepetitions (nonNgvRepetitions)
+{
+}
+
+VehicularWifiProfile
+VehicularWifiProfile::Ieee80211p (const std::string& dataMode,
+                                  double txPowerDbm,
+                                  double rxSensitivityDbm,
+                                  double snrThresholdDb)
+{
+  return VehicularWifiProfile (Standard::IEEE_80211P,
+                               dataMode,
+                               dataMode,
+                               10,
+                               txPowerDbm,
+                               rxSensitivityDbm,
+                               snrThresholdDb,
+                               6e6,
+                               VehicularWifiPpduFormat::NON_NGV_10,
+                               0,
+                               1,
+                               0);
+}
+
+VehicularWifiProfile
+VehicularWifiProfile::Ieee80211bd (const std::string& dataMode,
+                                   double txPowerDbm,
+                                   double rxSensitivityDbm,
+                                   double snrThresholdDb,
+                                   uint8_t ngvMcsIndex,
+                                   uint8_t ngvSpatialStreams,
+                                   uint16_t channelWidthMHz)
+{
+  const auto& mcs = GetVehicularNgvMcs (ngvMcsIndex, channelWidthMHz, ngvSpatialStreams);
+  return VehicularWifiProfile (Standard::IEEE_80211BD,
+                               dataMode,
+                               channelWidthMHz == 20 ? "OfdmRate6Mbps" : "OfdmRate6MbpsBW10MHz",
+                               channelWidthMHz,
+                               txPowerDbm,
+                               rxSensitivityDbm,
+                               snrThresholdDb,
+                               mcs.dataRateMbps * 1e6,
+                               VehicularWifiPpduFormat::NGV,
+                               ngvMcsIndex,
+                               ngvSpatialStreams,
+                               0);
+}
+
+VehicularWifiProfile
+VehicularWifiProfile::Ieee80211bd20 (const std::string& dataMode,
+                                     double txPowerDbm,
+                                     double rxSensitivityDbm,
+                                     double snrThresholdDb,
+                                     uint8_t ngvMcsIndex,
+                                     uint8_t ngvSpatialStreams)
+{
+  return Ieee80211bd (dataMode,
+                      txPowerDbm,
+                      rxSensitivityDbm,
+                      snrThresholdDb,
+                      ngvMcsIndex,
+                      ngvSpatialStreams,
+                      20);
+}
+
+VehicularWifiProfile
+VehicularWifiProfile::Ieee80211bdNonNgv10 (const std::string& dataMode,
+                                           double txPowerDbm,
+                                           double rxSensitivityDbm,
+                                           double snrThresholdDb,
+                                           uint8_t nonNgvRepetitions)
+{
+  return VehicularWifiProfile (Standard::IEEE_80211BD,
+                               dataMode,
+                               dataMode,
+                               10,
+                               txPowerDbm,
+                               rxSensitivityDbm,
+                               snrThresholdDb,
+                               6e6,
+                               VehicularWifiPpduFormat::NON_NGV_10,
+                               0,
+                               1,
+                               nonNgvRepetitions);
+}
+
+VehicularWifiProfile
+VehicularWifiProfile::Ieee80211bdNonNgv20Duplicate (const std::string& dataMode,
+                                                    double txPowerDbm,
+                                                    double rxSensitivityDbm,
+                                                    double snrThresholdDb)
+{
+  return VehicularWifiProfile (Standard::IEEE_80211BD,
+                               dataMode,
+                               dataMode,
+                               20,
+                               txPowerDbm,
+                               rxSensitivityDbm,
+                               snrThresholdDb,
+                               6e6,
+                               VehicularWifiPpduFormat::NON_NGV_20_DUPLICATE,
+                               0,
+                               1,
+                               0);
+}
+
+void
+VehicularWifiProfile::ConfigurePhy (YansWifiPhyHelper& wifiPhy) const
+{
+  wifiPhy.Set ("ChannelSettings",
+               StringValue ("{0, " + std::to_string (m_channelWidthMHz) + ", BAND_5GHZ, 0}"));
+  wifiPhy.Set ("RxSensitivity", DoubleValue (m_rxSensitivityDbm));
+  wifiPhy.Set ("TxPowerStart", DoubleValue (m_txPowerDbm));
+  wifiPhy.Set ("TxPowerEnd", DoubleValue (m_txPowerDbm));
+  if (m_standard == Standard::IEEE_80211BD)
+    {
+      const uint8_t spatialStreams = m_ppduFormat == VehicularWifiPpduFormat::NGV
+                                         ? m_ngvSpatialStreams
+                                         : 1;
+      wifiPhy.Set ("Antennas", UintegerValue (spatialStreams));
+      wifiPhy.Set ("MaxSupportedTxSpatialStreams", UintegerValue (spatialStreams));
+      wifiPhy.Set ("MaxSupportedRxSpatialStreams", UintegerValue (spatialStreams));
+      wifiPhy.Set ("CcaEdThreshold", DoubleValue (-65.0));
+    }
+  wifiPhy.SetPreambleDetectionModel ("ns3::ThresholdPreambleDetectionModel",
+                                     "MinimumRssi", DoubleValue (m_rxSensitivityDbm),
+                                     "Threshold", DoubleValue (m_snrThresholdDb));
+}
+
+void
+VehicularWifiProfile::ConfigureRemoteStationManager (Wifi80211pHelper& wifiHelper) const
+{
+  wifiHelper.SetStandard (m_standard == Standard::IEEE_80211BD ? WIFI_STANDARD_80211bd
+                                                               : WIFI_STANDARD_80211p);
+  uint8_t ppduFormatValue = 0;
+  if (m_ppduFormat == VehicularWifiPpduFormat::NGV)
+    {
+      ppduFormatValue = 1;
+    }
+  else if (m_ppduFormat == VehicularWifiPpduFormat::NON_NGV_20_DUPLICATE)
+    {
+      ppduFormatValue = 2;
+    }
+  wifiHelper.SetRemoteStationManager ("ns3::ConstantRateWifiManager",
+                                      "DataMode", StringValue (m_dataMode),
+                                      "ControlMode", StringValue (m_controlMode),
+                                      "NonUnicastMode", StringValue (m_dataMode),
+                                      "NgvPpduFormat", UintegerValue (ppduFormatValue),
+                                      "NgvMcs", UintegerValue (m_ngvMcsIndex),
+                                      "NgvSpatialStreams", UintegerValue (m_ngvSpatialStreams),
+                                      "NgvMidamblePeriodicity", UintegerValue (0),
+                                      "NgvLtfType", UintegerValue ((m_ppduFormat == VehicularWifiPpduFormat::NGV &&
+                                                                    m_channelWidthMHz == 10 &&
+                                                                    m_ngvSpatialStreams == 1 &&
+                                                                    m_ngvMcsIndex == 15)
+                                                                       ? 2
+                                                                       : (m_ppduFormat == VehicularWifiPpduFormat::NGV ? 1 : 0)),
+                                      "NgvPpduRepetitions", UintegerValue (m_nonNgvRepetitions));
+}
+
+void
+VehicularWifiProfile::ConfigureMetricSupervisor (Ptr<MetricSupervisor> metricSupervisor) const
+{
+  if (metricSupervisor != nullptr)
+    {
+      metricSupervisor->setChannelTechnology (GetTechnologyName ());
+    }
+}
+
+VehicularWifiProfile::Standard
+VehicularWifiProfile::GetStandard () const
+{
+  return m_standard;
+}
+
+std::string
+VehicularWifiProfile::GetTechnologyName () const
+{
+  return m_standard == Standard::IEEE_80211BD ? "80211bd" : "80211p";
+}
+
+std::string
+VehicularWifiProfile::GetDataMode () const
+{
+  return m_dataMode;
+}
+
+std::string
+VehicularWifiProfile::GetControlMode () const
+{
+  return m_controlMode;
+}
+
+uint16_t
+VehicularWifiProfile::GetChannelWidthMHz () const
+{
+  return m_channelWidthMHz;
+}
+
+double
+VehicularWifiProfile::GetTxPowerDbm () const
+{
+  return m_txPowerDbm;
+}
+
+double
+VehicularWifiProfile::GetRxSensitivityDbm () const
+{
+  return m_rxSensitivityDbm;
+}
+
+double
+VehicularWifiProfile::GetSnrThresholdDb () const
+{
+  return m_snrThresholdDb;
+}
+
+double
+VehicularWifiProfile::GetDccBitRate () const
+{
+  return m_dccBitRate;
+}
+
+VehicularWifiPpduFormat
+VehicularWifiProfile::GetPpduFormat () const
+{
+  return m_ppduFormat;
+}
+
+std::string
+VehicularWifiProfile::GetPpduFormatName () const
+{
+  return VehicularWifiPpduFormatName (m_ppduFormat);
+}
+
+uint8_t
+VehicularWifiProfile::GetNgvMcsIndex () const
+{
+  return m_ngvMcsIndex;
+}
+
+uint8_t
+VehicularWifiProfile::GetNgvSpatialStreams () const
+{
+  return m_ngvSpatialStreams;
+}
+
+uint8_t
+VehicularWifiProfile::GetNonNgvRepetitions () const
+{
+  return m_nonNgvRepetitions;
+}
+
+std::string
+VehicularWifiFallbackModeName (VehicularWifiFallbackMode mode)
+{
+  switch (mode)
+    {
+    case VehicularWifiFallbackMode::NGV_20:
+      return "NGV_20";
+    case VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE:
+      return "NON_NGV_20_DUPLICATE";
+    case VehicularWifiFallbackMode::NON_NGV_10:
+      return "NON_NGV_10";
+    }
+  return "UNKNOWN";
+}
+
+namespace
+{
+
+uint8_t
+NormalizeNgvSpatialStreams (uint8_t spatialStreams)
+{
+  if (spatialStreams < 1)
+    {
+      return 1;
+    }
+  if (spatialStreams > 2)
+    {
+      return 2;
+    }
+  return spatialStreams;
+}
+
+uint8_t
+SelectValidNgvMcs (uint8_t requestedMcs, uint16_t channelWidthMHz, uint8_t spatialStreams)
+{
+  if (IsVehicularNgvMcsValid (requestedMcs, channelWidthMHz, spatialStreams))
+    {
+      return requestedMcs;
+    }
+
+  const int highestCandidate = requestedMcs > 15 ? 15 : requestedMcs;
+  for (int candidate = highestCandidate; candidate >= 0; --candidate)
+    {
+      if (IsVehicularNgvMcsValid (static_cast<uint8_t> (candidate),
+                                  channelWidthMHz,
+                                  spatialStreams))
+        {
+          return static_cast<uint8_t> (candidate);
+        }
+    }
+
+  for (uint8_t candidate = requestedMcs + 1; candidate <= 15; ++candidate)
+    {
+      if (IsVehicularNgvMcsValid (candidate, channelWidthMHz, spatialStreams))
+        {
+          return candidate;
+        }
+    }
+  return 0;
+}
+
+std::string
+Default11bdDataMode (VehicularWifiFallbackMode mode)
+{
+  return mode == VehicularWifiFallbackMode::NGV_20 ? "OfdmRate24Mbps"
+                                                   : "OfdmRate6MbpsBW10MHz";
+}
+
+} // namespace
+
+VehicularWifiFallbackMode
+VehicularWifiFallbackController::Select (bool legacyReceiverPresent,
+                                         bool duplicate20Allowed,
+                                         bool forcePrimaryOnly)
+{
+  if (!legacyReceiverPresent)
+    {
+      return VehicularWifiFallbackMode::NGV_20;
+    }
+  if (forcePrimaryOnly || !duplicate20Allowed)
+    {
+      return VehicularWifiFallbackMode::NON_NGV_10;
+    }
+  return VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE;
+}
+
+VehicularWifiFallbackMode
+VehicularWifiFallbackController::SelectForLinkQuality (const LinkQualityPolicy& policy)
+{
+  if (policy.forcePrimaryOnly)
+    {
+      return VehicularWifiFallbackMode::NON_NGV_10;
+    }
+
+  if (policy.legacyReceiverPresent)
+    {
+      if (!policy.duplicate20Allowed)
+        {
+          return VehicularWifiFallbackMode::NON_NGV_10;
+        }
+      return policy.estimatedSnrDb >= policy.minDuplicate20SnrDb
+                 ? VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE
+                 : VehicularWifiFallbackMode::NON_NGV_10;
+    }
+
+  if (policy.estimatedSnrDb >= policy.minNgv20SnrDb)
+    {
+      return VehicularWifiFallbackMode::NGV_20;
+    }
+  if (policy.duplicate20Allowed && policy.estimatedSnrDb >= policy.minDuplicate20SnrDb)
+    {
+      return VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE;
+    }
+  return VehicularWifiFallbackMode::NON_NGV_10;
+}
+
+void
+VehicularWifiFallbackController::ResetObservationState (ObservationState& state)
+{
+  ResetObservationState (state, LinkQualityPolicy ());
+}
+
+void
+VehicularWifiFallbackController::ResetObservationState (ObservationState& state,
+                                                        const LinkQualityPolicy& initialPolicy)
+{
+  const double ewmaAlpha = state.ewmaAlpha;
+  const uint32_t failureThreshold = state.failureThreshold;
+
+  state = ObservationState ();
+  state.policy = initialPolicy;
+  state.ewmaSnrDb = initialPolicy.estimatedSnrDb;
+  state.ewmaAlpha = ewmaAlpha;
+  state.failureThreshold = failureThreshold;
+}
+
+VehicularWifiFallbackMode
+VehicularWifiFallbackController::UpdateFromObservation (ObservationState& state,
+                                                        double observedSnrDb,
+                                                        bool deliverySucceeded,
+                                                        bool legacyReceiverPresent)
+{
+  double alpha = state.ewmaAlpha;
+  if (alpha < 0.0)
+    {
+      alpha = 0.0;
+    }
+  else if (alpha > 1.0)
+    {
+      alpha = 1.0;
+    }
+
+  if (!state.initialized)
+    {
+      state.ewmaSnrDb = observedSnrDb;
+      state.initialized = true;
+    }
+  else
+    {
+      state.ewmaSnrDb = alpha * observedSnrDb + (1.0 - alpha) * state.ewmaSnrDb;
+    }
+
+  state.sampleCount++;
+  if (deliverySucceeded)
+    {
+      state.consecutiveFailures = 0;
+    }
+  else
+    {
+      state.consecutiveFailures++;
+    }
+
+  state.policy.estimatedSnrDb = state.ewmaSnrDb;
+  state.policy.legacyReceiverPresent = legacyReceiverPresent;
+
+  LinkQualityPolicy decisionPolicy = state.policy;
+  if (state.failureThreshold > 0 && state.consecutiveFailures >= state.failureThreshold)
+    {
+      decisionPolicy.forcePrimaryOnly = true;
+    }
+
+  return SelectForLinkQuality (decisionPolicy);
+}
+
+double
+VehicularWifiFallbackController::EstimateSnrDb (double signalDbm, double noiseDbm)
+{
+  return signalDbm - noiseDbm;
+}
+
+VehicularWifiFallbackMode
+VehicularWifiFallbackController::UpdateFromSignalNoise (ObservationState& state,
+                                                        double signalDbm,
+                                                        double noiseDbm,
+                                                        bool deliverySucceeded,
+                                                        bool legacyReceiverPresent)
+{
+  return UpdateFromObservation (state,
+                                EstimateSnrDb (signalDbm, noiseDbm),
+                                deliverySucceeded,
+                                legacyReceiverPresent);
+}
+
+VehicularWifiProfile
+VehicularWifiFallbackController::MakeProfile (VehicularWifiFallbackMode mode,
+                                              uint8_t ngvMcsIndex,
+                                              uint8_t ngvSpatialStreams)
+{
+  switch (mode)
+    {
+    case VehicularWifiFallbackMode::NGV_20:
+      return VehicularWifiProfile::Ieee80211bd20 ("OfdmRate24Mbps",
+                                                  23.0,
+                                                  -92.0,
+                                                  4.0,
+                                                  ngvMcsIndex,
+                                                  ngvSpatialStreams);
+    case VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE:
+      return VehicularWifiProfile::Ieee80211bdNonNgv20Duplicate ();
+    case VehicularWifiFallbackMode::NON_NGV_10:
+      return VehicularWifiProfile::Ieee80211bdNonNgv10 ();
+    }
+  return VehicularWifiProfile::Ieee80211bd20 ();
+}
+
+void
+VehicularWifiFallbackController::ConfigureRemoteStationManager (Ptr<WifiRemoteStationManager> manager,
+                                                                VehicularWifiFallbackMode mode,
+                                                                uint8_t ngvMcsIndex,
+                                                                uint8_t ngvSpatialStreams)
+{
+  if (manager == nullptr)
+    {
+      return;
+    }
+
+  manager->SetAttribute ("NgvMidamblePeriodicity", UintegerValue (0));
+  manager->SetAttribute ("NgvPpduRepetitions", UintegerValue (0));
+
+  switch (mode)
+    {
+    case VehicularWifiFallbackMode::NGV_20:
+      manager->SetAttribute ("NgvPpduFormat", UintegerValue (1));
+      manager->SetAttribute ("NgvMcs", UintegerValue (ngvMcsIndex));
+      manager->SetAttribute ("NgvSpatialStreams", UintegerValue (ngvSpatialStreams));
+      manager->SetAttribute ("NgvLtfType", UintegerValue (1));
+      manager->SetAttribute ("DataMode", WifiModeValue (WifiMode ("OfdmRate24Mbps")));
+      manager->SetAttribute ("ControlMode", WifiModeValue (WifiMode ("OfdmRate6Mbps")));
+      manager->SetAttribute ("NonUnicastMode", WifiModeValue (WifiMode ("OfdmRate24Mbps")));
+      break;
+    case VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE:
+      manager->SetAttribute ("NgvPpduFormat", UintegerValue (2));
+      manager->SetAttribute ("NgvMcs", UintegerValue (0));
+      manager->SetAttribute ("NgvSpatialStreams", UintegerValue (1));
+      manager->SetAttribute ("NgvLtfType", UintegerValue (0));
+      manager->SetAttribute ("DataMode", WifiModeValue (WifiMode ("OfdmRate6MbpsBW10MHz")));
+      manager->SetAttribute ("ControlMode", WifiModeValue (WifiMode ("OfdmRate6MbpsBW10MHz")));
+      manager->SetAttribute ("NonUnicastMode",
+                             WifiModeValue (WifiMode ("OfdmRate6MbpsBW10MHz")));
+      break;
+    case VehicularWifiFallbackMode::NON_NGV_10:
+      manager->SetAttribute ("NgvPpduFormat", UintegerValue (0));
+      manager->SetAttribute ("NgvMcs", UintegerValue (0));
+      manager->SetAttribute ("NgvSpatialStreams", UintegerValue (1));
+      manager->SetAttribute ("NgvLtfType", UintegerValue (0));
+      manager->SetAttribute ("DataMode", WifiModeValue (WifiMode ("OfdmRate6MbpsBW10MHz")));
+      manager->SetAttribute ("ControlMode", WifiModeValue (WifiMode ("OfdmRate6MbpsBW10MHz")));
+      manager->SetAttribute ("NonUnicastMode",
+                             WifiModeValue (WifiMode ("OfdmRate6MbpsBW10MHz")));
+      break;
+    }
+}
+
+VehicularWifiRateController::Policy::Policy ()
+{
+  linkQuality.minNgv20SnrDb = minLowNgvMcsSnrDb;
+  linkQuality.minDuplicate20SnrDb = 6.0;
+}
+
+VehicularWifiRateController::Decision
+VehicularWifiRateController::Select (const Policy& policy)
+{
+  return policy.standard == VehicularWifiProfile::Standard::IEEE_80211BD
+             ? SelectFor11bd (policy)
+             : SelectFor11p (policy);
+}
+
+VehicularWifiRateController::Decision
+VehicularWifiRateController::SelectFor11bd (const Policy& policy)
+{
+  VehicularWifiFallbackController::LinkQualityPolicy linkPolicy = policy.linkQuality;
+  linkPolicy.minNgv20SnrDb = policy.minLowNgvMcsSnrDb;
+
+  Decision decision;
+  decision.standard = VehicularWifiProfile::Standard::IEEE_80211BD;
+  decision.fallbackMode = VehicularWifiFallbackController::SelectForLinkQuality (linkPolicy);
+  decision.ngvSpatialStreams = NormalizeNgvSpatialStreams (policy.ngvSpatialStreams);
+  decision.dataMode = Default11bdDataMode (decision.fallbackMode);
+
+  if (decision.fallbackMode != VehicularWifiFallbackMode::NGV_20)
+    {
+      decision.ngvMcsIndex = 0;
+      decision.ngvSpatialStreams = 1;
+      return decision;
+    }
+
+  uint8_t requestedMcs = policy.lowNgvMcsIndex;
+  if (linkPolicy.estimatedSnrDb >= policy.minHighNgvMcsSnrDb)
+    {
+      requestedMcs = policy.highNgvMcsIndex;
+    }
+  else if (linkPolicy.estimatedSnrDb >= policy.minMediumNgvMcsSnrDb)
+    {
+      requestedMcs = policy.mediumNgvMcsIndex;
+    }
+
+  decision.ngvMcsIndex = SelectValidNgvMcs (requestedMcs, 20, decision.ngvSpatialStreams);
+  return decision;
+}
+
+VehicularWifiRateController::Decision
+VehicularWifiRateController::SelectFor11p (const Policy& policy)
+{
+  Decision decision;
+  decision.standard = VehicularWifiProfile::Standard::IEEE_80211P;
+  decision.fallbackMode = VehicularWifiFallbackMode::NON_NGV_10;
+  decision.ngvMcsIndex = 0;
+  decision.ngvSpatialStreams = 1;
+
+  if (policy.linkQuality.estimatedSnrDb >= policy.minHigh11pRateSnrDb)
+    {
+      decision.dataMode = policy.high11pDataMode;
+    }
+  else if (policy.linkQuality.estimatedSnrDb >= policy.minMedium11pRateSnrDb)
+    {
+      decision.dataMode = policy.medium11pDataMode;
+    }
+  else
+    {
+      decision.dataMode = policy.low11pDataMode;
+    }
+  return decision;
+}
+
+std::string
+VehicularWifiRateController::DecisionName (const Decision& decision)
+{
+  if (decision.standard == VehicularWifiProfile::Standard::IEEE_80211P)
+    {
+      return "80211p:" + decision.dataMode;
+    }
+  return "80211bd:" + VehicularWifiFallbackModeName (decision.fallbackMode) + ":MCS" +
+         std::to_string (decision.ngvMcsIndex) + ":NSS" +
+         std::to_string (decision.ngvSpatialStreams);
+}
+
+VehicularWifiProfile
+VehicularWifiRateController::MakeProfile (const Decision& decision)
+{
+  if (decision.standard == VehicularWifiProfile::Standard::IEEE_80211P)
+    {
+      return VehicularWifiProfile::Ieee80211p (decision.dataMode);
+    }
+  return VehicularWifiFallbackController::MakeProfile (decision.fallbackMode,
+                                                       decision.ngvMcsIndex,
+                                                       decision.ngvSpatialStreams);
+}
+
+void
+VehicularWifiRateController::ConfigureRemoteStationManager (Ptr<WifiRemoteStationManager> manager,
+                                                            const Decision& decision)
+{
+  if (manager == nullptr)
+    {
+      return;
+    }
+
+  if (decision.standard == VehicularWifiProfile::Standard::IEEE_80211P)
+    {
+      const WifiMode mode (decision.dataMode);
+      manager->SetAttribute ("DataMode", WifiModeValue (mode));
+      manager->SetAttribute ("ControlMode", WifiModeValue (mode));
+      manager->SetAttribute ("NonUnicastMode", WifiModeValue (mode));
+      manager->SetAttribute ("NgvPpduFormat", UintegerValue (0));
+      manager->SetAttribute ("NgvMcs", UintegerValue (0));
+      manager->SetAttribute ("NgvSpatialStreams", UintegerValue (1));
+      manager->SetAttribute ("NgvLtfType", UintegerValue (0));
+      manager->SetAttribute ("NgvPpduRepetitions", UintegerValue (0));
+      return;
+    }
+
+  VehicularWifiFallbackController::ConfigureRemoteStationManager (manager,
+                                                                  decision.fallbackMode,
+                                                                  decision.ngvMcsIndex,
+                                                                  decision.ngvSpatialStreams);
+}
+
+} // namespace ns3

--- a/src/automotive/helper/vehicular-wifi-helper.h
+++ b/src/automotive/helper/vehicular-wifi-helper.h
@@ -1,0 +1,203 @@
+#ifndef VEHICULAR_WIFI_HELPER_H
+#define VEHICULAR_WIFI_HELPER_H
+
+#include "ns3/MetricSupervisor.h"
+#include "ns3/ptr.h"
+#include "ns3/vehicular-ngv-wifi.h"
+#include "ns3/wifi-80211p-helper.h"
+#include "ns3/yans-wifi-helper.h"
+
+#include <cstdint>
+#include <string>
+
+namespace ns3
+{
+
+class WifiRemoteStationManager;
+
+class VehicularWifiProfile
+{
+public:
+  enum class Standard
+  {
+    IEEE_80211P,
+    IEEE_80211BD
+  };
+
+  static VehicularWifiProfile Ieee80211p (const std::string& dataMode = "OfdmRate6MbpsBW10MHz",
+                                          double txPowerDbm = 23.0,
+                                          double rxSensitivityDbm = -93.0,
+                                          double snrThresholdDb = 4.0);
+  static VehicularWifiProfile Ieee80211bd (const std::string& dataMode = "OfdmRate12MbpsBW10MHz",
+                                           double txPowerDbm = 23.0,
+                                           double rxSensitivityDbm = -95.0,
+                                           double snrThresholdDb = 4.0,
+                                           uint8_t ngvMcsIndex = 3,
+                                           uint8_t ngvSpatialStreams = 1,
+                                           uint16_t channelWidthMHz = 10);
+  static VehicularWifiProfile Ieee80211bd20 (const std::string& dataMode = "OfdmRate24Mbps",
+                                             double txPowerDbm = 23.0,
+                                             double rxSensitivityDbm = -92.0,
+                                             double snrThresholdDb = 4.0,
+                                             uint8_t ngvMcsIndex = 3,
+                                             uint8_t ngvSpatialStreams = 1);
+  static VehicularWifiProfile Ieee80211bdNonNgv10 (const std::string& dataMode = "OfdmRate6MbpsBW10MHz",
+                                                   double txPowerDbm = 23.0,
+                                                   double rxSensitivityDbm = -93.0,
+                                                   double snrThresholdDb = 4.0,
+                                                   uint8_t nonNgvRepetitions = 0);
+  static VehicularWifiProfile Ieee80211bdNonNgv20Duplicate (const std::string& dataMode = "OfdmRate6MbpsBW10MHz",
+                                                            double txPowerDbm = 23.0,
+                                                            double rxSensitivityDbm = -90.0,
+                                                            double snrThresholdDb = 4.0);
+
+  void ConfigurePhy (YansWifiPhyHelper& wifiPhy) const;
+  void ConfigureRemoteStationManager (Wifi80211pHelper& wifiHelper) const;
+  void ConfigureMetricSupervisor (Ptr<MetricSupervisor> metricSupervisor) const;
+
+  Standard GetStandard () const;
+  std::string GetTechnologyName () const;
+  std::string GetDataMode () const;
+  std::string GetControlMode () const;
+  uint16_t GetChannelWidthMHz () const;
+  double GetTxPowerDbm () const;
+  double GetRxSensitivityDbm () const;
+  double GetSnrThresholdDb () const;
+  double GetDccBitRate () const;
+  VehicularWifiPpduFormat GetPpduFormat () const;
+  std::string GetPpduFormatName () const;
+  uint8_t GetNgvMcsIndex () const;
+  uint8_t GetNgvSpatialStreams () const;
+  uint8_t GetNonNgvRepetitions () const;
+
+private:
+  VehicularWifiProfile (Standard standard,
+                        std::string dataMode,
+                        std::string controlMode,
+                        uint16_t channelWidthMHz,
+                        double txPowerDbm,
+                        double rxSensitivityDbm,
+                        double snrThresholdDb,
+                        double dccBitRate,
+                        VehicularWifiPpduFormat ppduFormat,
+                        uint8_t ngvMcsIndex,
+                        uint8_t ngvSpatialStreams,
+                        uint8_t nonNgvRepetitions);
+
+  Standard m_standard;
+  std::string m_dataMode;
+  std::string m_controlMode;
+  uint16_t m_channelWidthMHz;
+  double m_txPowerDbm;
+  double m_rxSensitivityDbm;
+  double m_snrThresholdDb;
+  double m_dccBitRate;
+  VehicularWifiPpduFormat m_ppduFormat;
+  uint8_t m_ngvMcsIndex;
+  uint8_t m_ngvSpatialStreams;
+  uint8_t m_nonNgvRepetitions;
+};
+
+enum class VehicularWifiFallbackMode
+{
+  NGV_20,
+  NON_NGV_20_DUPLICATE,
+  NON_NGV_10
+};
+
+std::string VehicularWifiFallbackModeName (VehicularWifiFallbackMode mode);
+
+class VehicularWifiFallbackController
+{
+public:
+  struct LinkQualityPolicy
+  {
+    bool legacyReceiverPresent = false;
+    bool duplicate20Allowed = true;
+    bool forcePrimaryOnly = false;
+    double estimatedSnrDb = 30.0;
+    double minNgv20SnrDb = 18.0;
+    double minDuplicate20SnrDb = 6.0;
+  };
+
+  struct ObservationState
+  {
+    LinkQualityPolicy policy;
+    bool initialized = false;
+    double ewmaSnrDb = 30.0;
+    double ewmaAlpha = 0.5;
+    uint32_t sampleCount = 0;
+    uint32_t consecutiveFailures = 0;
+    uint32_t failureThreshold = 2;
+  };
+
+  static VehicularWifiFallbackMode Select (bool legacyReceiverPresent,
+                                           bool duplicate20Allowed = true,
+                                           bool forcePrimaryOnly = false);
+  static VehicularWifiFallbackMode SelectForLinkQuality (const LinkQualityPolicy& policy);
+  static void ResetObservationState (ObservationState& state);
+  static void ResetObservationState (ObservationState& state,
+                                     const LinkQualityPolicy& initialPolicy);
+  static VehicularWifiFallbackMode UpdateFromObservation (ObservationState& state,
+                                                          double observedSnrDb,
+                                                          bool deliverySucceeded,
+                                                          bool legacyReceiverPresent);
+  static double EstimateSnrDb (double signalDbm, double noiseDbm);
+  static VehicularWifiFallbackMode UpdateFromSignalNoise (ObservationState& state,
+                                                          double signalDbm,
+                                                          double noiseDbm,
+                                                          bool deliverySucceeded,
+                                                          bool legacyReceiverPresent);
+  static VehicularWifiProfile MakeProfile (VehicularWifiFallbackMode mode,
+                                           uint8_t ngvMcsIndex = 3,
+                                           uint8_t ngvSpatialStreams = 1);
+  static void ConfigureRemoteStationManager (Ptr<WifiRemoteStationManager> manager,
+                                             VehicularWifiFallbackMode mode,
+                                             uint8_t ngvMcsIndex = 3,
+                                             uint8_t ngvSpatialStreams = 1);
+};
+
+class VehicularWifiRateController
+{
+public:
+  struct Policy
+  {
+    Policy ();
+
+    VehicularWifiProfile::Standard standard = VehicularWifiProfile::Standard::IEEE_80211BD;
+    VehicularWifiFallbackController::LinkQualityPolicy linkQuality;
+    double minLowNgvMcsSnrDb = 12.0;
+    double minMediumNgvMcsSnrDb = 18.0;
+    double minHighNgvMcsSnrDb = 30.0;
+    uint8_t lowNgvMcsIndex = 0;
+    uint8_t mediumNgvMcsIndex = 3;
+    uint8_t highNgvMcsIndex = 7;
+    uint8_t ngvSpatialStreams = 1;
+    double minMedium11pRateSnrDb = 8.0;
+    double minHigh11pRateSnrDb = 18.0;
+    std::string low11pDataMode = "OfdmRate3MbpsBW10MHz";
+    std::string medium11pDataMode = "OfdmRate6MbpsBW10MHz";
+    std::string high11pDataMode = "OfdmRate12MbpsBW10MHz";
+  };
+
+  struct Decision
+  {
+    VehicularWifiProfile::Standard standard = VehicularWifiProfile::Standard::IEEE_80211BD;
+    VehicularWifiFallbackMode fallbackMode = VehicularWifiFallbackMode::NGV_20;
+    uint8_t ngvMcsIndex = 3;
+    uint8_t ngvSpatialStreams = 1;
+    std::string dataMode = "OfdmRate6MbpsBW10MHz";
+  };
+
+  static Decision Select (const Policy& policy);
+  static Decision SelectFor11bd (const Policy& policy);
+  static Decision SelectFor11p (const Policy& policy);
+  static std::string DecisionName (const Decision& decision);
+  static VehicularWifiProfile MakeProfile (const Decision& decision);
+  static void ConfigureRemoteStationManager (Ptr<WifiRemoteStationManager> manager,
+                                             const Decision& decision);
+};
+
+} // namespace ns3
+
+#endif // VEHICULAR_WIFI_HELPER_H

--- a/src/automotive/model/DCC/DCC.cc
+++ b/src/automotive/model/DCC/DCC.cc
@@ -19,6 +19,11 @@
 
 #include "DCC.h"
 
+#include "ns3/mac48-address.h"
+#include "ns3/wifi-mac-header.h"
+#include "ns3/wifi-remote-station-manager.h"
+#include "ns3/wifi-tx-vector.h"
+
 namespace ns3 {
 NS_LOG_COMPONENT_DEFINE("DCC");
 
@@ -450,6 +455,33 @@ bool DCC::checkGateOpen(float now)
 
 void DCC::updateTonpp(ssize_t pktSize)
 {
+  if (m_node != nullptr && m_node->GetNDevices () > 0)
+    {
+      Ptr<WifiNetDevice> wifiDevice = DynamicCast<WifiNetDevice> (m_node->GetDevice (0));
+      if (wifiDevice != nullptr && wifiDevice->GetPhy () != nullptr &&
+          wifiDevice->GetRemoteStationManager () != nullptr)
+        {
+          WifiMacHeader broadcastData;
+          broadcastData.SetType (WIFI_MAC_DATA);
+          broadcastData.SetAddr1 (Mac48Address::GetBroadcast ());
+          broadcastData.SetAddr2 (Mac48Address ("00:00:00:00:00:01"));
+          broadcastData.SetAddr3 (Mac48Address::GetBroadcast ());
+
+          WifiTxVector txVector = wifiDevice->GetRemoteStationManager ()->GetDataTxVector (broadcastData);
+          Time txDuration = WifiPhy::CalculateTxDuration (static_cast<uint32_t> (pktSize),
+                                                          txVector,
+                                                          wifiDevice->GetPhy ()->GetPhyBand ());
+          Time totalDuration = txDuration;
+          if (txVector.IsNonNgv10 () && txVector.GetNgvPpduRepetitions () > 0)
+            {
+              const uint8_t repetitions = txVector.GetNgvPpduRepetitions ();
+              totalDuration = txDuration * (1 + repetitions) + wifiDevice->GetPhy ()->GetSifs () * repetitions;
+            }
+          m_Ton_pp = static_cast<float> (totalDuration.GetSeconds () * 1000.0);
+          return;
+        }
+    }
+
   double bits = pktSize * 8;
   double tx_duration_s = static_cast<double>(bits) / m_bitrate_bps;
   double total_duration_s = tx_duration_s + (68e-6); // 68 µs extra

--- a/src/automotive/model/DCC/DCC.h
+++ b/src/automotive/model/DCC/DCC.h
@@ -71,6 +71,7 @@ public:
   void updateTgoAfterDeltaUpdate();
   void updateTgoAfterTransmission();
   std::string getModality() {return m_modality;}
+  float getTonPpMs() const {return m_Ton_pp;}
   void setBitRate(long bitrate) {m_bitrate_bps = bitrate;}
   void setSendCallback(std::function<void(const QueuePacket&)> cb);
   void setCBRGCallback(std::function<void()> cb);

--- a/src/automotive/model/GeoNet/geonet.cc
+++ b/src/automotive/model/GeoNet/geonet.cc
@@ -23,6 +23,7 @@
 #include "ns3/log.h"
 #include "ns3/network-module.h"
 #include "ns3/gn-utils.h"
+#include <algorithm>
 #include <cmath>
 #include "ns3/ipv4-header.h"
 #include "ns3/DCC.h"
@@ -1143,123 +1144,120 @@ namespace ns3 {
     return gn_sock;
   }
 
+  GeoNet::GlobalCbrAggregation
+  GeoNet::ComputeGlobalCbrAggregation (std::vector<LocationTableExtension*> cbrExtensions,
+                                       int64_t nowMs,
+                                       int64_t cbrValidityMs,
+                                       double cbrTarget,
+                                       double cbrL0HopPrev)
+  {
+    double mean_cbr_r0_hop = 0.0;
+    uint64_t tot_r0 = 0;
+    double max_cbr_r0 = 0.0, second_max_cbr_r0 = 0.0;
+    double mean_cbr_r1_hop = 0.0;
+    uint64_t tot_r1 = 0;
+    double max_cbr_r1 = 0.0, second_max_cbr_r1 = 0.0;
+
+    for (auto cbr_data_ptr : cbrExtensions)
+      {
+        if (cbr_data_ptr == nullptr)
+          {
+            continue;
+          }
+        auto& cbr_data = *cbr_data_ptr;
+
+        auto isExpired = [nowMs, cbrValidityMs] (const std::tuple<int64_t, double>& sample) {
+          return nowMs - cbrValidityMs > std::get<0> (sample);
+        };
+        cbr_data.CBR_R0_Hop.erase (
+            std::remove_if (cbr_data.CBR_R0_Hop.begin (), cbr_data.CBR_R0_Hop.end (), isExpired),
+            cbr_data.CBR_R0_Hop.end ());
+        cbr_data.CBR_R1_Hop.erase (
+            std::remove_if (cbr_data.CBR_R1_Hop.begin (), cbr_data.CBR_R1_Hop.end (), isExpired),
+            cbr_data.CBR_R1_Hop.end ());
+
+        for (auto it2 = cbr_data.CBR_R0_Hop.begin (); it2 != cbr_data.CBR_R0_Hop.end (); ++it2)
+          {
+            double val = std::get<1> (*it2);
+            mean_cbr_r0_hop += val;
+
+            if (val > max_cbr_r0)
+              {
+                second_max_cbr_r0 = max_cbr_r0;
+                max_cbr_r0 = val;
+              }
+            else if (val < max_cbr_r0 && val > second_max_cbr_r0)
+              {
+                second_max_cbr_r0 = val;
+              }
+          }
+        tot_r0 += cbr_data.CBR_R0_Hop.size ();
+
+        for (auto it2 = cbr_data.CBR_R1_Hop.begin (); it2 != cbr_data.CBR_R1_Hop.end (); ++it2)
+          {
+            double val = std::get<1> (*it2);
+            mean_cbr_r1_hop += val;
+
+            if (val > max_cbr_r1)
+              {
+                second_max_cbr_r1 = max_cbr_r1;
+                max_cbr_r1 = val;
+              }
+            else if (val < max_cbr_r1 && val > second_max_cbr_r1)
+              {
+                second_max_cbr_r1 = val;
+              }
+          }
+        tot_r1 += cbr_data.CBR_R1_Hop.size ();
+      }
+
+    if (tot_r0 != 0)
+      {
+        mean_cbr_r0_hop /= tot_r0;
+      }
+    if (tot_r1 != 0)
+      {
+        mean_cbr_r1_hop /= tot_r1;
+      }
+
+    GlobalCbrAggregation aggregation;
+    aggregation.cbrL1Hop = mean_cbr_r0_hop > cbrTarget ? max_cbr_r0 : second_max_cbr_r0;
+    aggregation.cbrL2Hop = mean_cbr_r1_hop > cbrTarget ? max_cbr_r1 : second_max_cbr_r1;
+    aggregation.cbrG = std::max (cbrL0HopPrev, std::max (aggregation.cbrL1Hop, aggregation.cbrL2Hop));
+    aggregation.r0SampleCount = tot_r0;
+    aggregation.r1SampleCount = tot_r1;
+    return aggregation;
+  }
+
   void GeoNet::attachGlobalCBRCheck ()
   {
     if (m_dcc == nullptr) return;
     m_dcc->setCBRGCallback([this](){
-      struct timespec tv;
-      clock_gettime (CLOCK_MONOTONIC, &tv);
-      double now = static_cast<double>((tv.tv_sec * 1e9 + tv.tv_nsec)/1e6);
-      double mean_cbr_r0_hop = 0.0;
-      long tot_r0 = 0;
-      double max_cbr_r0 = 0.0, second_max_cbr_r0 = 0.0;
-      double mean_cbr_r1_hop = 0.0;
-      long tot_r1 = 0;
-      double max_cbr_r1 = 0.0, second_max_cbr_r1 = 0.0;
+      int64_t now = Simulator::Now ().GetMilliSeconds ();
+      std::vector<LocationTableExtension*> cbrExtensions;
       m_LocT_Mutex.lock ();
       for(auto it = m_GNLocT.begin(); it != m_GNLocT.end(); ++it)
         {
-          auto& cbr_data = it->second.cbr_extension;
-          // Clean old data
-          size_t counter = 0;
-          std::vector<size_t> to_delete;
-          for (auto it2 = cbr_data.CBR_R0_Hop.begin(); it2 != cbr_data.CBR_R0_Hop.end(); ++it2)
-            {
-              if(now - m_GNLocTTimerCBR_ms > std::get<0>(*it2)) to_delete.push_back (counter);
-              counter ++;
-            }
-          std::sort(to_delete.begin(), to_delete.end(), std::greater<size_t>());
-          for (size_t idx : to_delete) {
-              if (idx < cbr_data.CBR_R0_Hop.size()) {
-                  cbr_data.CBR_R0_Hop.erase(cbr_data.CBR_R0_Hop.begin() + idx);
-                }
-            }
-
-          counter = 0;
-          to_delete.clear();
-          for (auto it2 = cbr_data.CBR_R1_Hop.begin(); it2 != cbr_data.CBR_R1_Hop.end(); ++it2)
-            {
-              if(now - m_GNLocTTimerCBR_ms > std::get<0>(*it2)) to_delete.push_back (counter);
-              counter ++;
-            }
-          std::sort(to_delete.begin(), to_delete.end(), std::greater<size_t>());
-          for (size_t idx : to_delete) {
-              if (idx < cbr_data.CBR_R1_Hop.size()) {
-                  cbr_data.CBR_R1_Hop.erase(cbr_data.CBR_R1_Hop.begin() + idx);
-                }
-            }
-
-          for (auto it2 = cbr_data.CBR_R0_Hop.begin(); it2 != cbr_data.CBR_R0_Hop.end(); ++it2)
-            {
-              double val = std::get<1>(*it2);
-              mean_cbr_r0_hop += val;
-
-              if (val > max_cbr_r0)
-                {
-                  second_max_cbr_r0 = max_cbr_r0;
-                  max_cbr_r0 = val;
-                }
-              else if (val < max_cbr_r0 && val > second_max_cbr_r0)
-                {
-                  second_max_cbr_r0 = val;
-                }
-            }
-          tot_r0 += cbr_data.CBR_R0_Hop.size();
-
-          for (auto it2 = cbr_data.CBR_R1_Hop.begin(); it2 != cbr_data.CBR_R1_Hop.end(); ++it2)
-            {
-              double val = std::get<1>(*it2);
-              mean_cbr_r1_hop += val;
-
-              if (val > max_cbr_r1)
-                {
-                  second_max_cbr_r1 = max_cbr_r1;
-                  max_cbr_r1 = val;
-                }
-              else if (val < max_cbr_r1 && val > second_max_cbr_r1)
-                {
-                  second_max_cbr_r1 = val;
-                }
-            }
-          tot_r1 += cbr_data.CBR_R1_Hop.size();
+          cbrExtensions.push_back (&it->second.cbr_extension);
         }
+      GlobalCbrAggregation aggregation =
+          ComputeGlobalCbrAggregation (cbrExtensions,
+                                       now,
+                                       m_GNLocTTimerCBR_ms,
+                                       m_dcc->getCBRTarget (),
+                                       m_dcc->getCBRL0Prev ());
       m_LocT_Mutex.unlock ();
-      if (tot_r0 == 0) mean_cbr_r0_hop = 0;
-      else mean_cbr_r0_hop /= tot_r0;
-      if (tot_r1 == 0) mean_cbr_r1_hop = 0;
-      else mean_cbr_r1_hop /= tot_r1;
-      double CBR_L1_Hop, CBR_L2_Hop;
-      if (mean_cbr_r0_hop > m_dcc->getCBRTarget())
-        {
-          CBR_L1_Hop = max_cbr_r0;
-        }
-      else
-        {
-          CBR_L1_Hop = second_max_cbr_r0;
-        }
-
-      if (mean_cbr_r1_hop > m_dcc->getCBRTarget())
-        {
-          CBR_L2_Hop = max_cbr_r1;
-        }
-      else
-        {
-          CBR_L2_Hop = second_max_cbr_r1;
-        }
-      double CBR_L0_Hop_prev = m_dcc->getCBRL0Prev();
-      double CBR_G = std::max(CBR_L0_Hop_prev, CBR_L1_Hop);
-      CBR_G = std::max(CBR_G, CBR_L2_Hop);
       /*
 		std::ofstream file;
 		file.open("CBR_global.txt", std::ios::app);
 		file << std::fixed << std::setprecision(2);
 		file << "\n";
-		file << "[DCC] Global CBR: " << CBR_G << ", Local CBR L1: " << CBR_L1_Hop << ", Local CBR L2: " << CBR_L2_Hop << ", CBR L0 prev: " << CBR_L0_Hop_prev << std::endl;
+		file << "[DCC] Global CBR: " << aggregation.cbrG << ", Local CBR L1: " << aggregation.cbrL1Hop << ", Local CBR L2: " << aggregation.cbrL2Hop << ", CBR L0 prev: " << m_dcc->getCBRL0Prev() << std::endl;
 		file << "\n";
 		file.close();
 		*/
-      m_dcc->setCBRG(CBR_G);
-      m_dcc->setCBRL1(CBR_L1_Hop);
+      m_dcc->setCBRG(aggregation.cbrG);
+      m_dcc->setCBRL1(aggregation.cbrL1Hop);
     });
   }
 

--- a/src/automotive/model/GeoNet/geonet.h
+++ b/src/automotive/model/GeoNet/geonet.h
@@ -4,10 +4,13 @@
 #include "ns3/MetricSupervisor.h"
 #include "ns3/security.h"
 #include <stdint.h>
+#include <functional>
 #include <string>
 #include <map>
 #include <set>
 #include <mutex>
+#include <tuple>
+#include <vector>
 #include "ns3/vdpTraci.h"
 #include "ns3/asn_utils.h"
 #include "ns3/address.h"
@@ -50,6 +53,14 @@ namespace ns3
         std::vector<std::tuple<int64_t , double>> CBR_R0_Hop;
         std::vector<std::tuple<int64_t , double>> CBR_R1_Hop;
       } LocationTableExtension;
+
+      typedef struct GlobalCbrAggregation {
+        double cbrG;
+        double cbrL1Hop;
+        double cbrL2Hop;
+        uint64_t r0SampleCount;
+        uint64_t r1SampleCount;
+      } GlobalCbrAggregation;
 
       typedef struct _LocTableEntry {
         /**
@@ -162,6 +173,13 @@ namespace ns3
       void attachSendFromDCCQueue();
 
       void attachGlobalCBRCheck();
+
+      static GlobalCbrAggregation ComputeGlobalCbrAggregation (
+          std::vector<LocationTableExtension*> cbrExtensions,
+          int64_t nowMs,
+          int64_t cbrValidityMs,
+          double cbrTarget,
+          double cbrL0HopPrev);
 
   private:
       void LocTE_timeout(GNAddress entry_address);

--- a/src/automotive/model/Measurements/MetricSupervisor.cc
+++ b/src/automotive/model/Measurements/MetricSupervisor.cc
@@ -39,6 +39,7 @@ NS_LOG_COMPONENT_DEFINE("MetricSupervisor");
 
 std::unordered_map<std::string, Time> currentBusyCBR;
 std::unordered_map<std::string, std::pair<Time, WifiPhyState>> nodeLastState80211p;
+std::unordered_map<std::string, std::vector<std::pair<Time, Time>>> nodeBusyIntervals80211p;
 std::unordered_map<std::string, Time> nodeDurationStateNr;
 Time lastCBRCheck = Time(-1.0);
 
@@ -476,6 +477,56 @@ bool IsChannelBusy(WifiPhyState state) {
   return state != WifiPhyState::SLEEP && state != WifiPhyState::IDLE;
 }
 
+bool IsWaveCbrTechnology(const std::string& technology)
+{
+  return technology == "80211p" || technology == "80211bd";
+}
+
+void
+RefreshWaveBusyCbrForCurrentWindow ()
+{
+  Time windowStart = lastCBRCheck.IsNegative () ? Seconds (0) : lastCBRCheck;
+  Time windowEnd = Simulator::Now ();
+  currentBusyCBR.clear ();
+
+  for (auto it = nodeBusyIntervals80211p.begin (); it != nodeBusyIntervals80211p.end ();)
+    {
+      Time busyCbr = Seconds (0);
+      std::vector<std::pair<Time, Time>> remainingIntervals;
+
+      for (const auto& interval : it->second)
+        {
+          Time intervalStart = interval.first;
+          Time intervalEnd = interval.second;
+          if (intervalEnd > windowStart && intervalStart < windowEnd)
+            {
+              Time clippedStart = intervalStart < windowStart ? windowStart : intervalStart;
+              Time clippedEnd = intervalEnd > windowEnd ? windowEnd : intervalEnd;
+              if (clippedEnd > clippedStart)
+                {
+                  busyCbr += clippedEnd - clippedStart;
+                }
+            }
+
+          if (intervalEnd > windowEnd)
+            {
+              remainingIntervals.push_back (interval);
+            }
+        }
+
+      currentBusyCBR[it->first] = busyCbr;
+      if (remainingIntervals.empty ())
+        {
+          it = nodeBusyIntervals80211p.erase (it);
+        }
+      else
+        {
+          it->second = remainingIntervals;
+          ++it;
+        }
+    }
+}
+
 void
 storeCBR80211p (std::string context, Time start, Time duration, WifiPhyState state)
 {
@@ -487,24 +538,10 @@ storeCBR80211p (std::string context, Time start, Time duration, WifiPhyState sta
 
   if (IsChannelBusy (state))
     {
-      // Check if the last measurement for busy state started before the last CBR check
-      // In this case we need to consider only the time from the last CBR check
-      // The time before the last CBR check was already considered in the logic of the check
-      if (start < lastCBRCheck)
+      Time end = start + duration;
+      if (end > start)
         {
-          duration -= lastCBRCheck - start;
-          if (duration.IsNegative())
-            {
-              duration = Seconds (0);
-            }
-        }
-      if (currentBusyCBR.find(node) == currentBusyCBR.end())
-        {
-          currentBusyCBR[node] = duration;
-        }
-      else
-        {
-          currentBusyCBR[node] += duration;
+          nodeBusyIntervals80211p[node].push_back (std::make_pair (start, end));
         }
       // Storing the current state and the current time is essential
       // Situations where the next CBR check happens before the end of the current busy state must be handled with this method
@@ -550,6 +587,18 @@ MetricSupervisor::checkCBR ()
 {
 
   std::unordered_map<std::string, Time> nextTimeToAddNr;
+  if (IsWaveCbrTechnology (m_channel_technology))
+    {
+      RefreshWaveBusyCbrForCurrentWindow ();
+      for (uint32_t i = 0; i < m_node_container.GetN (); ++i)
+        {
+          const std::string node_id = std::to_string (m_node_container.Get (i)->GetId ());
+          if (currentBusyCBR.find (node_id) == currentBusyCBR.end ())
+            {
+              currentBusyCBR[node_id] = Seconds (0);
+            }
+        }
+    }
   if(m_traci_ptr != nullptr)
     {
       std::map<std::basic_string<char>, std::pair<StationType_t, Ptr<Node>>> nodes = m_traci_ptr->get_NodeMap ();
@@ -699,8 +748,45 @@ MetricSupervisor::checkCBR ()
             }
         }
     }
+  else
+    {
+      for (uint32_t i = 0; i < m_node_container.GetN (); ++i)
+        {
+          std::string node_id = std::to_string (m_node_container.Get (i)->GetId ());
+
+          if (currentBusyCBR.find (node_id) == currentBusyCBR.end ())
+            {
+              continue;
+            }
+
+          Time busyCbr = currentBusyCBR[node_id];
+
+          if (m_channel_technology == "Nr")
+            {
+              if (nodeDurationStateNr[node_id] > Simulator::Now ())
+                {
+                  Time nextToAdd = nodeDurationStateNr[node_id] - Simulator::Now ();
+                  busyCbr -= nextToAdd;
+                  nextTimeToAddNr[node_id] = nextToAdd;
+                }
+            }
+
+          double currentCbr = busyCbr.GetDouble () / (m_cbr_window * 1e6);
+
+          if (m_average_cbr.find (node_id) != m_average_cbr.end ())
+            {
+              double new_cbr =
+                  m_cbr_alpha * m_average_cbr[node_id].back () + (1 - m_cbr_alpha) * currentCbr;
+              m_average_cbr[node_id].push_back (new_cbr);
+            }
+          else
+            {
+              m_average_cbr[node_id].push_back (currentCbr);
+            }
+        }
+    }
   currentBusyCBR.clear();
-  if(m_channel_technology == "80211p") nodeLastState80211p.clear();
+  if(IsWaveCbrTechnology(m_channel_technology)) nodeLastState80211p.clear();
   if(m_channel_technology == "Nr")
     {
       nodeDurationStateNr.clear();
@@ -764,17 +850,23 @@ MetricSupervisor::startCheckCBR (int num_nodes)
   // Assert that the parameters for the CBR are set
   NS_ASSERT_MSG(m_cbr_window > 0, "CBR window must be greater than 0");
   NS_ASSERT_MSG(m_cbr_alpha >= 0 && m_cbr_alpha <= 1, "CBR alpha must be between 0 and 1");
-  NS_ASSERT_MSG (m_channel_technology != "", "Channel technology must be set, choose between 80211p and Nr");
+  NS_ASSERT_MSG (m_channel_technology != "", "Channel technology must be set, choose between 80211p, 80211bd, and Nr");
   NS_ASSERT_MSG (m_simulation_time > 0, "Simulation time must be greater than 0");
 
   NS_ASSERT_MSG (m_node_container.GetN() != 0, "The Node container must be filled before the CBR checking.");
+  currentBusyCBR.clear ();
+  nodeLastState80211p.clear ();
+  nodeBusyIntervals80211p.clear ();
+  nodeDurationStateNr.clear ();
+  lastCBRCheck = Time (-1.0);
+
   uint8_t i = 0;
   uint8_t nodes_to_check = num_nodes == -1 ? m_node_container.GetN() : num_nodes;
   for(; i < nodes_to_check; i++)
     {
       Ptr<Node> node = m_node_container.Get (i);
       std::basic_ostringstream<char> oss;
-      if (m_channel_technology == "80211p")
+      if (IsWaveCbrTechnology (m_channel_technology))
         {
           oss << "/NodeList/" << node->GetId() << "/DeviceList/*/$ns3::WifiNetDevice/Phy/State/State";
           std::string var = oss.str();

--- a/src/automotive/model/Measurements/MetricSupervisor.h
+++ b/src/automotive/model/Measurements/MetricSupervisor.h
@@ -426,12 +426,12 @@ public:
   void setChannelTechnology(std::string channelTechnology)
   {
     // Define the set of valid channel technologies
-    std::set<std::string> validChannelTechnologies = {"80211p", "Nr", "Lte", "CV2X"};
+    std::set<std::string> validChannelTechnologies = {"80211p", "80211bd", "Nr", "Lte", "CV2X"};
 
     // Check if the provided channelTechnology is valid
     if (validChannelTechnologies.find(channelTechnology) == validChannelTechnologies.end()) {
         // If the channelTechnology is not valid, throw an error
-        NS_FATAL_ERROR("Invalid channel technology. Must be one of '80211p', 'Nr', 'Lte', or 'CV2X'.");
+        NS_FATAL_ERROR("Invalid channel technology. Must be one of '80211p', '80211bd', 'Nr', 'Lte', or 'CV2X'.");
       }
 
     // If the channelTechnology is valid, set it

--- a/src/automotive/model/SignalInfo/WiFi/CMakeLists.txt
+++ b/src/automotive/model/SignalInfo/WiFi/CMakeLists.txt
@@ -54,6 +54,8 @@ set(source_files
     model/mgt-headers.cc
     model/mpdu-aggregator.cc
     model/msdu-aggregator.cc
+    model/ngv/ngv-phy.cc
+    model/ngv/ngv-ppdu.cc
     model/nist-error-rate-model.cc
     model/non-ht/dsss-error-rate-model.cc
     model/non-ht/dsss-parameter-set.cc
@@ -193,6 +195,9 @@ set(header_files
     model/mgt-headers.h
     model/mpdu-aggregator.h
     model/msdu-aggregator.h
+    model/ngv/ngv-calibration.h
+    model/ngv/ngv-phy.h
+    model/ngv/ngv-ppdu.h
     model/nist-error-rate-model.h
     model/non-ht/dsss-error-rate-model.h
     model/non-ht/dsss-parameter-set.h

--- a/src/automotive/model/SignalInfo/WiFi/error-rate-model.cc
+++ b/src/automotive/model/SignalInfo/WiFi/error-rate-model.cc
@@ -1,0 +1,213 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006 INRIA
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ */
+
+#include "error-rate-model.h"
+#include "ns3/dsss-error-rate-model.h"
+#include "ngv/ngv-calibration.h"
+#include "ngv/ngv-phy.h"
+#include "wifi-utils.h"
+#include "wifi-tx-vector.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ns3 {
+
+NS_OBJECT_ENSURE_REGISTERED (ErrorRateModel);
+
+namespace {
+
+const NgvCalibration::PerReference&
+GetNgvPerReference (const WifiTxVector& txVector)
+{
+  for (const auto& reference : NgvCalibration::PER_REFERENCES)
+    {
+      if (reference.mcs == txVector.GetNgvMcs () &&
+          reference.channelWidthMHz == txVector.GetChannelWidth () &&
+          reference.nss == txVector.GetNss ())
+        {
+          return reference;
+        }
+    }
+  NS_ABORT_MSG ("Invalid or reserved NGV-MCS index for " << txVector.GetChannelWidth ()
+                                                         << " MHz, NSS=" << +txVector.GetNss ());
+}
+
+double
+GetNgvMidambleDopplerGainDb (const WifiTxVector& txVector, uint64_t nbits)
+{
+  const uint16_t periodicity = txVector.GetNgvMidamblePeriodicity ();
+  double maxGainDb = 0.0;
+  for (const auto& gain : NgvCalibration::MIDAMBLE_DOPPLER_GAINS)
+    {
+      if (gain.periodicity == periodicity)
+        {
+          maxGainDb = gain.maxGainDb;
+          break;
+        }
+    }
+  if (maxGainDb == 0.0)
+    {
+      return 0.0;
+    }
+
+  const uint16_t dataBitsPerSymbol = NgvPhy::GetDataBitsPerSymbol (txVector);
+  const double codedBits =
+      static_cast<double> (NgvCalibration::SERVICE_BITS) + static_cast<double> (nbits) +
+      NgvCalibration::TAIL_BITS;
+  const uint32_t numSymbols = static_cast<uint32_t> (std::ceil (codedBits / dataBitsPerSymbol));
+  if (numSymbols <= NgvCalibration::SHORT_PPDU_SYMBOLS)
+    {
+      return 0.0;
+    }
+
+  const double longPpduFactor =
+      std::min (1.0,
+                (numSymbols - NgvCalibration::SHORT_PPDU_SYMBOLS) /
+                    NgvCalibration::LONG_PPDU_GAIN_NORMALIZATION_SYMBOLS);
+  return maxGainDb * longPpduFactor;
+}
+
+double
+GetNonNgv10RepetitionCombiningGainDb (const WifiTxVector& txVector, WifiPpduField field)
+{
+  if (!txVector.IsNonNgv10 () || txVector.GetNgvPpduRepetitions () == 0 ||
+      field != WIFI_PPDU_FIELD_DATA)
+    {
+      return 0.0;
+    }
+
+  const double repeatedObservations = 1.0 + txVector.GetNgvPpduRepetitions ();
+  return 10.0 * std::log10 (repeatedObservations);
+}
+
+double
+CalculateNgvChunkSuccessRate (const WifiTxVector& txVector, double snr, uint64_t nbits)
+{
+  NS_ABORT_MSG_IF (!txVector.IsValid (), "Cannot calculate PER for an invalid NGV TXVECTOR");
+
+  const NgvCalibration::PerReference& reference = GetNgvPerReference (txVector);
+  const double snrDb = RatioToDb (snr) + GetNgvMidambleDopplerGainDb (txVector, nbits);
+  const double snr50PercentPerDb =
+      reference.snr10PercentPerDb - NgvCalibration::PER_TRANSITION_SLOPE_DB * std::log (9.0);
+  const double logisticArgument =
+      (snrDb - snr50PercentPerDb) / NgvCalibration::PER_TRANSITION_SLOPE_DB;
+
+  double referencePer;
+  if (logisticArgument > 60.0)
+    {
+      referencePer = 0.0;
+    }
+  else if (logisticArgument < -60.0)
+    {
+      referencePer = 1.0;
+    }
+  else
+    {
+      referencePer = 1.0 / (1.0 + std::exp (logisticArgument));
+    }
+
+  const double referenceBits = static_cast<double> (reference.referenceBytes) * 8.0;
+  const double sizeRatio = std::max (1.0, static_cast<double> (nbits)) / referenceBits;
+  double per = 1.0 - std::pow (1.0 - referencePer, sizeRatio);
+  per = std::min (1.0, std::max (0.0, per));
+  return 1.0 - per;
+}
+
+} // namespace
+
+TypeId ErrorRateModel::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::ErrorRateModel")
+    .SetParent<Object> ()
+    .SetGroupName ("Wifi")
+  ;
+  return tid;
+}
+
+double
+ErrorRateModel::CalculateSnr (const WifiTxVector& txVector, double ber) const
+{
+  //This is a very simple binary search.
+  double low, high, precision;
+  low = 1e-25;
+  high = 1e25;
+  precision = 2e-12;
+  while (high - low > precision)
+    {
+      NS_ASSERT (high >= low);
+      double middle = low + (high - low) / 2;
+      if ((1 - GetChunkSuccessRate (txVector.GetMode (), txVector, middle, 1)) > ber)
+        {
+          low = middle;
+        }
+      else
+        {
+          high = middle;
+        }
+    }
+  return low;
+}
+
+double
+ErrorRateModel::GetChunkSuccessRate (WifiMode mode, const WifiTxVector& txVector, double snr, uint64_t nbits, uint8_t numRxAntennas, WifiPpduField field, uint16_t staId) const
+{
+  if (txVector.IsNgv () && field == WIFI_PPDU_FIELD_DATA)
+    {
+      return CalculateNgvChunkSuccessRate (txVector, snr, nbits);
+    }
+  else if (mode.GetModulationClass () == WIFI_MOD_CLASS_DSSS || mode.GetModulationClass () == WIFI_MOD_CLASS_HR_DSSS)
+    {
+      switch (mode.GetDataRate (22, 0, 1))
+        {
+          case 1000000:
+            return DsssErrorRateModel::GetDsssDbpskSuccessRate (snr, nbits);
+          case 2000000:
+            return DsssErrorRateModel::GetDsssDqpskSuccessRate (snr, nbits);
+          case 5500000:
+            return DsssErrorRateModel::GetDsssDqpskCck5_5SuccessRate (snr, nbits);
+          case 11000000:
+            return DsssErrorRateModel::GetDsssDqpskCck11SuccessRate (snr, nbits);
+          default:
+            NS_ASSERT ("undefined DSSS/HR-DSSS datarate");
+        }
+    }
+  else
+    {
+      snr *= DbToRatio (GetNonNgv10RepetitionCombiningGainDb (txVector, field));
+      return DoGetChunkSuccessRate (mode, txVector, snr, nbits, numRxAntennas, field, staId);
+    }
+  return 0;
+}
+
+bool
+ErrorRateModel::IsAwgn (void) const
+{
+  return true;
+}
+
+int64_t
+ErrorRateModel::AssignStreams (int64_t stream)
+{
+  // Override this method if the error model uses random variables
+  return 0;
+}
+
+} //namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/interference-helper.cc
+++ b/src/automotive/model/SignalInfo/WiFi/interference-helper.cc
@@ -1,0 +1,678 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006 INRIA
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ *          Sébastien Deronne <sebastien.deronne@gmail.com>
+ */
+
+#include <numeric>
+#include <algorithm>
+#include "ns3/simulator.h"
+#include "ns3/log.h"
+#include "ns3/packet.h"
+#include "interference-helper.h"
+#include "wifi-phy.h"
+#include "error-rate-model.h"
+#include "ngv/ngv-phy.h"
+#include "wifi-utils.h"
+#include "wifi-psdu.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("InterferenceHelper");
+
+NS_OBJECT_ENSURE_REGISTERED (InterferenceHelper);
+
+/****************************************************************
+ *       PHY event class
+ ****************************************************************/
+
+Event::Event (Ptr<const WifiPpdu> ppdu, const WifiTxVector& txVector, Time duration, RxPowerWattPerChannelBand&& rxPower)
+  : m_ppdu (ppdu),
+    m_txVector (txVector),
+    m_startTime (Simulator::Now ()),
+    m_endTime (m_startTime + duration),
+    m_rxPowerW (std::move (rxPower))
+{
+}
+
+Event::~Event ()
+{
+  m_ppdu = 0;
+  m_rxPowerW.clear ();
+}
+
+Ptr<const WifiPpdu>
+Event::GetPpdu (void) const
+{
+  return m_ppdu;
+}
+
+Time
+Event::GetStartTime (void) const
+{
+  return m_startTime;
+}
+
+Time
+Event::GetEndTime (void) const
+{
+  return m_endTime;
+}
+
+Time
+Event::GetDuration (void) const
+{
+  return m_endTime - m_startTime;
+}
+
+double
+Event::GetRxPowerW (void) const
+{
+  NS_ASSERT (m_rxPowerW.size () > 0);
+  //The total RX power corresponds to the maximum over all the bands
+  auto it = std::max_element (m_rxPowerW.begin (), m_rxPowerW.end (),
+    [] (const std::pair<WifiSpectrumBand, double>& p1, const std::pair<WifiSpectrumBand, double>& p2) {
+      return p1.second < p2.second;
+    });
+  return it->second;
+}
+
+double
+Event::GetRxPowerW (WifiSpectrumBand band) const
+{
+  auto it = m_rxPowerW.find (band);
+  NS_ASSERT (it != m_rxPowerW.end ());
+  return it->second;
+}
+
+const RxPowerWattPerChannelBand&
+Event::GetRxPowerWPerBand (void) const
+{
+  return m_rxPowerW;
+}
+
+const WifiTxVector&
+Event::GetTxVector (void) const
+{
+  return m_txVector;
+}
+
+void
+Event::UpdateRxPowerW (const RxPowerWattPerChannelBand& rxPower)
+{
+  NS_ASSERT (rxPower.size () == m_rxPowerW.size ());
+  //Update power band per band
+  for (auto & currentRxPowerW : m_rxPowerW)
+    {
+      auto band = currentRxPowerW.first;
+      auto it = rxPower.find (band);
+      if (it != rxPower.end ())
+        {
+          currentRxPowerW.second += it->second;
+        }
+    }
+}
+
+std::ostream & operator << (std::ostream &os, const Event &event)
+{
+  os << "start=" << event.GetStartTime () << ", end=" << event.GetEndTime ()
+     << ", TXVECTOR=" << event.GetTxVector ()
+     << ", power=" << event.GetRxPowerW () << "W"
+     << ", PPDU=" << event.GetPpdu ();
+  return os;
+}
+
+/****************************************************************
+ *       Class which records SNIR change events for a
+ *       short period of time.
+ ****************************************************************/
+
+InterferenceHelper::NiChange::NiChange (double power, Ptr<Event> event)
+  : m_power (power),
+    m_event (event)
+{
+}
+
+InterferenceHelper::NiChange::~NiChange ()
+{
+  m_event = 0;
+}
+
+double
+InterferenceHelper::NiChange::GetPower (void) const
+{
+  return m_power;
+}
+
+void
+InterferenceHelper::NiChange::AddPower (double power)
+{
+  m_power += power;
+}
+
+Ptr<Event>
+InterferenceHelper::NiChange::GetEvent (void) const
+{
+  return m_event;
+}
+
+
+/****************************************************************
+ *       The actual InterferenceHelper
+ ****************************************************************/
+
+InterferenceHelper::InterferenceHelper ()
+  : m_errorRateModel (0),
+    m_numRxAntennas (1),
+    m_rxing (false)
+{
+  NS_LOG_FUNCTION (this);
+}
+
+InterferenceHelper::~InterferenceHelper ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+TypeId
+InterferenceHelper::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::InterferenceHelper")
+    .SetParent<ns3::Object> ()
+    .SetGroupName ("Wifi")
+    .AddConstructor<InterferenceHelper> ()
+  ;
+  return tid;
+}
+
+void
+InterferenceHelper::DoDispose (void)
+{
+  NS_LOG_FUNCTION (this);
+  RemoveBands ();
+  m_errorRateModel = 0;
+}
+
+Ptr<Event>
+InterferenceHelper::Add (Ptr<const WifiPpdu> ppdu, const WifiTxVector& txVector, Time duration, RxPowerWattPerChannelBand& rxPowerW, bool isStartOfdmaRxing)
+{
+  Ptr<Event> event = Create<Event> (ppdu, txVector, duration, std::move (rxPowerW));
+  AppendEvent (event, isStartOfdmaRxing);
+  return event;
+}
+
+void
+InterferenceHelper::AddForeignSignal (Time duration, RxPowerWattPerChannelBand& rxPowerW)
+{
+  // Parameters other than duration and rxPowerW are unused for this type
+  // of signal, so we provide dummy versions
+  WifiMacHeader hdr;
+  hdr.SetType (WIFI_MAC_QOSDATA);
+  hdr.SetQosTid (0);
+  Ptr<WifiPpdu> fakePpdu = Create<WifiPpdu> (Create<WifiPsdu> (Create<Packet> (0), hdr),
+                                             WifiTxVector ());
+  Add (fakePpdu, WifiTxVector (), duration, rxPowerW);
+}
+
+void
+InterferenceHelper::RemoveBands(void)
+{
+  NS_LOG_FUNCTION (this);
+  for (auto it : m_niChangesPerBand)
+    {
+      it.second.clear ();
+    }
+  m_niChangesPerBand.clear();
+  m_firstPowerPerBand.clear();
+}
+
+void
+InterferenceHelper::AddBand (WifiSpectrumBand band)
+{
+  NS_LOG_FUNCTION (this << band.first << band.second);
+  NS_ASSERT (m_niChangesPerBand.find (band) == m_niChangesPerBand.end ());
+  NiChanges niChanges;
+  auto result = m_niChangesPerBand.insert ({band, niChanges});
+  NS_ASSERT (result.second);
+  // Always have a zero power noise event in the list
+  AddNiChangeEvent (Time (0), NiChange (0.0, 0), result.first);
+  m_firstPowerPerBand.insert ({band, 0.0});
+}
+
+void
+InterferenceHelper::SetNoiseFigure (double value)
+{
+  m_noiseFigure = value;
+}
+
+void
+InterferenceHelper::SetErrorRateModel (const Ptr<ErrorRateModel> rate)
+{
+  m_errorRateModel = rate;
+}
+
+Ptr<ErrorRateModel>
+InterferenceHelper::GetErrorRateModel (void) const
+{
+  return m_errorRateModel;
+}
+
+void
+InterferenceHelper::SetNumberOfReceiveAntennas (uint8_t rx)
+{
+  m_numRxAntennas = rx;
+}
+
+Time
+InterferenceHelper::GetEnergyDuration (double energyW, WifiSpectrumBand band)
+{
+  Time now = Simulator::Now ();
+  auto niIt = m_niChangesPerBand.find (band);
+  NS_ASSERT (niIt != m_niChangesPerBand.end ());
+  auto i = GetPreviousPosition (now, niIt);
+  Time end = i->first;
+  for (; i != niIt->second.end (); ++i)
+    {
+      double noiseInterferenceW = i->second.GetPower ();
+      end = i->first;
+      if (noiseInterferenceW < energyW)
+        {
+          break;
+        }
+    }
+  return end > now ? end - now : MicroSeconds (0);
+}
+
+void
+InterferenceHelper::AppendEvent (Ptr<Event> event, bool isStartOfdmaRxing)
+{
+  NS_LOG_FUNCTION (this << event << isStartOfdmaRxing);
+  for (auto const& it : event->GetRxPowerWPerBand ())
+    {
+      WifiSpectrumBand band = it.first;
+      auto niIt = m_niChangesPerBand.find (band);
+      NS_ASSERT (niIt != m_niChangesPerBand.end ());
+      double previousPowerStart = 0;
+      double previousPowerEnd = 0;
+      auto previousPowerPosition = GetPreviousPosition (event->GetStartTime (), niIt);
+      previousPowerStart = previousPowerPosition->second.GetPower ();
+      previousPowerEnd = GetPreviousPosition (event->GetEndTime (), niIt)->second.GetPower ();
+      if (!m_rxing)
+        {
+          m_firstPowerPerBand.find (band)->second = previousPowerStart;
+          // Always leave the first zero power noise event in the list
+          niIt->second.erase (++(niIt->second.begin ()), ++previousPowerPosition);
+        }
+      else if (isStartOfdmaRxing)
+        {
+          //When the first UL-OFDMA payload is received, we need to set m_firstPowerPerBand
+          //so that it takes into account interferences that arrived between the start of the
+          //UL MU transmission and the start of UL-OFDMA payload.
+          m_firstPowerPerBand.find (band)->second = previousPowerStart;
+        }
+      auto first = AddNiChangeEvent (event->GetStartTime (), NiChange (previousPowerStart, event), niIt);
+      auto last = AddNiChangeEvent (event->GetEndTime (), NiChange (previousPowerEnd, event), niIt);
+      for (auto i = first; i != last; ++i)
+        {
+          i->second.AddPower (it.second);
+        }
+    }
+}
+
+void
+InterferenceHelper::UpdateEvent (Ptr<Event> event, const RxPowerWattPerChannelBand& rxPower)
+{
+  NS_LOG_FUNCTION (this << event);
+  //This is called for UL MU events, in order to scale power as long as UL MU PPDUs arrive
+  for (auto const& it : rxPower)
+    {
+      WifiSpectrumBand band = it.first;
+      auto niIt = m_niChangesPerBand.find (band);
+      NS_ASSERT (niIt != m_niChangesPerBand.end ());
+      auto first = GetPreviousPosition (event->GetStartTime (), niIt);
+      auto last = GetPreviousPosition (event->GetEndTime (), niIt);
+      for (auto i = first; i != last; ++i)
+        {
+          i->second.AddPower (it.second);
+        }
+    }
+    event->UpdateRxPowerW (rxPower);
+}
+
+double
+InterferenceHelper::CalculateSnr (double signal, double noiseInterference, uint16_t channelWidth, uint8_t nss) const
+{
+  NS_LOG_FUNCTION (this << signal << noiseInterference << channelWidth << +nss);
+  //thermal noise at 290K in J/s = W
+  static const double BOLTZMANN = 1.3803e-23;
+  //Nt is the power of thermal noise in W
+  double Nt = BOLTZMANN * 290 * channelWidth * 1e6;
+  //receiver noise Floor (W) which accounts for thermal noise and non-idealities of the receiver
+  double noiseFloor = m_noiseFigure * Nt;
+  double noise = noiseFloor + noiseInterference;
+  double snr = signal / noise; //linear scale
+  NS_LOG_DEBUG ("bandwidth(MHz)=" << channelWidth << ", signal(W)= " << signal << ", noise(W)=" << noiseFloor << ", interference(W)=" << noiseInterference << ", snr=" << RatioToDb(snr) << "dB");
+  if (m_errorRateModel->IsAwgn ())
+    {
+      double gain = 1;
+      if (m_numRxAntennas > nss)
+        {
+          gain = static_cast<double> (m_numRxAntennas) / nss; //compute gain offered by diversity for AWGN
+        }
+      NS_LOG_DEBUG ("SNR improvement thanks to diversity: " << 10 * std::log10 (gain) << "dB");
+      snr *= gain;
+    }
+  return snr;
+}
+
+double
+InterferenceHelper::CalculateNoiseInterferenceW (Ptr<Event> event, NiChangesPerBand *nis, WifiSpectrumBand band) const
+{
+  NS_LOG_FUNCTION (this << band.first << band.second);
+  auto firstPower_it = m_firstPowerPerBand.find (band);
+  NS_ASSERT (firstPower_it != m_firstPowerPerBand.end ());
+  double noiseInterferenceW = firstPower_it->second;
+  auto niIt = m_niChangesPerBand.find (band);
+  NS_ASSERT (niIt != m_niChangesPerBand.end ());
+  auto it = niIt->second.find (event->GetStartTime ());
+  for (; it != niIt->second.end () && it->first < Simulator::Now (); ++it)
+    {
+      noiseInterferenceW = it->second.GetPower () - event->GetRxPowerW (band);
+    }
+  it = niIt->second.find (event->GetStartTime ());
+  NS_ASSERT (it != niIt->second.end ());
+  for (; it != niIt->second.end () && it->second.GetEvent () != event; ++it);
+  NiChanges ni;
+  ni.emplace (event->GetStartTime (), NiChange (0, event));
+  while (++it != niIt->second.end () && it->second.GetEvent () != event)
+    {
+      ni.insert (*it);
+    }
+  ni.emplace (event->GetEndTime (), NiChange (0, event));
+  nis->insert ({band, ni});
+  NS_ASSERT_MSG (noiseInterferenceW >= 0, "CalculateNoiseInterferenceW returns negative value " << noiseInterferenceW);
+  return noiseInterferenceW;
+}
+
+double
+InterferenceHelper::CalculateChunkSuccessRate (double snir, Time duration, WifiMode mode, const WifiTxVector& txVector, WifiPpduField field) const
+{
+  if (duration.IsZero ())
+    {
+      return 1.0;
+    }
+  uint64_t rate = mode.GetDataRate (txVector.GetChannelWidth ());
+  uint64_t nbits = static_cast<uint64_t> (rate * duration.GetSeconds ());
+  double csr = m_errorRateModel->GetChunkSuccessRate (mode, txVector, snir, nbits, m_numRxAntennas, field);
+  return csr;
+}
+
+double
+InterferenceHelper::CalculatePayloadChunkSuccessRate (double snir, Time duration, const WifiTxVector& txVector, uint16_t staId) const
+{
+  if (duration.IsZero ())
+    {
+      return 1.0;
+    }
+  WifiMode mode = txVector.GetMode (staId);
+  uint64_t rate = txVector.IsNgv () ? NgvPhy::GetDataRate (txVector) : mode.GetDataRate (txVector, staId);
+  uint64_t nbits = static_cast<uint64_t> (rate * duration.GetSeconds ());
+  nbits /= txVector.GetNss (staId); //divide effective number of bits by NSS to achieve same chunk error rate as SISO for AWGN
+  double csr = m_errorRateModel->GetChunkSuccessRate (mode, txVector, snir, nbits, m_numRxAntennas, WIFI_PPDU_FIELD_DATA, staId);
+  return csr;
+}
+
+double
+InterferenceHelper::CalculatePayloadPer (Ptr<const Event> event, uint16_t channelWidth,
+                                         NiChangesPerBand *nis, WifiSpectrumBand band,
+                                         uint16_t staId, std::pair<Time, Time> window) const
+{
+  NS_LOG_FUNCTION (this << channelWidth << band.first << band.second << staId << window.first << window.second);
+  double psr = 1.0; /* Packet Success Rate */
+  const auto& niIt = nis->find (band)->second;
+  auto j = niIt.cbegin ();
+  Time previous = j->first;
+  WifiMode payloadMode = event->GetTxVector ().GetMode (staId);
+  Time phyPayloadStart = j->first;
+  if (event->GetPpdu ()->GetType () != WIFI_PPDU_TYPE_UL_MU) //j->first corresponds to the start of the UL-OFDMA payload
+    {
+      phyPayloadStart = j->first + WifiPhy::CalculatePhyPreambleAndHeaderDuration (event->GetTxVector ());
+    }
+  Time windowStart = phyPayloadStart + window.first;
+  Time windowEnd = phyPayloadStart + window.second;
+  double noiseInterferenceW = m_firstPowerPerBand.find (band)->second;
+  double powerW = event->GetRxPowerW (band);
+  while (++j != niIt.cend ())
+    {
+      Time current = j->first;
+      NS_LOG_DEBUG ("previous= " << previous << ", current=" << current);
+      NS_ASSERT (current >= previous);
+      double snr = CalculateSnr (powerW, noiseInterferenceW, channelWidth, event->GetTxVector ().GetNss (staId));
+      //Case 1: Both previous and current point to the windowed payload
+      if (previous >= windowStart)
+        {
+          psr *= CalculatePayloadChunkSuccessRate (snr, Min (windowEnd, current) - previous, event->GetTxVector (), staId);
+          NS_LOG_DEBUG ("Both previous and current point to the windowed payload: mode=" << payloadMode << ", psr=" << psr);
+        }
+      //Case 2: previous is before windowed payload and current is in the windowed payload
+      else if (current >= windowStart)
+        {
+          psr *= CalculatePayloadChunkSuccessRate (snr, Min (windowEnd, current) - windowStart, event->GetTxVector (), staId);
+          NS_LOG_DEBUG ("previous is before windowed payload and current is in the windowed payload: mode=" << payloadMode << ", psr=" << psr);
+        }
+      noiseInterferenceW = j->second.GetPower () - powerW;
+      previous = j->first;
+      if (previous > windowEnd)
+        {
+          NS_LOG_DEBUG ("Stop: new previous=" << previous << " after time window end=" << windowEnd);
+          break;
+        }
+    }
+  double per = 1 - psr;
+  return per;
+}
+
+double
+InterferenceHelper::CalculatePhyHeaderSectionPsr (Ptr<const Event> event, NiChangesPerBand *nis,
+                                                  uint16_t channelWidth, WifiSpectrumBand band,
+                                                  PhyEntity::PhyHeaderSections phyHeaderSections) const
+{
+  NS_LOG_FUNCTION (this << band.first << band.second);
+  double psr = 1.0; /* Packet Success Rate */
+  auto niIt = nis->find (band)->second;
+  auto j = niIt.begin ();
+
+  NS_ASSERT (!phyHeaderSections.empty ());
+  Time stopLastSection = Seconds (0);
+  for (const auto & section : phyHeaderSections)
+    {
+      stopLastSection = Max (stopLastSection, section.second.first.second);
+    }
+
+  Time previous = j->first;
+  double noiseInterferenceW = m_firstPowerPerBand.find (band)->second;
+  double powerW = event->GetRxPowerW (band);
+  while (++j != niIt.end ())
+    {
+      Time current = j->first;
+      NS_LOG_DEBUG ("previous= " << previous << ", current=" << current);
+      NS_ASSERT (current >= previous);
+      double snr = CalculateSnr (powerW, noiseInterferenceW, channelWidth, 1);
+      for (const auto & section : phyHeaderSections)
+        {
+          Time start = section.second.first.first;
+          Time stop = section.second.first.second;
+
+          if (previous <= stop || current >= start)
+            {
+              Time duration = Min (stop, current) - Max (start, previous);
+              if (duration.IsStrictlyPositive ())
+                {
+                  psr *= CalculateChunkSuccessRate (snr, duration, section.second.second, event->GetTxVector (), section.first);
+                  NS_LOG_DEBUG ("Current NI change in " << section.first << " [" << start << ", " << stop << "] for "
+                                << duration.As (Time::NS) << ": mode=" << section.second.second << ", psr=" << psr);
+                }
+            }
+        }
+      noiseInterferenceW = j->second.GetPower () - powerW;
+      previous = j->first;
+      if (previous > stopLastSection)
+        {
+          NS_LOG_DEBUG ("Stop: new previous=" << previous << " after stop of last section=" << stopLastSection);
+          break;
+        }
+    }
+  return psr;
+}
+
+double
+InterferenceHelper::CalculatePhyHeaderPer (Ptr<const Event> event, NiChangesPerBand *nis,
+                                           uint16_t channelWidth, WifiSpectrumBand band,
+                                           WifiPpduField header) const
+{
+  NS_LOG_FUNCTION (this << band.first << band.second << header);
+  auto niIt = nis->find (band)->second;
+  auto phyEntity = WifiPhy::GetStaticPhyEntity (event->GetTxVector ().GetModulationClass ());
+
+  PhyEntity::PhyHeaderSections sections;
+  for (const auto & section : phyEntity->GetPhyHeaderSections (event->GetTxVector (), niIt.begin ()->first))
+    {
+      if (section.first == header)
+        {
+          sections[header] = section.second;
+        }
+    }
+
+  double psr = 1.0;
+  if (!sections.empty () > 0)
+    {
+      psr = CalculatePhyHeaderSectionPsr (event, nis, channelWidth, band, sections);
+    }
+  return 1 - psr;
+}
+
+struct PhyEntity::SnrPer
+InterferenceHelper::CalculatePayloadSnrPer (Ptr<Event> event, uint16_t channelWidth, WifiSpectrumBand band,
+                                            uint16_t staId, std::pair<Time, Time> relativeMpduStartStop) const
+{
+  NS_LOG_FUNCTION (this << channelWidth << band.first << band.second << staId << relativeMpduStartStop.first << relativeMpduStartStop.second);
+  NiChangesPerBand ni;
+  double noiseInterferenceW = CalculateNoiseInterferenceW (event, &ni, band);
+  double snr = CalculateSnr (event->GetRxPowerW (band),
+                             noiseInterferenceW,
+                             channelWidth,
+                             event->GetTxVector ().GetNss (staId));
+
+  /* calculate the SNIR at the start of the MPDU (located through windowing) and accumulate
+   * all SNIR changes in the SNIR vector.
+   */
+  double per = CalculatePayloadPer (event, channelWidth, &ni, band, staId, relativeMpduStartStop);
+
+  return PhyEntity::SnrPer (snr, per);
+}
+
+double
+InterferenceHelper::CalculateSnr (Ptr<Event> event, uint16_t channelWidth, uint8_t nss, WifiSpectrumBand band) const
+{
+  NiChangesPerBand ni;
+  double noiseInterferenceW = CalculateNoiseInterferenceW (event, &ni, band);
+  double snr = CalculateSnr (event->GetRxPowerW (band),
+                             noiseInterferenceW,
+                             channelWidth,
+                             nss);
+  return snr;
+}
+
+struct PhyEntity::SnrPer
+InterferenceHelper::CalculatePhyHeaderSnrPer (Ptr<Event> event, uint16_t channelWidth, WifiSpectrumBand band,
+                                              WifiPpduField header) const
+{
+  NS_LOG_FUNCTION (this << band.first << band.second << header);
+  NiChangesPerBand ni;
+  double noiseInterferenceW = CalculateNoiseInterferenceW (event, &ni, band);
+  double snr = CalculateSnr (event->GetRxPowerW (band),
+                             noiseInterferenceW,
+                             channelWidth,
+                             1);
+
+  /* calculate the SNIR at the start of the PHY header and accumulate
+   * all SNIR changes in the SNIR vector.
+   */
+  double per = CalculatePhyHeaderPer (event, &ni, channelWidth, band, header);
+
+  return PhyEntity::SnrPer (snr, per);
+}
+
+void
+InterferenceHelper::EraseEvents (void)
+{
+  for (auto niIt = m_niChangesPerBand.begin(); niIt != m_niChangesPerBand.end(); ++niIt)
+    {
+      niIt->second.clear ();
+      // Always have a zero power noise event in the list
+      AddNiChangeEvent (Time (0), NiChange (0.0, 0), niIt);
+      m_firstPowerPerBand.at (niIt->first) = 0.0;
+    }
+  m_rxing = false;
+}
+
+InterferenceHelper::NiChanges::iterator
+InterferenceHelper::GetNextPosition (Time moment, NiChangesPerBand::iterator niIt)
+{
+  return niIt->second.upper_bound (moment);
+}
+
+InterferenceHelper::NiChanges::iterator
+InterferenceHelper::GetPreviousPosition (Time moment, NiChangesPerBand::iterator niIt)
+{
+  auto it = GetNextPosition (moment, niIt);
+  // This is safe since there is always an NiChange at time 0,
+  // before moment.
+  --it;
+  return it;
+}
+
+InterferenceHelper::NiChanges::iterator
+InterferenceHelper::AddNiChangeEvent (Time moment, NiChange change, NiChangesPerBand::iterator niIt)
+{
+  return niIt->second.insert (GetNextPosition (moment, niIt), std::make_pair (moment, change));
+}
+
+void
+InterferenceHelper::NotifyRxStart ()
+{
+  NS_LOG_FUNCTION (this);
+  m_rxing = true;
+}
+
+void
+InterferenceHelper::NotifyRxEnd (Time endTime)
+{
+  NS_LOG_FUNCTION (this << endTime);
+  m_rxing = false;
+  //Update m_firstPowerPerBand for frame capture
+  for (auto niIt = m_niChangesPerBand.begin(); niIt != m_niChangesPerBand.end(); ++niIt)
+    {
+      NS_ASSERT (niIt->second.size () > 1);
+      auto it = GetPreviousPosition (endTime, niIt);
+      it--;
+      m_firstPowerPerBand.find (niIt->first)->second = it->second.GetPower ();
+    }
+}
+
+} //namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/mac-rx-middle.cc
+++ b/src/automotive/model/SignalInfo/WiFi/mac-rx-middle.cc
@@ -1,0 +1,351 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005 INRIA
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ */
+
+#include "ns3/log.h"
+#include "ns3/sequence-number.h"
+#include "ns3/packet.h"
+#include "mac-rx-middle.h"
+#include "wifi-mac-queue-item.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("MacRxMiddle");
+
+/**
+ * A class to keep track of the packet originator status.
+ * It recomposes the packet from multiple fragments.
+ */
+class OriginatorRxStatus
+{
+private:
+  /**
+   * typedef for a list of fragments (i.e. incomplete Packet).
+   */
+  typedef std::list<Ptr<const Packet> > Fragments;
+  /**
+   * typedef for a const iterator for Fragments
+   */
+  typedef std::list<Ptr<const Packet> >::const_iterator FragmentsCI;
+
+  bool m_defragmenting; ///< flag to indicate whether we are defragmenting
+  uint16_t m_lastSequenceControl; ///< last sequence control
+  Fragments m_fragments; ///< fragments
+
+
+public:
+  OriginatorRxStatus ()
+  {
+    /* this is a magic value necessary. */
+    m_lastSequenceControl = 0xffff;
+    m_defragmenting = false;
+  }
+  ~OriginatorRxStatus ()
+  {
+    m_fragments.clear ();
+  }
+  /**
+   * Check if we are de-fragmenting packets.
+   *
+   * \return true if we are de-fragmenting packets,
+   *         false otherwise
+   */
+  bool IsDeFragmenting (void) const
+  {
+    return m_defragmenting;
+  }
+  /**
+   * We have received a first fragmented packet.
+   * We start the deframentation by saving the first fragment.
+   *
+   * \param packet the first fragmented packet
+   */
+  void AccumulateFirstFragment (Ptr<const Packet> packet)
+  {
+    NS_ASSERT (!m_defragmenting);
+    m_defragmenting = true;
+    m_fragments.push_back (packet);
+  }
+  /**
+   * We have received a last fragment of the fragmented packets
+   * (indicated by the no more fragment field).
+   * We re-construct the packet from the fragments we saved
+   * and return the full packet.
+   *
+   * \param packet the last fragment
+   *
+   * \return the fully reconstructed packet
+   */
+  Ptr<Packet> AccumulateLastFragment (Ptr<const Packet> packet)
+  {
+    NS_ASSERT (m_defragmenting);
+    m_fragments.push_back (packet);
+    m_defragmenting = false;
+    Ptr<Packet> full = Create<Packet> ();
+    for (FragmentsCI i = m_fragments.begin (); i != m_fragments.end (); i++)
+      {
+        full->AddAtEnd (*i);
+      }
+    m_fragments.erase (m_fragments.begin (), m_fragments.end ());
+    return full;
+  }
+  /**
+   * We received a fragmented packet (not first and not last).
+   * We simply save it into our internal list.
+   *
+   * \param packet the received fragment
+   */
+  void AccumulateFragment (Ptr<const Packet> packet)
+  {
+    NS_ASSERT (m_defragmenting);
+    m_fragments.push_back (packet);
+  }
+  /**
+   * Check if the sequence control (i.e. fragment number) is
+   * in order.
+   *
+   * \param sequenceControl the raw sequence control
+   *
+   * \return true if the sequence control is in order,
+   *         false otherwise
+   */
+  bool IsNextFragment (uint16_t sequenceControl) const
+  {
+    if ((sequenceControl >> 4) == (m_lastSequenceControl >> 4)
+        && (sequenceControl & 0x0f) == ((m_lastSequenceControl & 0x0f) + 1))
+      {
+        return true;
+      }
+    else
+      {
+        return false;
+      }
+  }
+  /**
+   * Return the last sequence control we received.
+   *
+   * \return the last sequence control
+   */
+  uint16_t GetLastSequenceControl (void) const
+  {
+    return m_lastSequenceControl;
+  }
+  /**
+   * Set the last sequence control we received.
+   *
+   * \param sequenceControl the last sequence control we received
+   */
+  void SetSequenceControl (uint16_t sequenceControl)
+  {
+    m_lastSequenceControl = sequenceControl;
+  }
+};
+
+
+MacRxMiddle::MacRxMiddle ()
+{
+  NS_LOG_FUNCTION_NOARGS ();
+}
+
+MacRxMiddle::~MacRxMiddle ()
+{
+  NS_LOG_FUNCTION_NOARGS ();
+  for (OriginatorsI i = m_originatorStatus.begin ();
+       i != m_originatorStatus.end (); i++)
+    {
+      delete (*i).second;
+    }
+  m_originatorStatus.erase (m_originatorStatus.begin (),
+                            m_originatorStatus.end ());
+  for (QosOriginatorsI i = m_qosOriginatorStatus.begin ();
+       i != m_qosOriginatorStatus.end (); i++)
+    {
+      delete (*i).second;
+    }
+  m_qosOriginatorStatus.erase (m_qosOriginatorStatus.begin (),
+                               m_qosOriginatorStatus.end ());
+}
+
+void
+MacRxMiddle::SetForwardCallback (ForwardUpCallback callback)
+{
+  NS_LOG_FUNCTION_NOARGS ();
+  m_callback = callback;
+}
+
+OriginatorRxStatus *
+MacRxMiddle::Lookup (const WifiMacHeader *hdr)
+{
+  NS_LOG_FUNCTION (hdr);
+  OriginatorRxStatus *originator;
+  Mac48Address source = hdr->GetAddr2 ();
+  if (hdr->IsQosData ()
+      && !hdr->GetAddr2 ().IsGroup ())
+    {
+      /* only for QoS data non-broadcast frames */
+      originator = m_qosOriginatorStatus[std::make_pair (source, hdr->GetQosTid ())];
+      if (originator == 0)
+        {
+          originator = new OriginatorRxStatus ();
+          m_qosOriginatorStatus[std::make_pair (source, hdr->GetQosTid ())] = originator;
+        }
+    }
+  else
+    {
+      /* - management frames
+       * - QoS data broadcast frames
+       * - non-QoS data frames
+       * see section 7.1.3.4.1
+       */
+      originator = m_originatorStatus[source];
+      if (originator == 0)
+        {
+          originator = new OriginatorRxStatus ();
+          m_originatorStatus[source] = originator;
+        }
+    }
+  return originator;
+}
+
+bool
+MacRxMiddle::IsDuplicate (const WifiMacHeader* hdr,
+                          OriginatorRxStatus *originator) const
+{
+  NS_LOG_FUNCTION (hdr << originator);
+  if ((hdr->IsRetry () || hdr->GetAddr1 ().IsGroup ())
+      && originator->GetLastSequenceControl () == hdr->GetSequenceControl ())
+    {
+      return true;
+    }
+  return false;
+}
+
+Ptr<const Packet>
+MacRxMiddle::HandleFragments (Ptr<const Packet> packet, const WifiMacHeader *hdr,
+                              OriginatorRxStatus *originator)
+{
+  NS_LOG_FUNCTION (packet << hdr << originator);
+  if (originator->IsDeFragmenting ())
+    {
+      if (hdr->IsMoreFragments ())
+        {
+          if (originator->IsNextFragment (hdr->GetSequenceControl ()))
+            {
+              NS_LOG_DEBUG ("accumulate fragment seq=" << hdr->GetSequenceNumber () <<
+                            ", frag=" << +hdr->GetFragmentNumber () <<
+                            ", size=" << packet->GetSize ());
+              originator->AccumulateFragment (packet);
+              originator->SetSequenceControl (hdr->GetSequenceControl ());
+            }
+          else
+            {
+              NS_LOG_DEBUG ("non-ordered fragment");
+            }
+          return 0;
+        }
+      else
+        {
+          if (originator->IsNextFragment (hdr->GetSequenceControl ()))
+            {
+              NS_LOG_DEBUG ("accumulate last fragment seq=" << hdr->GetSequenceNumber () <<
+                            ", frag=" << +hdr->GetFragmentNumber () <<
+                            ", size=" << hdr->GetSize ());
+              Ptr<Packet> p = originator->AccumulateLastFragment (packet);
+              originator->SetSequenceControl (hdr->GetSequenceControl ());
+              return p;
+            }
+          else
+            {
+              NS_LOG_DEBUG ("non-ordered fragment");
+              return 0;
+            }
+        }
+    }
+  else
+    {
+      if (hdr->IsMoreFragments ())
+        {
+          NS_LOG_DEBUG ("accumulate first fragment seq=" << hdr->GetSequenceNumber () <<
+                        ", frag=" << +hdr->GetFragmentNumber () <<
+                        ", size=" << packet->GetSize ());
+          originator->AccumulateFirstFragment (packet);
+          originator->SetSequenceControl (hdr->GetSequenceControl ());
+          return 0;
+        }
+      else
+        {
+          return packet;
+        }
+    }
+}
+
+void
+MacRxMiddle::Receive (Ptr<WifiMacQueueItem> mpdu)
+{
+  NS_LOG_FUNCTION (*mpdu);
+  const WifiMacHeader* hdr = &mpdu->GetHeader ();
+  NS_ASSERT (hdr->IsData () || hdr->IsMgt ());
+
+  OriginatorRxStatus *originator = Lookup (hdr);
+  /**
+   * The check below is really unneeded because it can fail in a lot of
+   * normal cases. Specifically, it is possible for sequence numbers to
+   * loop back to zero once they reach 0xfff0 and to go up to 0xf7f0 in
+   * which case the check below will report the two sequence numbers to
+   * not have the correct order relationship.
+   * So, this check cannot be used to discard old duplicate frames. It is
+   * thus here only for documentation purposes.
+   */
+  if (!(SequenceNumber16 (originator->GetLastSequenceControl ()) < SequenceNumber16 (hdr->GetSequenceControl ())))
+    {
+      NS_LOG_DEBUG ("Sequence numbers have looped back. last recorded=" << originator->GetLastSequenceControl () <<
+                    " currently seen=" << hdr->GetSequenceControl ());
+    }
+  //filter duplicates.
+  if (IsDuplicate (hdr, originator))
+    {
+      NS_LOG_DEBUG ("duplicate from=" << hdr->GetAddr2 () <<
+                    ", seq=" << hdr->GetSequenceNumber () <<
+                    ", frag=" << +hdr->GetFragmentNumber ());
+      return;
+    }
+  Ptr<const Packet> aggregate = HandleFragments (mpdu->GetPacket (), hdr, originator);
+  if (aggregate == 0)
+    {
+      return;
+    }
+  NS_LOG_DEBUG ("forwarding data from=" << hdr->GetAddr2 () <<
+                ", seq=" << hdr->GetSequenceNumber () <<
+                ", frag=" << +hdr->GetFragmentNumber ());
+  originator->SetSequenceControl (hdr->GetSequenceControl ());
+  if (aggregate == mpdu->GetPacket ())
+    {
+      m_callback (mpdu);
+    }
+  else
+    {
+      // We could do this in all cases, but passing the received mpdu in case of
+      // A-MSDUs saves us the time to deaggregate the A-MSDU in MSDUs (which are
+      // kept separate in the received mpdu) and allows us to pass the originally
+      // transmitted packets (i.e., with the same UID) to the receiver.
+      m_callback (Create<WifiMacQueueItem> (aggregate, *hdr));
+    }
+}
+
+} //namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/ngv/ngv-calibration.h
+++ b/src/automotive/model/SignalInfo/WiFi/ngv/ngv-calibration.h
@@ -1,0 +1,93 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Surrogate 802.11bd NGV PER parameters for VaN3Twin's current 10 MHz,
+ * NSS=1 network-simulation model.
+ *
+ * These constants are modeling assumptions, not link-level calibrated
+ * waveform results. Future work should replace them with calibrated
+ * PER-vs-SNR and midamble/Doppler parameters.
+ */
+
+#ifndef NGV_CALIBRATION_H
+#define NGV_CALIBRATION_H
+
+#include <array>
+#include <cstdint>
+
+namespace ns3 {
+namespace NgvCalibration {
+
+struct PerReference
+{
+  uint8_t mcs;
+  uint16_t channelWidthMHz;
+  uint8_t nss;
+  double snr10PercentPerDb;
+  uint32_t referenceBytes;
+};
+
+struct MidambleDopplerGain
+{
+  uint16_t periodicity;
+  double maxGainDb;
+};
+
+constexpr double PER_TRANSITION_SLOPE_DB = 1.5;
+constexpr uint16_t SERVICE_BITS = 16;
+constexpr uint16_t TAIL_BITS = 6;
+constexpr uint32_t SHORT_PPDU_SYMBOLS = 16;
+constexpr double LONG_PPDU_GAIN_NORMALIZATION_SYMBOLS = 128;
+
+constexpr std::array<PerReference, 40> PER_REFERENCES = {{
+    {0, 10, 1, 12, 4096},
+    {1, 10, 1, 15, 4096},
+    {2, 10, 1, 17, 4096},
+    {3, 10, 1, 20, 4096},
+    {4, 10, 1, 24, 4096},
+    {5, 10, 1, 28, 4096},
+    {6, 10, 1, 29, 4096},
+    {7, 10, 1, 30, 4096},
+    {8, 10, 1, 35, 4096},
+    {15, 10, 1, 9, 2048},
+    {0, 10, 2, 12, 4096},
+    {1, 10, 2, 15, 4096},
+    {2, 10, 2, 17, 4096},
+    {3, 10, 2, 20, 4096},
+    {4, 10, 2, 24, 4096},
+    {5, 10, 2, 28, 4096},
+    {6, 10, 2, 29, 4096},
+    {7, 10, 2, 30, 4096},
+    {8, 10, 2, 35, 4096},
+    {0, 20, 1, 12, 4096},
+    {1, 20, 1, 15, 4096},
+    {2, 20, 1, 17, 4096},
+    {3, 20, 1, 20, 4096},
+    {4, 20, 1, 24, 4096},
+    {5, 20, 1, 28, 4096},
+    {6, 20, 1, 29, 4096},
+    {7, 20, 1, 30, 4096},
+    {8, 20, 1, 35, 4096},
+    {9, 20, 1, 37, 4096},
+    {15, 20, 1, 12, 2048},
+    {0, 20, 2, 12, 4096},
+    {1, 20, 2, 15, 4096},
+    {2, 20, 2, 17, 4096},
+    {3, 20, 2, 20, 4096},
+    {4, 20, 2, 24, 4096},
+    {5, 20, 2, 28, 4096},
+    {6, 20, 2, 29, 4096},
+    {7, 20, 2, 30, 4096},
+    {8, 20, 2, 35, 4096},
+    {9, 20, 2, 37, 4096}
+}};
+
+constexpr std::array<MidambleDopplerGain, 3> MIDAMBLE_DOPPLER_GAINS = {{
+    {4, 2},
+    {8, 1.4},
+    {16, 0.8}
+}};
+
+} // namespace NgvCalibration
+} // namespace ns3
+
+#endif /* NGV_CALIBRATION_H */

--- a/src/automotive/model/SignalInfo/WiFi/ngv/ngv-phy.cc
+++ b/src/automotive/model/SignalInfo/WiFi/ngv/ngv-phy.cc
@@ -1,0 +1,293 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ngv-phy.h"
+#include "ngv-ppdu.h"
+
+#include "ns3/log.h"
+#include "ns3/object.h"
+#include "ns3/interference-helper.h"
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-psdu.h"
+
+#include <array>
+#include <cmath>
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("NgvPhy");
+
+namespace {
+
+struct NgvMcsParams
+{
+  uint8_t index;
+  uint16_t channelWidth;
+  uint8_t nss;
+  uint16_t dataBitsPerSymbol;
+};
+
+// Keep in sync with VehicularNgvMcs for the supported 10/20 MHz profile slices.
+constexpr std::array<NgvMcsParams, 40> g_ngvMcs = {{
+    {0, 10, 1, 26},
+    {1, 10, 1, 52},
+    {2, 10, 1, 78},
+    {3, 10, 1, 104},
+    {4, 10, 1, 156},
+    {5, 10, 1, 208},
+    {6, 10, 1, 234},
+    {7, 10, 1, 260},
+    {8, 10, 1, 312},
+    {15, 10, 1, 13},
+    {0, 10, 2, 52},
+    {1, 10, 2, 104},
+    {2, 10, 2, 156},
+    {3, 10, 2, 208},
+    {4, 10, 2, 312},
+    {5, 10, 2, 416},
+    {6, 10, 2, 468},
+    {7, 10, 2, 520},
+    {8, 10, 2, 624},
+    {0, 20, 1, 54},
+    {1, 20, 1, 108},
+    {2, 20, 1, 162},
+    {3, 20, 1, 216},
+    {4, 20, 1, 324},
+    {5, 20, 1, 432},
+    {6, 20, 1, 486},
+    {7, 20, 1, 540},
+    {8, 20, 1, 648},
+    {9, 20, 1, 720},
+    {15, 20, 1, 27},
+    {0, 20, 2, 108},
+    {1, 20, 2, 216},
+    {2, 20, 2, 324},
+    {3, 20, 2, 432},
+    {4, 20, 2, 648},
+    {5, 20, 2, 864},
+    {6, 20, 2, 972},
+    {7, 20, 2, 1080},
+    {8, 20, 2, 1296},
+    {9, 20, 2, 1440},
+}};
+
+constexpr uint64_t NGV_SYMBOL_NS = 8000;
+constexpr uint64_t NGV_LTF_1X_NS = 4800;
+constexpr uint64_t NGV_LTF_2X_NS = 8000;
+constexpr uint64_t NGV_LTF_2X_REPEAT_NS = 14400;
+constexpr uint16_t NGV_SERVICE_BITS = 16;
+constexpr uint16_t NGV_TAIL_BITS = 6;
+
+} // namespace
+
+const PhyEntity::PpduFormats NgvPhy::m_ngvPpduFormats {
+  { WIFI_PREAMBLE_LONG, { WIFI_PPDU_FIELD_PREAMBLE,      // L-STF + L-LTF
+                          WIFI_PPDU_FIELD_NON_HT_HEADER, // L-SIG + RL-SIG
+                          WIFI_PPDU_FIELD_SIG_A,         // NGV-SIG + RNGV-SIG
+                          WIFI_PPDU_FIELD_TRAINING,      // NGV-STF + NGV-LTF
+                          WIFI_PPDU_FIELD_DATA } }
+};
+
+NgvPhy::NgvPhy ()
+  : OfdmPhy (OFDM_PHY_10_MHZ, false)
+{
+  NS_LOG_FUNCTION (this);
+}
+
+NgvPhy::~NgvPhy ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+WifiMode
+NgvPhy::GetSigMode (WifiPpduField field, const WifiTxVector& txVector) const
+{
+  switch (field)
+    {
+      case WIFI_PPDU_FIELD_PREAMBLE:
+      case WIFI_PPDU_FIELD_NON_HT_HEADER:
+      case WIFI_PPDU_FIELD_SIG_A:
+      case WIFI_PPDU_FIELD_TRAINING:
+        return GetHeaderMode (txVector);
+      default:
+        return OfdmPhy::GetSigMode (field, txVector);
+    }
+}
+
+const PhyEntity::PpduFormats&
+NgvPhy::GetPpduFormats (void) const
+{
+  return m_ngvPpduFormats;
+}
+
+Time
+NgvPhy::GetDuration (WifiPpduField field, const WifiTxVector& txVector) const
+{
+  if (!txVector.IsNgv ())
+    {
+      return OfdmPhy::GetDuration (field, txVector);
+    }
+
+  switch (field)
+    {
+      case WIFI_PPDU_FIELD_PREAMBLE:
+        return MicroSeconds (32); // L-STF + L-LTF for CBW10
+      case WIFI_PPDU_FIELD_NON_HT_HEADER:
+        return MicroSeconds (16); // L-SIG + RL-SIG
+      case WIFI_PPDU_FIELD_SIG_A:
+        return MicroSeconds (16); // NGV-SIG + RNGV-SIG
+      case WIFI_PPDU_FIELD_TRAINING:
+        return MicroSeconds (8) + GetNgvLtfSymbolDuration (txVector) * GetNgvLtfSymbolCount (txVector);
+      case WIFI_PPDU_FIELD_HT_SIG:
+      case WIFI_PPDU_FIELD_SIG_B:
+        return NanoSeconds (0);
+      default:
+        return OfdmPhy::GetDuration (field, txVector);
+    }
+}
+
+Time
+NgvPhy::GetPayloadDuration (uint32_t size, const WifiTxVector& txVector, WifiPhyBand /* band */,
+                            MpduType /* mpdutype */, bool /* incFlag */, uint32_t& /* totalAmpduSize */,
+                            double& /* totalAmpduNumSymbols */, uint16_t /* staId */) const
+{
+  NS_ABORT_MSG_IF (!txVector.IsNgv (), "NgvPhy can only calculate NGV payload duration");
+
+  const uint32_t numSymbols = GetNgvDataSymbolCount (size, txVector);
+  const uint16_t midamblePeriodicity = GetMidamblePeriodicity (txVector);
+  const uint32_t numMidambles = (midamblePeriodicity == 0 || numSymbols == 0)
+                                    ? 0
+                                    : (numSymbols - 1) / midamblePeriodicity;
+  const Time midambleDuration = GetNgvLtfSymbolDuration (txVector) * GetNgvLtfSymbolCount (txVector);
+
+  return NanoSeconds (numSymbols * NGV_SYMBOL_NS) + numMidambles * midambleDuration;
+}
+
+uint16_t
+NgvPhy::GetDataBitsPerSymbol (const WifiTxVector& txVector)
+{
+  const uint16_t channelWidth = txVector.GetChannelWidth ();
+  const uint8_t nss = txVector.GetNss ();
+  for (const auto& mcs : g_ngvMcs)
+    {
+      if (mcs.index == txVector.GetNgvMcs () && mcs.channelWidth == channelWidth && mcs.nss == nss)
+        {
+          return mcs.dataBitsPerSymbol;
+        }
+    }
+  NS_ABORT_MSG ("Invalid or reserved NGV-MCS index for " << channelWidth << " MHz, NSS=" << +nss);
+  return 0;
+}
+
+uint64_t
+NgvPhy::GetDataRate (const WifiTxVector& txVector)
+{
+  return static_cast<uint64_t> (GetDataBitsPerSymbol (txVector) * (1000000000ull / NGV_SYMBOL_NS));
+}
+
+Ptr<WifiPpdu>
+NgvPhy::BuildPpdu (const WifiConstPsduMap& psdus, const WifiTxVector& txVector, Time ppduDuration)
+{
+  NS_LOG_FUNCTION (this << psdus << txVector << ppduDuration);
+  NS_ABORT_MSG_IF (!txVector.IsNgv (), "NgvPhy can only build NGV PPDUs");
+  NS_ABORT_MSG_IF (psdus.size () != 1, "NGV MU PPDUs are not implemented");
+  return Create<NgvPpdu> (psdus.begin ()->second,
+                          txVector,
+                          m_wifiPhy->GetPhyBand (),
+                          ObtainNextUid (txVector),
+                          ppduDuration);
+}
+
+PhyEntity::PhyFieldRxStatus
+NgvPhy::DoEndReceiveField (WifiPpduField field, Ptr<Event> event)
+{
+  NS_LOG_FUNCTION (this << field << *event);
+  switch (field)
+    {
+      case WIFI_PPDU_FIELD_PREAMBLE:
+        return OfdmPhy::DoEndReceiveField (field, event);
+      case WIFI_PPDU_FIELD_NON_HT_HEADER:
+      case WIFI_PPDU_FIELD_SIG_A:
+      case WIFI_PPDU_FIELD_TRAINING:
+        {
+          SnrPer snrPer = GetPhyHeaderSnrPer (field, event);
+          PhyFieldRxStatus status (GetRandomValue () > snrPer.per);
+          if (status.isSuccess)
+            {
+              if (!IsAllConfigSupported (field, event->GetPpdu ()))
+                {
+                  status = PhyFieldRxStatus (false, UNSUPPORTED_SETTINGS, DROP);
+                }
+            }
+          else
+            {
+              status.reason = (field == WIFI_PPDU_FIELD_NON_HT_HEADER) ? L_SIG_FAILURE : SIG_A_FAILURE;
+              status.actionIfFailure = ABORT;
+            }
+          return status;
+        }
+      default:
+        return OfdmPhy::DoEndReceiveField (field, event);
+    }
+}
+
+bool
+NgvPhy::IsConfigSupported (Ptr<const WifiPpdu> ppdu) const
+{
+  const WifiTxVector txVector = ppdu->GetTxVector ();
+  return txVector.IsNgv () && txVector.IsValid () && txVector.GetModulationClass () == WIFI_MOD_CLASS_NGV;
+}
+
+Time
+NgvPhy::GetNgvLtfSymbolDuration (const WifiTxVector& txVector)
+{
+  switch (txVector.GetNgvLtfType ())
+    {
+      case WifiNgvLtfType::NGV_LTF_1X:
+        return NanoSeconds (NGV_LTF_1X_NS);
+      case WifiNgvLtfType::NGV_LTF_2X:
+        return NanoSeconds (NGV_LTF_2X_NS);
+      case WifiNgvLtfType::NGV_LTF_2X_REPEAT:
+        return NanoSeconds (NGV_LTF_2X_REPEAT_NS);
+      default:
+        NS_ABORT_MSG ("Unknown NGV-LTF type");
+    }
+  return NanoSeconds (NGV_LTF_2X_NS);
+}
+
+uint16_t
+NgvPhy::GetNgvLtfSymbolCount (const WifiTxVector& txVector)
+{
+  NS_ABORT_MSG_IF (txVector.GetNss () == 0 || txVector.GetNss () > 2,
+                   "Only NGV NSS=1 and NSS=2 are implemented");
+  return txVector.GetNss ();
+}
+
+uint16_t
+NgvPhy::GetMidamblePeriodicity (const WifiTxVector& txVector)
+{
+  const uint16_t periodicity = txVector.GetNgvMidamblePeriodicity ();
+  if (periodicity == 4 || periodicity == 8 || periodicity == 16)
+    {
+      return periodicity;
+    }
+  return 0;
+}
+
+uint32_t
+NgvPhy::GetNgvDataSymbolCount (uint32_t size, const WifiTxVector& txVector)
+{
+  const uint16_t dataBitsPerSymbol = GetDataBitsPerSymbol (txVector);
+  const double codedBits = NGV_SERVICE_BITS + size * 8.0 + NGV_TAIL_BITS;
+  return static_cast<uint32_t> (std::ceil (codedBits / dataBitsPerSymbol));
+}
+
+static class NgvPhyConstructor
+{
+public:
+  NgvPhyConstructor ()
+  {
+    WifiPhy::AddStaticPhyEntity (WIFI_MOD_CLASS_NGV, Create<NgvPhy> ());
+  }
+} g_ngvPhyConstructor;
+
+} // namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/ngv/ngv-phy.h
+++ b/src/automotive/model/SignalInfo/WiFi/ngv/ngv-phy.h
@@ -1,0 +1,64 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#ifndef NGV_PHY_H
+#define NGV_PHY_H
+
+#include "ns3/ofdm-phy.h"
+
+namespace ns3 {
+
+/**
+ * \brief PHY entity for 802.11bd NGV PPDUs.
+ * \ingroup wifi
+ *
+ * This first NGV entity models the 10 MHz, NSS=1 PPDU timing path used by
+ * VaN3Twin's vehicular 802.11bd profile.
+ */
+class NgvPhy : public OfdmPhy
+{
+public:
+  NgvPhy ();
+  ~NgvPhy () override;
+
+  WifiMode GetSigMode (WifiPpduField field, const WifiTxVector& txVector) const override;
+  const PpduFormats& GetPpduFormats (void) const override;
+  Time GetDuration (WifiPpduField field, const WifiTxVector& txVector) const override;
+  Time GetPayloadDuration (uint32_t size, const WifiTxVector& txVector, WifiPhyBand band, MpduType mpdutype,
+                           bool incFlag, uint32_t& totalAmpduSize, double& totalAmpduNumSymbols,
+                           uint16_t staId) const override;
+  Ptr<WifiPpdu> BuildPpdu (const WifiConstPsduMap& psdus, const WifiTxVector& txVector, Time ppduDuration) override;
+
+  /**
+   * Return the number of coded Data bits per NGV OFDM symbol for the current
+   * 10 MHz / NSS=1 implementation subset.
+   *
+   * \param txVector the NGV TXVECTOR
+   * \return NGV Data bits per symbol
+   */
+  static uint16_t GetDataBitsPerSymbol (const WifiTxVector& txVector);
+
+  /**
+   * Return the NGV Data field rate in bit/s for the current 10 MHz / NSS=1
+   * implementation subset.
+   *
+   * \param txVector the NGV TXVECTOR
+   * \return NGV Data rate in bit/s
+   */
+  static uint64_t GetDataRate (const WifiTxVector& txVector);
+
+protected:
+  PhyFieldRxStatus DoEndReceiveField (WifiPpduField field, Ptr<Event> event) override;
+  bool IsConfigSupported (Ptr<const WifiPpdu> ppdu) const override;
+
+private:
+  static Time GetNgvLtfSymbolDuration (const WifiTxVector& txVector);
+  static uint16_t GetNgvLtfSymbolCount (const WifiTxVector& txVector);
+  static uint16_t GetMidamblePeriodicity (const WifiTxVector& txVector);
+  static uint32_t GetNgvDataSymbolCount (uint32_t size, const WifiTxVector& txVector);
+
+  static const PpduFormats m_ngvPpduFormats; //!< NGV PPDU format
+};
+
+} // namespace ns3
+
+#endif /* NGV_PHY_H */

--- a/src/automotive/model/SignalInfo/WiFi/ngv/ngv-ppdu.cc
+++ b/src/automotive/model/SignalInfo/WiFi/ngv/ngv-ppdu.cc
@@ -1,0 +1,47 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ngv-ppdu.h"
+
+#include "ns3/log.h"
+#include "ns3/wifi-psdu.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("NgvPpdu");
+
+NgvPpdu::NgvPpdu (Ptr<const WifiPsdu> psdu,
+                  const WifiTxVector& txVector,
+                  WifiPhyBand band,
+                  uint64_t uid,
+                  Time txDuration)
+  : WifiPpdu (psdu, txVector, uid),
+    m_txVector (txVector),
+    m_band (band),
+    m_txDuration (txDuration)
+{
+  NS_LOG_FUNCTION (this << psdu << txVector << band << uid << txDuration);
+}
+
+NgvPpdu::~NgvPpdu ()
+{
+}
+
+WifiTxVector
+NgvPpdu::DoGetTxVector (void) const
+{
+  return m_txVector;
+}
+
+Time
+NgvPpdu::GetTxDuration (void) const
+{
+  return m_txDuration;
+}
+
+Ptr<WifiPpdu>
+NgvPpdu::Copy (void) const
+{
+  return Create<NgvPpdu> (GetPsdu (), GetTxVector (), m_band, m_uid, m_txDuration);
+}
+
+} // namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/ngv/ngv-ppdu.h
+++ b/src/automotive/model/SignalInfo/WiFi/ngv/ngv-ppdu.h
@@ -1,0 +1,41 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#ifndef NGV_PPDU_H
+#define NGV_PPDU_H
+
+#include "ns3/wifi-phy-band.h"
+#include "ns3/wifi-ppdu.h"
+
+namespace ns3 {
+
+/**
+ * \brief NGV PPDU (IEEE 802.11bd Clause 32).
+ * \ingroup wifi
+ *
+ * This PPDU stores the full 802.11bd TXVECTOR metadata instead of
+ * reconstructing it from the legacy L-SIG field.
+ */
+class NgvPpdu : public WifiPpdu
+{
+public:
+  NgvPpdu (Ptr<const WifiPsdu> psdu,
+           const WifiTxVector& txVector,
+           WifiPhyBand band,
+           uint64_t uid,
+           Time txDuration);
+  ~NgvPpdu () override;
+
+  Time GetTxDuration (void) const override;
+  Ptr<WifiPpdu> Copy (void) const override;
+
+private:
+  WifiTxVector DoGetTxVector (void) const override;
+
+  WifiTxVector m_txVector; //!< TXVECTOR used for the NGV PPDU
+  WifiPhyBand m_band;      //!< band used by this PPDU
+  Time m_txDuration;       //!< cached NGV TX duration
+};
+
+} // namespace ns3
+
+#endif /* NGV_PPDU_H */

--- a/src/automotive/model/SignalInfo/WiFi/non-ht/ofdm-ppdu.cc
+++ b/src/automotive/model/SignalInfo/WiFi/non-ht/ofdm-ppdu.cc
@@ -1,0 +1,266 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2020 Orange Labs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Rediet <getachew.redieteab@orange.com>
+ *         Muhammad Iqbal Rochman <muhiqbalcr@uchicago.edu>
+ *         Sébastien Deronne <sebastien.deronne@gmail.com> (LSigHeader)
+ */
+
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-psdu.h"
+#include "ofdm-phy.h"
+#include "ofdm-ppdu.h"
+#include "ns3/log.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("OfdmPpdu");
+
+OfdmPpdu::OfdmPpdu (Ptr<const WifiPsdu> psdu, const WifiTxVector& txVector,
+                    WifiPhyBand band, uint64_t uid,
+                    bool instantiateLSig /* = true */)
+  : WifiPpdu (psdu, txVector, uid),
+    m_band (band),
+    m_channelWidth (txVector.GetChannelWidth ()),
+    m_txVector (txVector),
+    m_preserveTxVector (txVector.IsNonNgv20Duplicate ())
+{
+  NS_LOG_FUNCTION (this << psdu << txVector << band << uid);
+  if (instantiateLSig)
+    {
+      m_lSig.SetRate (txVector.GetMode ().GetDataRate (txVector), m_channelWidth);
+      m_lSig.SetLength (psdu->GetSize ());
+    }
+}
+
+OfdmPpdu::~OfdmPpdu ()
+{
+}
+
+WifiTxVector
+OfdmPpdu::DoGetTxVector (void) const
+{
+  if (m_preserveTxVector)
+    {
+      return m_txVector;
+    }
+
+  WifiTxVector txVector;
+  txVector.SetPreambleType (m_preamble);
+  //OFDM uses 20 MHz, unless PHY channel width is 5 MHz or 10 MHz
+  uint16_t channelWidth = m_channelWidth < 20 ? m_channelWidth : 20;
+  txVector.SetMode (OfdmPhy::GetOfdmRate (m_lSig.GetRate (m_channelWidth), channelWidth));
+  txVector.SetChannelWidth (channelWidth);
+  return txVector;
+}
+
+Time
+OfdmPpdu::GetTxDuration (void) const
+{
+  Time ppduDuration = Seconds (0);
+  const WifiTxVector& txVector = GetTxVector ();
+  ppduDuration = WifiPhy::CalculateTxDuration (m_lSig.GetLength (), txVector, m_band);
+  return ppduDuration;
+}
+
+Ptr<WifiPpdu>
+OfdmPpdu::Copy (void) const
+{
+  return Create<OfdmPpdu> (GetPsdu (), GetTxVector (), m_band, m_uid);
+}
+
+OfdmPpdu::LSigHeader::LSigHeader ()
+  : m_rate (0b1101),
+    m_length (0)
+{
+}
+
+OfdmPpdu::LSigHeader::~LSigHeader ()
+{
+}
+
+TypeId
+OfdmPpdu::LSigHeader::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::LSigHeader")
+    .SetParent<Header> ()
+    .SetGroupName ("Wifi")
+    .AddConstructor<LSigHeader> ()
+  ;
+  return tid;
+}
+
+TypeId
+OfdmPpdu::LSigHeader::GetInstanceTypeId (void) const
+{
+  return GetTypeId ();
+}
+
+void
+OfdmPpdu::LSigHeader::Print (std::ostream &os) const
+{
+  os << "SIGNAL=" << GetRate ()
+     << " LENGTH=" << m_length;
+}
+
+uint32_t
+OfdmPpdu::LSigHeader::GetSerializedSize (void) const
+{
+  return 3;
+}
+
+void
+OfdmPpdu::LSigHeader::SetRate (uint64_t rate, uint16_t channelWidth)
+{
+  if (channelWidth == 5)
+    {
+      rate *= 4; //corresponding 20 MHz rate if 5 MHz is used
+    }
+  else if (channelWidth == 10)
+    {
+      rate *= 2; //corresponding 20 MHz rate if 10 MHz is used
+    }
+  /* Here is the binary representation for a given rate:
+   * 6 Mbit/s: 1101
+   * 9 Mbit/s: 1111
+   * 12 Mbit/s: 0101
+   * 18 Mbit/s: 0111
+   * 24 Mbit/s: 1001
+   * 36 Mbit/s: 1011
+   * 48 Mbit/s: 0001
+   * 54 Mbit/s: 0011
+   */
+  switch (rate)
+    {
+      case 6000000:
+        m_rate = 0b1101;
+        break;
+      case 9000000:
+        m_rate = 0b1111;
+        break;
+      case 12000000:
+        m_rate = 0b0101;
+        break;
+      case 18000000:
+        m_rate = 0b0111;
+        break;
+      case 24000000:
+        m_rate = 0b1001;
+        break;
+      case 36000000:
+        m_rate = 0b1011;
+        break;
+      case 48000000:
+        m_rate = 0b0001;
+        break;
+      case 54000000:
+        m_rate = 0b0011;
+        break;
+      default:
+        NS_ASSERT_MSG (false, "Invalid rate");
+        break;
+    }
+}
+
+uint64_t
+OfdmPpdu::LSigHeader::GetRate (uint16_t channelWidth) const
+{
+  uint64_t rate = 0;
+  switch (m_rate)
+    {
+      case 0b1101:
+        rate = 6000000;
+        break;
+      case 0b1111:
+        rate = 9000000;
+        break;
+      case 0b0101:
+        rate = 12000000;
+        break;
+      case 0b0111:
+        rate = 18000000;
+        break;
+      case 0b1001:
+        rate = 24000000;
+        break;
+      case 0b1011:
+        rate = 36000000;
+        break;
+      case 0b0001:
+        rate = 48000000;
+        break;
+      case 0b0011:
+        rate = 54000000;
+        break;
+      default:
+        NS_ASSERT_MSG (false, "Invalid rate");
+        break;
+    }
+  if (channelWidth == 5)
+    {
+      rate /= 4; //compute corresponding 5 MHz rate
+    }
+  else if (channelWidth == 10)
+    {
+      rate /= 2; //compute corresponding 10 MHz rate
+    }
+  return rate;
+}
+
+void
+OfdmPpdu::LSigHeader::SetLength (uint16_t length)
+{
+  NS_ASSERT_MSG (length < 4096, "Invalid length");
+  m_length = length;
+}
+
+uint16_t
+OfdmPpdu::LSigHeader::GetLength (void) const
+{
+  return m_length;
+}
+
+void
+OfdmPpdu::LSigHeader::Serialize (Buffer::Iterator start) const
+{
+  uint8_t byte = 0;
+  uint16_t bytes = 0;
+
+  byte |= m_rate;
+  byte |= (m_length & 0x07) << 5;
+  start.WriteU8 (byte);
+
+  bytes |= (m_length & 0x0ff8) >> 3;
+  start.WriteU16 (bytes);
+}
+
+uint32_t
+OfdmPpdu::LSigHeader::Deserialize (Buffer::Iterator start)
+{
+  Buffer::Iterator i = start;
+
+  uint8_t byte = i.ReadU8 ();
+  m_rate = byte & 0x0f;
+  m_length = (byte >> 5) & 0x07;
+
+  uint16_t bytes = i.ReadU16 ();
+  m_length |= (bytes << 3) & 0x0ff8;
+
+  return i.GetDistanceFrom (start);
+}
+
+} //namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/non-ht/ofdm-ppdu.h
+++ b/src/automotive/model/SignalInfo/WiFi/non-ht/ofdm-ppdu.h
@@ -1,0 +1,138 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2020 Orange Labs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Rediet <getachew.redieteab@orange.com>
+ *         Muhammad Iqbal Rochman <muhiqbalcr@uchicago.edu>
+ *         Sébastien Deronne <sebastien.deronne@gmail.com> (LSigHeader)
+ */
+
+#ifndef OFDM_PPDU_H
+#define OFDM_PPDU_H
+
+#include "ns3/wifi-phy-band.h"
+#include "ns3/wifi-ppdu.h"
+#include "ns3/header.h"
+
+/**
+ * \file
+ * \ingroup wifi
+ * Declaration of ns3::OfdmPpdu class.
+ */
+
+namespace ns3 {
+
+class WifiPsdu;
+
+/**
+ * \brief OFDM PPDU (11a)
+ * \ingroup wifi
+ *
+ * OfdmPpdu stores a preamble, PHY headers and a PSDU of a PPDU with non-HT header,
+ * i.e., PPDU that uses OFDM modulation.
+ */
+class OfdmPpdu : public WifiPpdu
+{
+public:
+
+  /**
+   * OFDM and ERP OFDM L-SIG PHY header.
+   * See section 17.3.4 in IEEE 802.11-2016.
+   */
+  class LSigHeader : public Header
+  {
+  public:
+    LSigHeader ();
+    virtual ~LSigHeader ();
+
+    /**
+     * \brief Get the type ID.
+     * \return the object TypeId
+     */
+    static TypeId GetTypeId (void);
+
+    TypeId GetInstanceTypeId (void) const override;
+    void Print (std::ostream &os) const override;
+    uint32_t GetSerializedSize (void) const override;
+    void Serialize (Buffer::Iterator start) const override;
+    uint32_t Deserialize (Buffer::Iterator start) override;
+
+    /**
+     * Fill the RATE field of L-SIG (in bit/s).
+     *
+     * \param rate the RATE field of L-SIG expressed in bit/s
+     * \param channelWidth the channel width (in MHz)
+     */
+    void SetRate (uint64_t rate, uint16_t channelWidth = 20);
+    /**
+     * Return the RATE field of L-SIG (in bit/s).
+     *
+     * \param channelWidth the channel width (in MHz)
+     * \return the RATE field of L-SIG expressed in bit/s
+     */
+    uint64_t GetRate (uint16_t channelWidth = 20) const;
+    /**
+     * Fill the LENGTH field of L-SIG (in bytes).
+     *
+     * \param length the LENGTH field of L-SIG expressed in bytes
+     */
+    void SetLength (uint16_t length);
+    /**
+     * Return the LENGTH field of L-SIG (in bytes).
+     *
+     * \return the LENGTH field of L-SIG expressed in bytes
+     */
+    uint16_t GetLength (void) const;
+
+  private:
+    uint8_t m_rate;    ///< RATE field
+    uint16_t m_length; ///< LENGTH field
+  }; //class LSigHeader
+
+  /**
+   * Create an OFDM PPDU.
+   *
+   * \param psdu the PHY payload (PSDU)
+   * \param txVector the TXVECTOR that was used for this PPDU
+   * \param band the WifiPhyBand used for the transmission of this PPDU
+   * \param uid the unique ID of this PPDU
+   * \param instantiateLSig flag used to instantiate LSigHeader (set LSigHeader's
+   *                        rate and length), should be disabled by child classes
+   */
+  OfdmPpdu (Ptr<const WifiPsdu> psdu, const WifiTxVector& txVector, WifiPhyBand band, uint64_t uid,
+            bool instantiateLSig = true);
+  /**
+   * Destructor for OfdmPpdu.
+   */
+  virtual ~OfdmPpdu ();
+
+  Time GetTxDuration (void) const override;
+  Ptr<WifiPpdu> Copy (void) const override;
+
+protected:
+  WifiPhyBand m_band;       //!< the WifiPhyBand used to transmit that PPDU
+  uint16_t m_channelWidth;  //!< the channel width used to transmit that PPDU in MHz
+  LSigHeader m_lSig;        //!< the L-SIG PHY header
+  WifiTxVector m_txVector;  //!< original TXVECTOR for 802.11bd non-NGV duplicate metadata
+  bool m_preserveTxVector;  //!< preserve the original TXVECTOR instead of reconstructing it from L-SIG
+
+private:
+  WifiTxVector DoGetTxVector (void) const override;
+}; //class OfdmPpdu
+
+} //namespace ns3
+
+#endif /* OFDM_PPDU_H */

--- a/src/automotive/model/SignalInfo/WiFi/ocb-wifi-mac.cc
+++ b/src/automotive/model/SignalInfo/WiFi/ocb-wifi-mac.cc
@@ -407,7 +407,7 @@ void
 OcbWifiMac::ConfigureStandard (enum WifiStandard standard)
 {
   NS_LOG_FUNCTION (this << standard);
-  NS_ASSERT (standard == WIFI_STANDARD_80211p);
+  NS_ASSERT (standard == WIFI_STANDARD_80211p || standard == WIFI_STANDARD_80211bd);
 
   uint32_t cwmin = 15;
   uint32_t cwmax = 1023;
@@ -421,8 +421,7 @@ OcbWifiMac::ConfigureStandard (enum WifiStandard standard)
   else
     {
       // Now we configure the EDCA functions
-      // see IEEE802.11p-2010 section 7.3.2.29
-      // Wave CCH and SCHs set default 802.11p EDCA
+      // Wave CCH and SCHs set the default vehicular OCB EDCA parameters.
       ConfigureEdca (cwmin, cwmax, 2, AC_VO);
       ConfigureEdca (cwmin, cwmax, 3, AC_VI);
       ConfigureEdca (cwmin, cwmax, 6, AC_BE);

--- a/src/automotive/model/SignalInfo/WiFi/spectrum-wifi-phy.cc
+++ b/src/automotive/model/SignalInfo/WiFi/spectrum-wifi-phy.cc
@@ -1,0 +1,551 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006 INRIA
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ *          Ghada Badawy <gbadawy@gmail.com>
+ *          Sébastien Deronne <sebastien.deronne@gmail.com>
+ *
+ * Ported from yans-wifi-phy.cc by several contributors starting
+ * with Nicola Baldo and Dean Armstrong
+ */
+
+#include "ns3/log.h"
+#include "ns3/double.h"
+#include "ns3/boolean.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/node.h"
+#include "ns3/simulator.h"
+#include "spectrum-wifi-phy.h"
+#include "wifi-spectrum-phy-interface.h"
+#include "wifi-spectrum-signal-parameters.h"
+#include "interference-helper.h"
+#include "wifi-utils.h"
+#include "wifi-psdu.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("SpectrumWifiPhy");
+
+NS_OBJECT_ENSURE_REGISTERED (SpectrumWifiPhy);
+
+TypeId
+SpectrumWifiPhy::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::SpectrumWifiPhy")
+    .SetParent<WifiPhy> ()
+    .SetGroupName ("Wifi")
+    .AddConstructor<SpectrumWifiPhy> ()
+    .AddAttribute ("DisableWifiReception",
+                   "Prevent Wi-Fi frame sync from ever happening",
+                   BooleanValue (false),
+                   MakeBooleanAccessor (&SpectrumWifiPhy::m_disableWifiReception),
+                   MakeBooleanChecker ())
+    .AddAttribute ("TxMaskInnerBandMinimumRejection",
+                   "Minimum rejection (dBr) for the inner band of the transmit spectrum mask",
+                   DoubleValue (-20.0),
+                   MakeDoubleAccessor (&SpectrumWifiPhy::m_txMaskInnerBandMinimumRejection),
+                   MakeDoubleChecker<double> ())
+    .AddAttribute ("TxMaskOuterBandMinimumRejection",
+                   "Minimum rejection (dBr) for the outer band of the transmit spectrum mask",
+                   DoubleValue (-28.0),
+                   MakeDoubleAccessor (&SpectrumWifiPhy::m_txMaskOuterBandMinimumRejection),
+                   MakeDoubleChecker<double> ())
+    .AddAttribute ("TxMaskOuterBandMaximumRejection",
+                   "Maximum rejection (dBr) for the outer band of the transmit spectrum mask",
+                   DoubleValue (-40.0),
+                   MakeDoubleAccessor (&SpectrumWifiPhy::m_txMaskOuterBandMaximumRejection),
+                   MakeDoubleChecker<double> ())
+    .AddTraceSource ("SignalArrival",
+                     "Signal arrival",
+                     MakeTraceSourceAccessor (&SpectrumWifiPhy::m_signalCb),
+                     "ns3::SpectrumWifiPhy::SignalArrivalCallback")
+  ;
+  return tid;
+}
+
+SpectrumWifiPhy::SpectrumWifiPhy ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+SpectrumWifiPhy::~SpectrumWifiPhy ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+void
+SpectrumWifiPhy::DoDispose (void)
+{
+  NS_LOG_FUNCTION (this);
+  m_channel = 0;
+  m_wifiSpectrumPhyInterface = 0;
+  m_antenna = 0;
+  m_rxSpectrumModel = 0;
+  m_ruBands.clear ();
+  WifiPhy::DoDispose ();
+}
+
+void
+SpectrumWifiPhy::DoInitialize (void)
+{
+  NS_LOG_FUNCTION (this);
+  WifiPhy::DoInitialize ();
+  // This connection is deferred until frequency and channel width are set
+  if (m_channel && m_wifiSpectrumPhyInterface)
+    {
+      m_channel->AddRx (m_wifiSpectrumPhyInterface);
+    }
+  else
+    {
+      NS_FATAL_ERROR ("SpectrumWifiPhy misses channel and WifiSpectrumPhyInterface objects at initialization time");
+    }
+}
+
+Ptr<const SpectrumModel>
+SpectrumWifiPhy::GetRxSpectrumModel ()
+{
+  NS_LOG_FUNCTION (this);
+  if (m_rxSpectrumModel)
+    {
+      return m_rxSpectrumModel;
+    }
+  else
+    {
+      if (GetFrequency () == 0)
+        {
+          NS_LOG_DEBUG ("Frequency is not set; returning 0");
+          return 0;
+        }
+      else
+        {
+          uint16_t channelWidth = GetChannelWidth ();
+          NS_LOG_DEBUG ("Creating spectrum model from frequency/width pair of (" << GetFrequency () << ", " << channelWidth << ")");
+          m_rxSpectrumModel = WifiSpectrumValueHelper::GetSpectrumModel (GetFrequency (), channelWidth, GetBandBandwidth (), GetGuardBandwidth (channelWidth));
+          UpdateInterferenceHelperBands ();
+        }
+    }
+  return m_rxSpectrumModel;
+}
+
+void
+SpectrumWifiPhy::UpdateInterferenceHelperBands (void)
+{
+  NS_LOG_FUNCTION (this);
+  uint16_t channelWidth = GetChannelWidth ();
+  m_interference->RemoveBands ();
+  if (channelWidth < 20)
+    {
+      WifiSpectrumBand band = GetBand (channelWidth);
+      m_interference->AddBand (band);
+    }
+  else
+    {
+      for (uint16_t bw = 160; bw >= 20; bw = bw / 2)
+        {
+          for (uint8_t i = 0; i < (channelWidth / bw); ++i)
+            {
+              m_interference->AddBand (GetBand (bw, i));
+            }
+        }
+    }
+  if (GetStandard () >= WIFI_STANDARD_80211ax)
+    {
+      // For a given RU type, some RUs over a channel occupy the same tones as
+      // the corresponding RUs over a subchannel, while some others not. For instance,
+      // the first nine 26-tone RUs over an 80 MHz channel occupy the same tones as
+      // the first nine 26-tone RUs over the lowest 40 MHz subchannel. Therefore, we
+      // need to store all the bands in a set (which removes duplicates) and then
+      // pass the elements in the set to AddBand (to which we cannot pass duplicates)
+      if (m_ruBands[channelWidth].empty ())
+        {
+          for (uint16_t bw = 160; bw >= 20; bw = bw / 2)
+            {
+              for (uint8_t i = 0; i < (channelWidth / bw); ++i)
+                {
+                  for (unsigned int type = 0; type < 7; type++)
+                    {
+                      HeRu::RuType ruType = static_cast <HeRu::RuType> (type);
+                      std::size_t nRus = HeRu::GetNRus (bw, ruType);
+                      for (std::size_t phyIndex = 1; phyIndex <= nRus; phyIndex++)
+                        {
+                          HeRu::SubcarrierGroup group = HeRu::GetSubcarrierGroup (bw, ruType, phyIndex);
+                          HeRu::SubcarrierRange range = std::make_pair (group.front ().first, group.back ().second);
+                          WifiSpectrumBand band = ConvertHeRuSubcarriers (bw, GetGuardBandwidth (channelWidth),
+                                                                          range, i);
+                          std::size_t index = (bw == 160 && phyIndex > nRus / 2
+                                               ? phyIndex - nRus / 2 : phyIndex);
+                          bool primary80IsLower80 = (GetOperatingChannel ().GetPrimaryChannelIndex (20)
+                                                     < bw / 40);
+                          bool primary80 = (bw < 160
+                                            || ruType == HeRu::RU_2x996_TONE
+                                            || (primary80IsLower80 && phyIndex <= nRus / 2)
+                                            || (!primary80IsLower80 && phyIndex > nRus / 2));
+                          HeRu::RuSpec ru (ruType, index, primary80);
+                          ru.SetPhyIndex (bw, GetOperatingChannel ().GetPrimaryChannelIndex (20));
+                          NS_ABORT_IF (ru.GetPhyIndex () != phyIndex);
+                          m_ruBands[channelWidth].insert ({band, ru});
+                        }
+                    }
+                }
+            }
+        }
+      for (const auto& bandRuPair : m_ruBands[channelWidth])
+        {
+          m_interference->AddBand (bandRuPair.first);
+        }
+    }
+}
+
+Ptr<Channel>
+SpectrumWifiPhy::GetChannel (void) const
+{
+  return m_channel;
+}
+
+void
+SpectrumWifiPhy::SetChannel (const Ptr<SpectrumChannel> channel)
+{
+  m_channel = channel;
+}
+
+void
+SpectrumWifiPhy::ResetSpectrumModel (void)
+{
+  NS_LOG_FUNCTION (this);
+  NS_ASSERT_MSG (IsInitialized (), "Executing method before run-time");
+  uint16_t channelWidth = GetChannelWidth ();
+  NS_LOG_DEBUG ("Run-time change of spectrum model from frequency/width pair of (" << GetFrequency () << ", " << channelWidth << ")");
+  // Replace existing spectrum model with new one, and must call AddRx ()
+  // on the SpectrumChannel to provide this new spectrum model to it
+  m_rxSpectrumModel = WifiSpectrumValueHelper::GetSpectrumModel (GetFrequency (), channelWidth, GetBandBandwidth (), GetGuardBandwidth (channelWidth));
+  m_channel->AddRx (m_wifiSpectrumPhyInterface);
+  UpdateInterferenceHelperBands ();
+}
+
+void
+SpectrumWifiPhy::DoChannelSwitch (void)
+{
+  NS_LOG_FUNCTION (this);
+  WifiPhy::DoChannelSwitch ();
+  if (IsInitialized ())
+    {
+      ResetSpectrumModel ();
+    }
+}
+
+void
+SpectrumWifiPhy::StartRx (Ptr<SpectrumSignalParameters> rxParams)
+{
+  NS_LOG_FUNCTION (this << rxParams);
+  Time rxDuration = rxParams->duration;
+  Ptr<SpectrumValue> receivedSignalPsd = rxParams->psd;
+  NS_LOG_DEBUG ("Received signal with PSD " << *receivedSignalPsd << " and duration " << rxDuration.As (Time::NS));
+  uint32_t senderNodeId = 0;
+  if (rxParams->txPhy)
+    {
+      senderNodeId = rxParams->txPhy->GetDevice ()->GetNode ()->GetId ();
+    }
+  NS_LOG_DEBUG ("Received signal from " << senderNodeId << " with unfiltered power " << WToDbm (Integral (*receivedSignalPsd)) << " dBm");
+
+  // Integrate over our receive bandwidth (i.e., all that the receive
+  // spectral mask representing our filtering allows) to find the
+  // total energy apparent to the "demodulator".
+  // This is done per 20 MHz channel band.
+  uint16_t channelWidth = GetChannelWidth ();
+  double totalRxPowerW = 0;
+  RxPowerWattPerChannelBand rxPowerW;
+
+  if ((channelWidth == 5) || (channelWidth == 10))
+    {
+      WifiSpectrumBand filteredBand = GetBand (channelWidth);
+      double rxPowerPerBandW = WifiSpectrumValueHelper::GetBandPowerW (receivedSignalPsd, filteredBand);
+      NS_LOG_DEBUG ("Signal power received (watts) before antenna gain: " << rxPowerPerBandW);
+      rxPowerPerBandW *= DbToRatio (GetRxGain ());
+      totalRxPowerW += rxPowerPerBandW;
+      rxPowerW.insert ({filteredBand, rxPowerPerBandW});
+      NS_LOG_DEBUG ("Signal power received after antenna gain for " << channelWidth << " MHz channel: " << rxPowerPerBandW << " W (" << WToDbm (rxPowerPerBandW) << " dBm)");
+    }
+
+  for (uint16_t bw = 160; bw > 20; bw = bw / 2) //20 MHz is handled apart since the totalRxPowerW is computed through it
+    {
+      for (uint8_t i = 0; i < (channelWidth / bw); i++)
+        {
+          NS_ASSERT (channelWidth >= bw);
+          WifiSpectrumBand filteredBand = GetBand (bw, i);
+          double rxPowerPerBandW = WifiSpectrumValueHelper::GetBandPowerW (receivedSignalPsd, filteredBand);
+          NS_LOG_DEBUG ("Signal power received (watts) before antenna gain for " << bw << " MHz channel band " << +i << ": " << rxPowerPerBandW);
+          rxPowerPerBandW *= DbToRatio (GetRxGain ());
+          rxPowerW.insert ({filteredBand, rxPowerPerBandW});
+          NS_LOG_DEBUG ("Signal power received after antenna gain for " << bw << " MHz channel band " << +i << ": " << rxPowerPerBandW << " W (" << WToDbm (rxPowerPerBandW) << " dBm)");
+        }
+    }
+
+
+  for (uint8_t i = 0; i < (channelWidth / 20); i++)
+    {
+      WifiSpectrumBand filteredBand = GetBand (20, i);
+      double rxPowerPerBandW = WifiSpectrumValueHelper::GetBandPowerW (receivedSignalPsd, filteredBand);
+      NS_LOG_DEBUG ("Signal power received (watts) before antenna gain for 20 MHz channel band " << +i << ": " << rxPowerPerBandW);
+      rxPowerPerBandW *= DbToRatio (GetRxGain ());
+      totalRxPowerW += rxPowerPerBandW;
+      rxPowerW.insert ({filteredBand, rxPowerPerBandW});
+      NS_LOG_DEBUG ("Signal power received after antenna gain for 20 MHz channel band " << +i << ": " << rxPowerPerBandW << " W (" << WToDbm (rxPowerPerBandW) << " dBm)");
+    }
+
+  if (GetStandard () >= WIFI_STANDARD_80211ax)
+    {
+      NS_ASSERT (!m_ruBands[channelWidth].empty ());
+      for (const auto& bandRuPair : m_ruBands[channelWidth])
+        {
+          double rxPowerPerBandW = WifiSpectrumValueHelper::GetBandPowerW (receivedSignalPsd, bandRuPair.first);
+          NS_LOG_DEBUG ("Signal power received (watts) before antenna gain for RU with type " << bandRuPair.second.GetRuType () << " and index " << bandRuPair.second.GetIndex () << " -> (" << bandRuPair.first.first << "; " << bandRuPair.first.second <<  "): " << rxPowerPerBandW);
+          rxPowerPerBandW *= DbToRatio (GetRxGain ());
+          NS_LOG_DEBUG ("Signal power received after antenna gain for RU with type " << bandRuPair.second.GetRuType () << " and index " << bandRuPair.second.GetIndex () << " -> (" << bandRuPair.first.first << "; " << bandRuPair.first.second <<  "): " << rxPowerPerBandW << " W (" << WToDbm (rxPowerPerBandW) << " dBm)");
+          rxPowerW.insert ({bandRuPair.first, rxPowerPerBandW});
+        }
+    }
+
+  NS_LOG_DEBUG ("Total signal power received after antenna gain: " << totalRxPowerW << " W (" << WToDbm (totalRxPowerW) << " dBm)");
+
+  Ptr<WifiSpectrumSignalParameters> wifiRxParams = DynamicCast<WifiSpectrumSignalParameters> (rxParams);
+
+  // Log the signal arrival to the trace source
+  m_signalCb (wifiRxParams, senderNodeId, WToDbm (totalRxPowerW), rxDuration);
+
+  if (wifiRxParams == 0)
+    {
+      NS_LOG_INFO ("Received non Wi-Fi signal");
+      m_interference->AddForeignSignal (rxDuration, rxPowerW);
+      SwitchMaybeToCcaBusy (GetMeasurementChannelWidth (nullptr));
+      return;
+    }
+  if (wifiRxParams && m_disableWifiReception)
+    {
+      NS_LOG_INFO ("Received Wi-Fi signal but blocked from syncing");
+      m_interference->AddForeignSignal (rxDuration, rxPowerW);
+      SwitchMaybeToCcaBusy (GetMeasurementChannelWidth (nullptr));
+      return;
+    }
+  // Do no further processing if signal is too weak
+  // Current implementation assumes constant RX power over the PPDU duration
+  // Compare received TX power per MHz to normalized RX sensitivity
+  uint16_t txWidth = wifiRxParams->ppdu->GetTransmissionChannelWidth ();
+  if (totalRxPowerW < DbmToW (GetRxSensitivity ()) * (txWidth / 20.0))
+    {
+      NS_LOG_INFO ("Received signal too weak to process: " << WToDbm (totalRxPowerW) << " dBm");
+      m_interference->Add (wifiRxParams->ppdu, wifiRxParams->ppdu->GetTxVector (), rxDuration,
+                          rxPowerW);
+      SwitchMaybeToCcaBusy (GetMeasurementChannelWidth (wifiRxParams->ppdu));
+      return;
+    }
+
+  // Unless we are receiving a TB PPDU, do not sync with this signal if the PPDU
+  // does not overlap with the receiver's primary20 channel
+  if (wifiRxParams->txPhy != 0)
+    {
+      // if the channel width is a multiple of 20 MHz, then we consider the primary20 channel
+      uint16_t width = (GetChannelWidth () % 20 == 0 ? 20 : GetChannelWidth ());
+      uint16_t p20MinFreq =
+          GetOperatingChannel ().GetPrimaryChannelCenterFrequency (width) - width / 2;
+      uint16_t p20MaxFreq =
+          GetOperatingChannel ().GetPrimaryChannelCenterFrequency (width) + width / 2;
+
+      if (!wifiRxParams->ppdu->CanBeReceived (wifiRxParams->txCenterFreq, p20MinFreq, p20MaxFreq))
+        {
+          NS_LOG_INFO ("Cannot receive the PPDU, consider it as interference");
+          m_interference->Add (wifiRxParams->ppdu, wifiRxParams->ppdu->GetTxVector (),
+                              rxDuration, rxPowerW);
+          SwitchMaybeToCcaBusy (GetMeasurementChannelWidth (wifiRxParams->ppdu));
+          return;
+        }
+    }
+
+  NS_LOG_INFO ("Received Wi-Fi signal");
+  Ptr<WifiPpdu> ppdu = wifiRxParams->ppdu->Copy ();
+  StartReceivePreamble (ppdu, rxPowerW, rxDuration);
+}
+
+Ptr<Object>
+SpectrumWifiPhy::GetAntenna (void) const
+{
+  return m_antenna;
+}
+
+void
+SpectrumWifiPhy::SetAntenna (const Ptr<AntennaModel> a)
+{
+  NS_LOG_FUNCTION (this << a);
+  m_antenna = a;
+}
+
+void
+SpectrumWifiPhy::CreateWifiSpectrumPhyInterface (Ptr<NetDevice> device)
+{
+  NS_LOG_FUNCTION (this << device);
+  m_wifiSpectrumPhyInterface = CreateObject<WifiSpectrumPhyInterface> ();
+  m_wifiSpectrumPhyInterface->SetSpectrumWifiPhy (this);
+  m_wifiSpectrumPhyInterface->SetDevice (device);
+}
+
+void
+SpectrumWifiPhy::StartTx (Ptr<WifiPpdu> ppdu)
+{
+  NS_LOG_FUNCTION (this << ppdu);
+  GetPhyEntity (ppdu->GetModulation ())->StartTx (ppdu);
+}
+
+void
+SpectrumWifiPhy::Transmit (Ptr<WifiSpectrumSignalParameters> txParams)
+{
+  NS_LOG_FUNCTION (this << txParams);
+
+  //Finish configuration
+  NS_ASSERT_MSG (m_wifiSpectrumPhyInterface, "SpectrumPhy() is not set; maybe forgot to call CreateWifiSpectrumPhyInterface?");
+  txParams->txPhy = m_wifiSpectrumPhyInterface->GetObject<SpectrumPhy> ();
+  txParams->txAntenna = m_antenna;
+
+  m_channel->StartTx (txParams);
+}
+
+uint32_t
+SpectrumWifiPhy::GetBandBandwidth (void) const
+{
+  uint32_t bandBandwidth = 0;
+  switch (GetStandard ())
+    {
+    case WIFI_STANDARD_80211a:
+    case WIFI_STANDARD_80211g:
+    case WIFI_STANDARD_80211b:
+    case WIFI_STANDARD_80211n:
+    case WIFI_STANDARD_80211ac:
+      // Use OFDM subcarrier width of 312.5 KHz as band granularity
+      bandBandwidth = 312500;
+      break;
+    case WIFI_STANDARD_80211p:
+    case WIFI_STANDARD_80211bd:
+      if (GetChannelWidth () == 5)
+        {
+          // Use OFDM subcarrier width of 78.125 KHz as band granularity
+          bandBandwidth = 78125;
+        }
+      else
+        {
+          // Use OFDM subcarrier width of 156.25 KHz as band granularity
+          bandBandwidth = 156250;
+        }
+      break;
+    case WIFI_STANDARD_80211ax:
+      // Use OFDM subcarrier width of 78.125 KHz as band granularity
+      bandBandwidth = 78125;
+      break;
+    default:
+      NS_FATAL_ERROR ("Standard unknown: " << GetStandard ());
+      break;
+    }
+  return bandBandwidth;
+}
+
+uint16_t
+SpectrumWifiPhy::GetGuardBandwidth (uint16_t currentChannelWidth) const
+{
+  uint16_t guardBandwidth = 0;
+  if (currentChannelWidth == 22)
+    {
+      //handle case of DSSS transmission
+      guardBandwidth = 10;
+    }
+  else
+    {
+      //In order to properly model out of band transmissions for OFDM, the guard
+      //band has been configured so as to expand the modeled spectrum up to the
+      //outermost referenced point in "Transmit spectrum mask" sections' PSDs of
+      //each PHY specification of 802.11-2016 standard. It thus ultimately corresponds
+      //to the currently considered channel bandwidth (which can be different from
+      //supported channel width).
+      guardBandwidth = currentChannelWidth;
+    }
+  return guardBandwidth;
+}
+
+WifiSpectrumBand
+SpectrumWifiPhy::GetBand (uint16_t bandWidth, uint8_t bandIndex)
+{
+  uint16_t channelWidth = GetChannelWidth ();
+  uint32_t bandBandwidth = GetBandBandwidth ();
+  size_t numBandsInChannel = static_cast<size_t> (channelWidth * 1e6 / bandBandwidth);
+  size_t numBandsInBand = static_cast<size_t> (bandWidth * 1e6 / bandBandwidth);
+  if (numBandsInBand % 2 == 0)
+    {
+      numBandsInChannel += 1; // symmetry around center frequency
+    }
+  size_t totalNumBands = GetRxSpectrumModel ()->GetNumBands ();
+  NS_ASSERT_MSG ((numBandsInChannel % 2 == 1) && (totalNumBands % 2 == 1), "Should have odd number of bands");
+  NS_ASSERT_MSG ((bandIndex * bandWidth) < channelWidth, "Band index is out of bound");
+  WifiSpectrumBand band;
+  band.first = ((totalNumBands - numBandsInChannel) / 2) + (bandIndex * numBandsInBand);
+  if (band.first >= totalNumBands / 2)
+    {
+      //step past DC
+      band.first += 1;
+    }
+  band.second = band.first + numBandsInBand - 1;
+  return band;
+}
+
+WifiSpectrumBand
+SpectrumWifiPhy::ConvertHeRuSubcarriers (uint16_t bandWidth, uint16_t guardBandwidth,
+                                         HeRu::SubcarrierRange range, uint8_t bandIndex) const
+{
+  WifiSpectrumBand convertedSubcarriers;
+  uint32_t nGuardBands = static_cast<uint32_t> (((2 * guardBandwidth * 1e6) / GetBandBandwidth ()) + 0.5);
+  uint32_t centerFrequencyIndex = 0;
+  switch (bandWidth)
+    {
+    case 20:
+      centerFrequencyIndex = (nGuardBands / 2) + 6 + 122;
+      break;
+    case 40:
+      centerFrequencyIndex = (nGuardBands / 2) + 12 + 244;
+      break;
+    case 80:
+      centerFrequencyIndex = (nGuardBands / 2) + 12 + 500;
+      break;
+    case 160:
+      centerFrequencyIndex = (nGuardBands / 2) + 12 + 1012;
+      break;
+    default:
+      NS_FATAL_ERROR ("ChannelWidth " << bandWidth << " unsupported");
+      break;
+    }
+
+  size_t numBandsInBand = static_cast<size_t> (bandWidth * 1e6 / GetBandBandwidth ());
+  centerFrequencyIndex += numBandsInBand * bandIndex;
+
+  convertedSubcarriers.first = centerFrequencyIndex + range.first;
+  convertedSubcarriers.second = centerFrequencyIndex + range.second;
+  return convertedSubcarriers;
+}
+
+std::tuple<double, double, double>
+SpectrumWifiPhy::GetTxMaskRejectionParams (void) const
+{
+  return std::make_tuple (m_txMaskInnerBandMinimumRejection,
+                          m_txMaskOuterBandMinimumRejection,
+                          m_txMaskOuterBandMaximumRejection);
+}
+
+} //namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/wifi-80211p-helper.cc
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-80211p-helper.cc
@@ -1,0 +1,91 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2008 INRIA
+ * Copyright (c) 2009 MIRKO BANCHI
+ * Copyright (c) 2013 Dalian University of Technology
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ * Author: Mirko Banchi <mk.banchi@gmail.com>
+ * Author: Junling Bu <linlinjavaer@gmail.com>
+ */
+#include "ns3/string.h"
+#include "ns3/log.h"
+#include <typeinfo>
+#include "wave-mac-helper.h"
+#include "wifi-80211p-helper.h"
+
+namespace ns3 {
+
+Wifi80211pHelper::Wifi80211pHelper ()
+{
+}
+
+Wifi80211pHelper::~Wifi80211pHelper ()
+{
+}
+
+Wifi80211pHelper
+Wifi80211pHelper::Default (void)
+{
+  Wifi80211pHelper helper;
+  helper.SetStandard (WIFI_STANDARD_80211p);
+  helper.SetRemoteStationManager ("ns3::ConstantRateWifiManager",
+                                  "DataMode", StringValue ("OfdmRate6MbpsBW10MHz"),
+                                  "ControlMode",StringValue ("OfdmRate6MbpsBW10MHz"),
+                                  "NonUnicastMode", StringValue ("OfdmRate6MbpsBW10MHz"));
+  return helper;
+}
+
+void
+Wifi80211pHelper::SetStandard (enum WifiStandard standard)
+{
+  if (standard == WIFI_STANDARD_80211p || standard == WIFI_STANDARD_80211bd)
+    {
+      WifiHelper::SetStandard (standard);
+    }
+  else
+    {
+      NS_FATAL_ERROR ("wrong vehicular Wi-Fi standard selected!");
+    }
+}
+
+void
+Wifi80211pHelper::EnableLogComponents (void)
+{
+  WifiHelper::EnableLogComponents ();
+
+  LogComponentEnable ("OcbWifiMac", LOG_LEVEL_ALL);
+  LogComponentEnable ("VendorSpecificAction", LOG_LEVEL_ALL);
+}
+
+NetDeviceContainer
+Wifi80211pHelper::Install (const WifiPhyHelper &phyHelper, const WifiMacHelper &macHelper, NodeContainer c) const
+{
+  [[maybe_unused]] QosWaveMacHelper const * qosMac = dynamic_cast <QosWaveMacHelper const *> (&macHelper);
+  if (qosMac == 0)
+    {
+      [[maybe_unused]] NqosWaveMacHelper const * nqosMac = dynamic_cast <NqosWaveMacHelper const *> (&macHelper);
+      if (nqosMac == 0)
+        {
+          NS_FATAL_ERROR ("the macHelper should be either QosWaveMacHelper or NqosWaveMacHelper"
+                          ", or should be the subclass of QosWaveMacHelper or NqosWaveMacHelper");
+        }
+    }
+
+  return WifiHelper::Install (phyHelper, macHelper, c);
+}
+
+} // namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/wifi-80211p-helper.h
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-80211p-helper.h
@@ -1,0 +1,79 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2008 INRIA
+ * Copyright (c) 2009 MIRKO BANCHI
+ * Copyright (c) 2013 Dalian University of Technology
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ * Author: Mirko Banchi <mk.banchi@gmail.com>
+ * Author: Junling Bu <linlinjavaer@gmail.com>
+ */
+#ifndef WIFI_802_11P_HELPER_H
+#define WIFI_802_11P_HELPER_H
+#include "ns3/wifi-helper.h"
+#include "ns3/deprecated.h"
+
+namespace ns3 {
+
+/**
+ * \ingroup wave
+ * \brief helps to create wifi 802.11p and 802.11bd OCB objects of
+ * WifiNetDevice class
+ *
+ * This class can help to create a large set of similar
+ * wifi 802.11p or 802.11bd OCB objects and to configure a large set of
+ * their attributes during creation.
+ */
+class Wifi80211pHelper : public WifiHelper
+{
+public:
+  Wifi80211pHelper ();
+  virtual ~Wifi80211pHelper ();
+
+  /**
+   * \returns a new Wifi80211pHelper in a default state
+   *
+   * The default state is defined as being an OcbWifiMac MAC
+   * layer with constant rate OfdmRate6MbpsBW10MHz
+   * and both objects using their default attribute values.
+   */
+  static Wifi80211pHelper Default (void);
+
+  /**
+   * \param standard the phy standard to configure during installation
+   *
+   * Users can only configure 802.11p or 802.11bd OCB operation with 10 MHz or
+   * 5 MHz channel bandwidth. The default 802.11p standard uses 10 MHz.
+   */
+  virtual void SetStandard (enum WifiStandard standard);
+
+  /**
+   * \param phy the PHY helper to create PHY objects
+   * \param macHelper the MAC helper to create MAC objects
+   * \param c the set of nodes on which a wifi device must be created
+   * \returns a device container which contains all the devices created by this method.
+   */
+  virtual NetDeviceContainer Install (const WifiPhyHelper &phy, const WifiMacHelper &macHelper,NodeContainer c) const;
+
+  /**
+   * Helper to enable all WifiNetDevice log components with one statement
+   */
+  static void EnableLogComponents (void);
+};
+
+}
+
+#endif /* WIFI_802_11P_HELPER_H */

--- a/src/automotive/model/SignalInfo/WiFi/wifi-phy-common.cc
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-phy-common.cc
@@ -1,0 +1,184 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2021
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Sébastien Deronne <sebastien.deronne@gmail.com>
+ */
+
+#include "wifi-phy-common.h"
+#include "wifi-mode.h"
+#include "wifi-net-device.h"
+#include "ns3/ht-configuration.h"
+#include "ns3/he-configuration.h"
+
+namespace ns3 {
+
+uint16_t
+ConvertGuardIntervalToNanoSeconds (WifiMode mode, const Ptr<WifiNetDevice> device)
+{
+  uint16_t gi = 800;
+  if (mode.GetModulationClass () == WIFI_MOD_CLASS_HE)
+    {
+      Ptr<HeConfiguration> heConfiguration = device->GetHeConfiguration ();
+      NS_ASSERT (heConfiguration); //If HE modulation is used, we should have a HE configuration attached
+      gi = static_cast<uint16_t> (heConfiguration->GetGuardInterval ().GetNanoSeconds ());
+    }
+  else if (mode.GetModulationClass () == WIFI_MOD_CLASS_HT || mode.GetModulationClass () == WIFI_MOD_CLASS_VHT)
+    {
+      Ptr<HtConfiguration> htConfiguration = device->GetHtConfiguration ();
+      NS_ASSERT (htConfiguration); //If HT/VHT modulation is used, we should have a HT configuration attached
+      gi = htConfiguration->GetShortGuardIntervalSupported () ? 400 : 800;
+    }
+  return gi;
+}
+
+uint16_t
+ConvertGuardIntervalToNanoSeconds (WifiMode mode, bool htShortGuardInterval, Time heGuardInterval)
+{
+  uint16_t gi;
+  if (mode.GetModulationClass () == WIFI_MOD_CLASS_HE)
+    {
+      gi = static_cast<uint16_t> (heGuardInterval.GetNanoSeconds ());
+    }
+  else if (mode.GetModulationClass () == WIFI_MOD_CLASS_HT || mode.GetModulationClass () == WIFI_MOD_CLASS_VHT)
+    {
+      gi = htShortGuardInterval ? 400 : 800;
+    }
+  else
+    {
+      gi = 800;
+    }
+  return gi;
+}
+
+uint16_t
+GetChannelWidthForTransmission (WifiMode mode, uint16_t maxAllowedChannelWidth)
+{
+  WifiModulationClass modulationClass = mode.GetModulationClass ();
+  if (maxAllowedChannelWidth > 20
+      && (modulationClass == WifiModulationClass::WIFI_MOD_CLASS_OFDM // all non-HT OFDM control and management frames
+          || modulationClass == WifiModulationClass::WIFI_MOD_CLASS_ERP_OFDM)) // special case of beacons at 2.4 GHz
+    {
+      return 20;
+    }
+  //at 2.4 GHz basic rate can be non-ERP DSSS
+  if (modulationClass == WifiModulationClass::WIFI_MOD_CLASS_DSSS
+      || modulationClass == WifiModulationClass::WIFI_MOD_CLASS_HR_DSSS)
+    {
+      return 22;
+    }
+  return maxAllowedChannelWidth;
+}
+
+uint16_t
+GetChannelWidthForTransmission (WifiMode mode, uint16_t operatingChannelWidth,
+                                uint16_t maxSupportedChannelWidth)
+{
+  return GetChannelWidthForTransmission (mode, (operatingChannelWidth < maxSupportedChannelWidth)
+                                                ? operatingChannelWidth : maxSupportedChannelWidth);
+}
+
+WifiPreamble
+GetPreambleForTransmission (WifiModulationClass modulation, bool useShortPreamble)
+{
+  if (modulation == WIFI_MOD_CLASS_HE)
+    {
+      return WIFI_PREAMBLE_HE_SU;
+    }
+  else if (modulation == WIFI_MOD_CLASS_VHT)
+    {
+      return WIFI_PREAMBLE_VHT_SU;
+    }
+  else if (modulation == WIFI_MOD_CLASS_HT)
+    {
+      return WIFI_PREAMBLE_HT_MF; // HT_GF has been removed
+    }
+  else if (modulation == WIFI_MOD_CLASS_HR_DSSS && useShortPreamble) //ERP_DSSS is modeled through HR_DSSS (since same preamble and modulation)
+    {
+      return WIFI_PREAMBLE_SHORT;
+    }
+  else
+    {
+      return WIFI_PREAMBLE_LONG;
+    }
+}
+
+bool
+IsAllowedControlAnswerModulationClass (WifiModulationClass modClassReq, WifiModulationClass modClassAnswer)
+{
+  switch (modClassReq)
+    {
+    case WIFI_MOD_CLASS_DSSS:
+      return (modClassAnswer == WIFI_MOD_CLASS_DSSS);
+    case WIFI_MOD_CLASS_HR_DSSS:
+      return (modClassAnswer == WIFI_MOD_CLASS_DSSS || modClassAnswer == WIFI_MOD_CLASS_HR_DSSS);
+    case WIFI_MOD_CLASS_ERP_OFDM:
+      return (modClassAnswer == WIFI_MOD_CLASS_DSSS || modClassAnswer == WIFI_MOD_CLASS_HR_DSSS || modClassAnswer == WIFI_MOD_CLASS_ERP_OFDM);
+    case WIFI_MOD_CLASS_OFDM:
+      return (modClassAnswer == WIFI_MOD_CLASS_OFDM);
+    case WIFI_MOD_CLASS_HT:
+    case WIFI_MOD_CLASS_VHT:
+    case WIFI_MOD_CLASS_HE:
+    case WIFI_MOD_CLASS_NGV:
+      return true;
+    default:
+      NS_FATAL_ERROR ("Modulation class not defined");
+      return false;
+    }
+}
+
+Time
+GetPpduMaxTime (WifiPreamble preamble)
+{
+  Time duration;
+
+  switch (preamble)
+    {
+      case WIFI_PREAMBLE_HT_MF:
+      case WIFI_PREAMBLE_VHT_SU:
+      case WIFI_PREAMBLE_VHT_MU:
+      case WIFI_PREAMBLE_HE_SU:
+      case WIFI_PREAMBLE_HE_ER_SU:
+      case WIFI_PREAMBLE_HE_MU:
+      case WIFI_PREAMBLE_HE_TB:
+        duration = MicroSeconds (5484);
+        break;
+      default:
+        duration = MicroSeconds (0);
+        break;
+    }
+  return duration;
+}
+
+bool
+IsMu (WifiPreamble preamble)
+{
+  return (IsDlMu (preamble) || IsUlMu (preamble));
+}
+
+bool
+IsDlMu (WifiPreamble preamble)
+{
+  return (preamble == WIFI_PREAMBLE_HE_MU);
+}
+
+bool
+IsUlMu (WifiPreamble preamble)
+{
+  return (preamble == WIFI_PREAMBLE_HE_TB);
+}
+
+} //namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/wifi-phy-common.h
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-phy-common.h
@@ -1,0 +1,449 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006,2007 INRIA
+ * Copyright (c) 2020 Orange Labs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ *          Rediet <getachew.redieteab@orange.com>
+ */
+
+#ifndef WIFI_PHY_COMMON_H
+#define WIFI_PHY_COMMON_H
+
+#include <ostream>
+#include "ns3/fatal-error.h"
+#include "ns3/ptr.h"
+
+/**
+ * \file
+ * \ingroup wifi
+ * Declaration of the following enums:
+ * - ns3::WifiPreamble
+ * - ns3::WifiModulationClass
+ * - ns3::WifiPpduField
+ * - ns3::WifiPpduType
+ * - ns3::WifiPhyRxfailureReason
+ */
+
+namespace ns3 {
+
+class WifiNetDevice;
+class WifiMode;
+class Time;
+
+/**
+ * These constants define the various convolutional coding rates
+ * used for the OFDM transmission modes in the IEEE 802.11
+ * standard. DSSS (for example) rates which do not have an explicit
+ * coding stage in their generation should have this parameter set to
+ * WIFI_CODE_RATE_UNDEFINED.
+ * \note This typedef and constants could be converted to an enum or scoped
+ * enum if pybindgen is upgraded to support Callback<WifiCodeRate>
+ */
+typedef uint16_t WifiCodeRate;
+const uint16_t WIFI_CODE_RATE_UNDEFINED = 0; //!< undefined coding rate
+const uint16_t WIFI_CODE_RATE_1_2 = 1;       //!< 1/2 coding rate
+const uint16_t WIFI_CODE_RATE_2_3 = 2;       //!< 2/3 coding rate
+const uint16_t WIFI_CODE_RATE_3_4 = 3;       //!< 3/4 coding rate
+const uint16_t WIFI_CODE_RATE_5_6 = 4;       //!< 5/6 coding rate
+
+/**
+ * \ingroup wifi
+ * The type of preamble to be used by an IEEE 802.11 transmission
+ */
+enum WifiPreamble
+{
+  WIFI_PREAMBLE_LONG,
+  WIFI_PREAMBLE_SHORT,
+  WIFI_PREAMBLE_HT_MF,
+  WIFI_PREAMBLE_VHT_SU,
+  WIFI_PREAMBLE_VHT_MU,
+  WIFI_PREAMBLE_HE_SU,
+  WIFI_PREAMBLE_HE_ER_SU,
+  WIFI_PREAMBLE_HE_MU,
+  WIFI_PREAMBLE_HE_TB
+};
+
+/**
+ * \brief Stream insertion operator.
+ *
+ * \param os the stream
+ * \param preamble the preamble
+ * \returns a reference to the stream
+ */
+inline std::ostream& operator<< (std::ostream &os, const WifiPreamble &preamble)
+{
+  switch (preamble)
+    {
+      case WIFI_PREAMBLE_LONG:
+        return (os << "LONG");
+      case WIFI_PREAMBLE_SHORT:
+        return (os << "SHORT");
+      case WIFI_PREAMBLE_HT_MF:
+        return (os << "HT_MF");
+      case WIFI_PREAMBLE_VHT_SU:
+        return (os << "VHT_SU");
+      case WIFI_PREAMBLE_VHT_MU:
+        return (os << "VHT_MU");
+      case WIFI_PREAMBLE_HE_SU:
+        return (os << "HE_SU");
+      case WIFI_PREAMBLE_HE_ER_SU:
+        return (os << "HE_ER_SU");
+      case WIFI_PREAMBLE_HE_MU:
+        return (os << "HE_MU");
+      case WIFI_PREAMBLE_HE_TB:
+        return (os << "HE_TB");
+      default:
+        NS_FATAL_ERROR ("Invalid preamble");
+        return (os << "INVALID");
+    }
+}
+
+/**
+ * \ingroup wifi
+ * This enumeration defines the modulation classes per
+ * (Table 10-6 "Modulation classes"; IEEE 802.11-2016, with
+ * updated in 802.11ax/D6.0 as Table 10-9).
+ */
+enum WifiModulationClass
+{
+  /** Modulation class unknown or unspecified. A WifiMode with this
+  WifiModulationClass has not been properly initialized. */
+  WIFI_MOD_CLASS_UNKNOWN = 0,
+  WIFI_MOD_CLASS_DSSS,     //!< DSSS (Clause 15)
+  WIFI_MOD_CLASS_HR_DSSS,  //!< HR/DSSS (Clause 16)
+  WIFI_MOD_CLASS_ERP_OFDM, //!< ERP-OFDM (18.4)
+  WIFI_MOD_CLASS_OFDM,     //!< OFDM (Clause 17)
+  WIFI_MOD_CLASS_HT,       //!< HT (Clause 19)
+  WIFI_MOD_CLASS_VHT,      //!< VHT (Clause 22)
+  WIFI_MOD_CLASS_HE,       //!< HE (Clause 27)
+  WIFI_MOD_CLASS_NGV       //!< NGV (IEEE 802.11bd Clause 32)
+};
+
+/**
+ * \brief Stream insertion operator.
+ *
+ * \param os the stream
+ * \param modulation the WifiModulationClass
+ * \returns a reference to the stream
+ */
+inline std::ostream& operator<< (std::ostream &os, const WifiModulationClass &modulation)
+{
+  switch (modulation)
+    {
+      case WIFI_MOD_CLASS_DSSS:
+        return (os << "DSSS");
+      case WIFI_MOD_CLASS_HR_DSSS:
+        return (os << "HR/DSSS");
+      case WIFI_MOD_CLASS_ERP_OFDM:
+        return (os << "ERP-OFDM");
+      case WIFI_MOD_CLASS_OFDM:
+        return (os << "OFDM");
+      case WIFI_MOD_CLASS_HT:
+        return (os << "HT");
+      case WIFI_MOD_CLASS_VHT:
+        return (os << "VHT");
+      case WIFI_MOD_CLASS_HE:
+        return (os << "HE");
+      case WIFI_MOD_CLASS_NGV:
+        return (os << "NGV");
+      default:
+        NS_FATAL_ERROR ("Unknown modulation");
+        return (os << "unknown");
+    }
+}
+
+/**
+ * \ingroup wifi
+ * The type of PPDU field (grouped for convenience)
+ */
+enum WifiPpduField
+{
+  /**
+   * SYNC + SFD fields for DSSS or ERP,
+   * shortSYNC + shortSFD fields for HR/DSSS or ERP,
+   * HT-GF-STF + HT-GF-LTF1 fields for HT-GF,
+   * L-STF + L-LTF fields otherwise.
+   */
+  WIFI_PPDU_FIELD_PREAMBLE = 0,
+  /**
+   * PHY header field for DSSS or ERP,
+   * short PHY header field for HR/DSSS or ERP,
+   * field not present for HT-GF,
+   * L-SIG field or L-SIG + RL-SIG fields otherwise.
+   */
+  WIFI_PPDU_FIELD_NON_HT_HEADER,
+  WIFI_PPDU_FIELD_HT_SIG,   //!< HT-SIG field
+  WIFI_PPDU_FIELD_TRAINING, //!< STF + LTF fields (excluding those in preamble for HT-GF)
+  WIFI_PPDU_FIELD_SIG_A,    //!< SIG-A field
+  WIFI_PPDU_FIELD_SIG_B,    //!< SIG-B field
+  WIFI_PPDU_FIELD_DATA      //!< data field
+};
+
+/**
+ * \brief Stream insertion operator.
+ *
+ * \param os the stream
+ * \param field the PPDU field
+ * \returns a reference to the stream
+ */
+inline std::ostream& operator<< (std::ostream &os, const WifiPpduField &field)
+{
+  switch (field)
+    {
+      case WIFI_PPDU_FIELD_PREAMBLE:
+        return (os << "preamble");
+      case WIFI_PPDU_FIELD_NON_HT_HEADER:
+        return (os << "non-HT header");
+      case WIFI_PPDU_FIELD_HT_SIG:
+        return (os << "HT-SIG");
+      case WIFI_PPDU_FIELD_TRAINING:
+        return (os << "training");
+      case WIFI_PPDU_FIELD_SIG_A:
+        return (os << "SIG-A");
+      case WIFI_PPDU_FIELD_SIG_B:
+        return (os << "SIG-B");
+      case WIFI_PPDU_FIELD_DATA:
+        return (os << "data");
+      default:
+        NS_FATAL_ERROR ("Unknown field");
+        return (os << "unknown");
+    }
+}
+
+/**
+ * \ingroup wifi
+ * The type of PPDU (SU, DL MU, or UL MU)
+ */
+enum WifiPpduType
+{
+  WIFI_PPDU_TYPE_SU = 0,
+  WIFI_PPDU_TYPE_DL_MU,
+  WIFI_PPDU_TYPE_UL_MU
+};
+
+/**
+ * \brief Stream insertion operator.
+ *
+ * \param os the stream
+ * \param type the PPDU type
+ * \returns a reference to the stream
+ */
+inline std::ostream& operator<< (std::ostream &os, const WifiPpduType &type)
+{
+  switch (type)
+    {
+      case WIFI_PPDU_TYPE_SU:
+        return (os << "SU");
+      case WIFI_PPDU_TYPE_DL_MU:
+        return (os << "DL MU");
+      case WIFI_PPDU_TYPE_UL_MU:
+        return (os << "UL MU");
+      default:
+        NS_FATAL_ERROR ("Unknown type");
+        return (os << "unknown");
+    }
+}
+
+/**
+ * \ingroup wifi
+ * Enumeration of the possible reception failure reasons.
+ */
+enum WifiPhyRxfailureReason
+{
+  UNKNOWN = 0,
+  UNSUPPORTED_SETTINGS,
+  CHANNEL_SWITCHING,
+  RXING,
+  TXING,
+  SLEEPING,
+  POWERED_OFF,
+  TRUNCATED_TX,
+  BUSY_DECODING_PREAMBLE,
+  PREAMBLE_DETECT_FAILURE,
+  RECEPTION_ABORTED_BY_TX,
+  L_SIG_FAILURE,
+  HT_SIG_FAILURE,
+  SIG_A_FAILURE,
+  SIG_B_FAILURE,
+  PREAMBLE_DETECTION_PACKET_SWITCH,
+  FRAME_CAPTURE_PACKET_SWITCH,
+  OBSS_PD_CCA_RESET,
+  HE_TB_PPDU_TOO_LATE,
+  FILTERED
+};
+
+/**
+ * \brief Stream insertion operator.
+ *
+ * \param os the stream
+ * \param reason the failure reason
+ * \returns a reference to the stream
+ */
+inline std::ostream& operator<< (std::ostream &os, const WifiPhyRxfailureReason &reason)
+{
+  switch (reason)
+    {
+      case UNSUPPORTED_SETTINGS:
+        return (os << "UNSUPPORTED_SETTINGS");
+      case CHANNEL_SWITCHING:
+        return (os << "CHANNEL_SWITCHING");
+      case RXING:
+        return (os << "RXING");
+      case TXING:
+        return (os << "TXING");
+      case SLEEPING:
+        return (os << "SLEEPING");
+      case POWERED_OFF:
+        return (os << "OFF");
+      case TRUNCATED_TX:
+        return (os << "TRUNCATED_TX");
+      case BUSY_DECODING_PREAMBLE:
+        return (os << "BUSY_DECODING_PREAMBLE");
+      case PREAMBLE_DETECT_FAILURE:
+        return (os << "PREAMBLE_DETECT_FAILURE");
+      case RECEPTION_ABORTED_BY_TX:
+        return (os << "RECEPTION_ABORTED_BY_TX");
+      case L_SIG_FAILURE:
+        return (os << "L_SIG_FAILURE");
+      case HT_SIG_FAILURE:
+        return (os << "HT_SIG_FAILURE");
+      case SIG_A_FAILURE:
+        return (os << "SIG_A_FAILURE");
+      case SIG_B_FAILURE:
+        return (os << "SIG_B_FAILURE");
+      case PREAMBLE_DETECTION_PACKET_SWITCH:
+        return (os << "PREAMBLE_DETECTION_PACKET_SWITCH");
+      case FRAME_CAPTURE_PACKET_SWITCH:
+        return (os << "FRAME_CAPTURE_PACKET_SWITCH");
+      case OBSS_PD_CCA_RESET:
+        return (os << "OBSS_PD_CCA_RESET");
+      case HE_TB_PPDU_TOO_LATE:
+        return (os << "HE_TB_PPDU_TOO_LATE");
+      case FILTERED:
+        return (os << "FILTERED");
+      case UNKNOWN:
+      default:
+        NS_FATAL_ERROR ("Unknown reason");
+        return (os << "UNKNOWN");
+    }
+}
+
+/**
+ * Convert the guard interval to nanoseconds based on the WifiMode.
+ *
+ * \param mode the WifiMode
+ * \param device pointer to the WifiNetDevice object
+ *
+ * \return the guard interval duration in nanoseconds
+ */
+uint16_t ConvertGuardIntervalToNanoSeconds (WifiMode mode, const Ptr<WifiNetDevice> device);
+
+/**
+ * Convert the guard interval to nanoseconds based on the WifiMode.
+ *
+ * \param mode the WifiMode
+ * \param htShortGuardInterval whether HT/VHT short guard interval is enabled
+ * \param heGuardInterval the HE guard interval duration
+ *
+ * \return the guard interval duration in nanoseconds
+ */
+uint16_t ConvertGuardIntervalToNanoSeconds (WifiMode mode, bool htShortGuardInterval, Time heGuardInterval);
+
+/**
+ * Return the preamble to be used for the transmission.
+ *
+ * \param modulation the modulation selected for the transmission
+ * \param useShortPreamble whether short preamble should be used
+ *
+ * \return the preamble to be used for the transmission
+ */
+WifiPreamble GetPreambleForTransmission (WifiModulationClass modulation, bool useShortPreamble);
+
+/**
+ * Return the channel width that is allowed based on the selected mode and the given
+ * maximum channel width. This is especially useful when using non-HT modes with
+ * HT/VHT/HE capable stations (with default width above 20 MHz).
+ *
+ * \param mode selected WifiMode
+ * \param maxAllowedChannelWidth maximum channel width allowed for the transmission
+ * \return channel width adapted to the selected mode
+ */
+uint16_t GetChannelWidthForTransmission (WifiMode mode, uint16_t maxAllowedChannelWidth);
+/**
+ * Return the channel width that is allowed based on the selected mode, the current
+ * width of the operating channel and the maximum channel width supported by the
+ * receiver. This is especially useful when using non-HT modes with HT/VHT/HE
+ * capable stations (with default width above 20 MHz).
+ *
+ * \param mode selected WifiMode
+ * \param operatingChannelWidth operating channel width
+ * \param maxSupportedChannelWidth maximum channel width supported by the receiver
+ * \return channel width adapted to the selected mode
+ */
+uint16_t GetChannelWidthForTransmission (WifiMode mode, uint16_t operatingChannelWidth,
+                                         uint16_t maxSupportedChannelWidth);
+
+/**
+ * Return whether the modulation class of the selected mode for the
+ * control answer frame is allowed.
+ *
+ * \param modClassReq modulation class of the request frame
+ * \param modClassAnswer modulation class of the answer frame
+ *
+ * \return true if the modulation class of the selected mode for the
+ * control answer frame is allowed, false otherwise
+ */
+bool IsAllowedControlAnswerModulationClass (WifiModulationClass modClassReq, WifiModulationClass modClassAnswer);
+
+/**
+ * Get the maximum PPDU duration (see Section 10.14 of 802.11-2016) for
+ * the PHY layers defining the aPPDUMaxTime characteristic (HT, VHT and HE).
+ * Return zero otherwise.
+ *
+ * \param preamble the preamble type
+ *
+ * \return the maximum PPDU duration, if defined, and zero otherwise
+ */
+Time GetPpduMaxTime (WifiPreamble preamble);
+
+/**
+ * Return true if a preamble corresponds to a multi-user transmission.
+ *
+ * \param preamble the preamble
+ * \return true if the provided preamble corresponds to a multi-user transmission
+ */
+bool IsMu (WifiPreamble preamble);
+
+/**
+ * Return true if a preamble corresponds to a downlink multi-user transmission.
+ *
+ * \param preamble the preamble
+ * \return true if the provided preamble corresponds to a downlink multi-user transmission
+ */
+bool IsDlMu (WifiPreamble preamble);
+
+/**
+ * Return true if a preamble corresponds to a uplink multi-user transmission.
+ *
+ * \param preamble the preamble
+ * \return true if the provided preamble corresponds to a uplink multi-user transmission
+ */
+bool IsUlMu (WifiPreamble preamble);
+
+} //namespace ns3
+
+#endif /* WIFI_PHY_COMMON_H */

--- a/src/automotive/model/SignalInfo/WiFi/wifi-phy.cc
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-phy.cc
@@ -1,0 +1,2097 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006 INRIA
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ *          Sébastien Deronne <sebastien.deronne@gmail.com>
+ */
+
+#include <algorithm>
+#include "ns3/simulator.h"
+#include "ns3/log.h"
+#include "ns3/pointer.h"
+#include "ns3/string.h"
+#include "ns3/tuple.h"
+#include "ns3/mobility-model.h"
+#include "ns3/random-variable-stream.h"
+#include "ns3/error-model.h"
+#include "wifi-net-device.h"
+#include "wifi-phy.h"
+#include "wifi-utils.h"
+#include "interference-helper.h"
+#include "frame-capture-model.h"
+#include "preamble-detection-model.h"
+#include "wifi-radio-energy-model.h"
+#include "error-rate-model.h"
+#include "wifi-net-device.h"
+#include "wifi-psdu.h"
+#include "wifi-ppdu.h"
+#include "ns3/dsss-phy.h"
+#include "ns3/erp-ofdm-phy.h"
+#include "ns3/he-phy.h" //includes OFDM, HT, and VHT
+#include "ns3/ngv-phy.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("WifiPhy");
+
+/****************************************************************
+ *       The actual WifiPhy class
+ ****************************************************************/
+
+NS_OBJECT_ENSURE_REGISTERED (WifiPhy);
+
+namespace
+{
+
+bool g_nonNgv10PpduRepeatInProgress = false;
+
+void
+SendNonNgv10RepeatedPpdu (WifiPhy* phy, WifiConstPsduMap psdus, WifiTxVector txVector)
+{
+  g_nonNgv10PpduRepeatInProgress = true;
+  phy->Send (psdus, txVector);
+  g_nonNgv10PpduRepeatInProgress = false;
+}
+
+} // namespace
+
+TypeId
+WifiPhy::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::WifiPhy")
+    .SetParent<Object> ()
+    .SetGroupName ("Wifi")
+    .AddAttribute ("ChannelSettings",
+                   "Tuple {channel number, channel width (MHz), PHY band, primary20 index} "
+                   "describing the settings of the operating channel. The primary20 index is "
+                   "the index of the primary 20 MHz channel within the operating channel "
+                   "(0 indicates the 20 MHz subchannel with the lowest center frequency) and "
+                   "is only valid if the width of the operating channel is a multiple of 20 MHz. "
+                   "If the standard for this object has not been set yet, the value of this "
+                   "attribute is saved and will be used to set the operating channel when the "
+                   "standard is configured. If the PHY band is left unspecified, the default "
+                   "band for the configured standard is used. If the channel width and the "
+                   "channel number are both 0, the default channel width for the configured "
+                   "standard and band are used. If the channel number is 0, the default "
+                   "channel number for the configured standard, band and channel width is used."
+                   "Note that the channel width can be left unspecified (0) if the channel "
+                   "number uniquely identify a frequency channel for the given standard and band. ",
+                   StringValue ("{0, 0, BAND_UNSPECIFIED, 0}"),
+                   MakeTupleAccessor <UintegerValue, UintegerValue, EnumValue, UintegerValue> ((void (WifiPhy::*) (const ChannelTuple&))(&WifiPhy::SetOperatingChannel)),
+                   MakeTupleChecker<UintegerValue, UintegerValue, EnumValue, UintegerValue>
+                     (MakeUintegerChecker<uint8_t> (0, 233),
+                      MakeUintegerChecker<uint16_t> (0, 160),
+                      MakeEnumChecker (WifiPhyBand::WIFI_PHY_BAND_2_4GHZ, "BAND_2_4GHZ",
+                                       WifiPhyBand::WIFI_PHY_BAND_5GHZ, "BAND_5GHZ",
+                                       WifiPhyBand::WIFI_PHY_BAND_6GHZ, "BAND_6GHZ",
+                                       WifiPhyBand::WIFI_PHY_BAND_UNSPECIFIED, "BAND_UNSPECIFIED"),
+                      MakeUintegerChecker<uint8_t> (0, 7)))
+    .AddAttribute ("Frequency",
+                   "The center frequency (MHz) of the current operating channel.",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&WifiPhy::GetFrequency),
+                   MakeUintegerChecker<uint16_t> ())
+    .AddAttribute ("ChannelNumber",
+                   "The channel number of the current operating channel.",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&WifiPhy::GetChannelNumber),
+                   MakeUintegerChecker<uint8_t> (0, 233))
+    .AddAttribute ("ChannelWidth",
+                   "The width in MHz of the current operating channel (5, 10, 20, 22, 40, 80 or 160).",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&WifiPhy::GetChannelWidth),
+                   MakeUintegerChecker<uint16_t> (5, 160))
+    .AddAttribute ("Primary20MHzIndex",
+                   "The index of the primary 20 MHz channel within the current operating channel "
+                   "(0 indicates the 20 MHz subchannel with the lowest center frequency).",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&WifiPhy::GetPrimary20Index),
+                   MakeUintegerChecker<uint8_t> (0, 7))
+    .AddAttribute ("RxSensitivity",
+                   "The energy of a received signal should be higher than "
+                   "this threshold (dBm) for the PHY to detect the signal. "
+                   "This threshold refers to a width of 20 MHz and will be "
+                   "scaled to match the width of the received signal.",
+                   DoubleValue (-101.0),
+                   MakeDoubleAccessor (&WifiPhy::SetRxSensitivity,
+                                       &WifiPhy::GetRxSensitivity),
+                   MakeDoubleChecker<double> ())
+    .AddAttribute ("CcaEdThreshold",
+                   "The energy of a non Wi-Fi received signal should be higher than "
+                   "this threshold (dBm) to allow the PHY layer to declare CCA BUSY state. "
+                   "This check is performed on the 20 MHz primary channel only.",
+                   DoubleValue (-62.0),
+                   MakeDoubleAccessor (&WifiPhy::SetCcaEdThreshold,
+                                       &WifiPhy::GetCcaEdThreshold),
+                   MakeDoubleChecker<double> ())
+    .AddAttribute ("TxGain",
+                   "Transmission gain (dB).",
+                   DoubleValue (0.0),
+                   MakeDoubleAccessor (&WifiPhy::SetTxGain,
+                                       &WifiPhy::GetTxGain),
+                   MakeDoubleChecker<double> ())
+    .AddAttribute ("RxGain",
+                   "Reception gain (dB).",
+                   DoubleValue (0.0),
+                   MakeDoubleAccessor (&WifiPhy::SetRxGain,
+                                       &WifiPhy::GetRxGain),
+                   MakeDoubleChecker<double> ())
+    .AddAttribute ("TxPowerLevels",
+                   "Number of transmission power levels available between "
+                   "TxPowerStart and TxPowerEnd included.",
+                   UintegerValue (1),
+                   MakeUintegerAccessor (&WifiPhy::m_nTxPower),
+                   MakeUintegerChecker<uint8_t> ())
+    .AddAttribute ("TxPowerEnd",
+                   "Maximum available transmission level (dBm).",
+                   DoubleValue (16.0206),
+                   MakeDoubleAccessor (&WifiPhy::SetTxPowerEnd,
+                                       &WifiPhy::GetTxPowerEnd),
+                   MakeDoubleChecker<double> ())
+    .AddAttribute ("TxPowerStart",
+                   "Minimum available transmission level (dBm).",
+                   DoubleValue (16.0206),
+                   MakeDoubleAccessor (&WifiPhy::SetTxPowerStart,
+                                       &WifiPhy::GetTxPowerStart),
+                   MakeDoubleChecker<double> ())
+    .AddAttribute ("RxNoiseFigure",
+                   "Loss (dB) in the Signal-to-Noise-Ratio due to non-idealities in the receiver."
+                   " According to Wikipedia (http://en.wikipedia.org/wiki/Noise_figure), this is "
+                   "\"the difference in decibels (dB) between"
+                   " the noise output of the actual receiver to the noise output of an "
+                   " ideal receiver with the same overall gain and bandwidth when the receivers "
+                   " are connected to sources at the standard noise temperature T0 (usually 290 K)\".",
+                   DoubleValue (7),
+                   MakeDoubleAccessor (&WifiPhy::SetRxNoiseFigure),
+                   MakeDoubleChecker<double> ())
+    .AddAttribute ("State",
+                   "The state of the PHY layer.",
+                   PointerValue (),
+                   MakePointerAccessor (&WifiPhy::m_state),
+                   MakePointerChecker<WifiPhyStateHelper> ())
+    .AddAttribute ("ChannelSwitchDelay",
+                   "Delay between two short frames transmitted on different frequencies.",
+                   TimeValue (MicroSeconds (250)),
+                   MakeTimeAccessor (&WifiPhy::m_channelSwitchDelay),
+                   MakeTimeChecker ())
+    .AddAttribute ("Antennas",
+                   "The number of antennas on the device.",
+                   UintegerValue (1),
+                   MakeUintegerAccessor (&WifiPhy::GetNumberOfAntennas,
+                                         &WifiPhy::SetNumberOfAntennas),
+                   MakeUintegerChecker<uint8_t> (1, 8))
+    .AddAttribute ("MaxSupportedTxSpatialStreams",
+                   "The maximum number of supported TX spatial streams."
+                   "This parameter is only valuable for 802.11n/ac/ax STAs and APs.",
+                   UintegerValue (1),
+                   MakeUintegerAccessor (&WifiPhy::GetMaxSupportedTxSpatialStreams,
+                                         &WifiPhy::SetMaxSupportedTxSpatialStreams),
+                   MakeUintegerChecker<uint8_t> (1, 8))
+    .AddAttribute ("MaxSupportedRxSpatialStreams",
+                   "The maximum number of supported RX spatial streams."
+                   "This parameter is only valuable for 802.11n/ac/ax STAs and APs.",
+                   UintegerValue (1),
+                   MakeUintegerAccessor (&WifiPhy::GetMaxSupportedRxSpatialStreams,
+                                         &WifiPhy::SetMaxSupportedRxSpatialStreams),
+                   MakeUintegerChecker<uint8_t> (1, 8))
+    .AddAttribute ("ShortPlcpPreambleSupported",
+                   "Whether or not short PHY preamble is supported."
+                   "This parameter is only valuable for 802.11b STAs and APs."
+                   "Note: 802.11g APs and STAs always support short PHY preamble.",
+                   BooleanValue (false),
+                   MakeBooleanAccessor (&WifiPhy::GetShortPhyPreambleSupported,
+                                        &WifiPhy::SetShortPhyPreambleSupported),
+                   MakeBooleanChecker ())
+    .AddAttribute ("FrameCaptureModel",
+                   "Ptr to an object that implements the frame capture model",
+                   PointerValue (),
+                   MakePointerAccessor (&WifiPhy::m_frameCaptureModel),
+                   MakePointerChecker <FrameCaptureModel> ())
+    .AddAttribute ("PreambleDetectionModel",
+                   "Ptr to an object that implements the preamble detection model",
+                   PointerValue (),
+                   MakePointerAccessor (&WifiPhy::m_preambleDetectionModel),
+                   MakePointerChecker <PreambleDetectionModel> ())
+    .AddAttribute ("PostReceptionErrorModel",
+                   "An optional packet error model can be added to the receive "
+                   "packet process after any propagation-based (SNR-based) error "
+                   "models have been applied. Typically this is used to force "
+                   "specific packet drops, for testing purposes.",
+                   PointerValue (),
+                   MakePointerAccessor (&WifiPhy::m_postReceptionErrorModel),
+                   MakePointerChecker<ErrorModel> ())
+    .AddAttribute ("Sifs",
+                   "The duration of the Short Interframe Space. "
+                   "NOTE that the default value is overwritten by the value defined "
+                   "by the standard; if you want to set this attribute, you have to "
+                   "do it after that the PHY object is initialized.",
+                   TimeValue (MicroSeconds (0)),
+                   MakeTimeAccessor (&WifiPhy::m_sifs),
+                   MakeTimeChecker ())
+    .AddAttribute ("Slot",
+                   "The duration of a slot. "
+                   "NOTE that the default value is overwritten by the value defined "
+                   "by the standard; if you want to set this attribute, you have to "
+                   "do it after that the PHY object is initialized.",
+                   TimeValue (MicroSeconds (0)),
+                   MakeTimeAccessor (&WifiPhy::m_slot),
+                   MakeTimeChecker ())
+    .AddAttribute ("Pifs",
+                   "The duration of the PCF Interframe Space. "
+                   "NOTE that the default value is overwritten by the value defined "
+                   "by the standard; if you want to set this attribute, you have to "
+                   "do it after that the PHY object is initialized.",
+                   TimeValue (MicroSeconds (0)),
+                   MakeTimeAccessor (&WifiPhy::m_pifs),
+                   MakeTimeChecker ())
+    .AddAttribute ("PowerDensityLimit",
+                   "The mean equivalent isotropically radiated power density"
+                   "limit (in dBm/MHz) set by regulators.",
+                   DoubleValue (100.0), //set to a high value so as to have no effect
+                   MakeDoubleAccessor (&WifiPhy::m_powerDensityLimit),
+                   MakeDoubleChecker<double> ())
+    .AddTraceSource ("PhyTxBegin",
+                     "Trace source indicating a packet "
+                     "has begun transmitting over the channel medium",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyTxBeginTrace),
+                     "ns3::WifiPhy::PhyTxBeginTracedCallback")
+    .AddTraceSource ("PhyTxPsduBegin",
+                     "Trace source indicating a PSDU "
+                     "has begun transmitting over the channel medium",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyTxPsduBeginTrace),
+                     "ns3::WifiPhy::PsduTxBeginCallback")
+    .AddTraceSource ("PhyTxEnd",
+                     "Trace source indicating a packet "
+                     "has been completely transmitted over the channel.",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyTxEndTrace),
+                     "ns3::Packet::TracedCallback")
+    .AddTraceSource ("PhyTxDrop",
+                     "Trace source indicating a packet "
+                     "has been dropped by the device during transmission",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyTxDropTrace),
+                     "ns3::Packet::TracedCallback")
+    .AddTraceSource ("PhyRxBegin",
+                     "Trace source indicating a packet "
+                     "has begun being received from the channel medium "
+                     "by the device",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyRxBeginTrace),
+                     "ns3::WifiPhy::PhyRxBeginTracedCallback")
+    .AddTraceSource ("PhyRxPayloadBegin",
+                     "Trace source indicating the reception of the "
+                     "payload of a PPDU has begun",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyRxPayloadBeginTrace),
+                     "ns3::WifiPhy::PhyRxPayloadBeginTracedCallback")
+    .AddTraceSource ("PhyRxEnd",
+                     "Trace source indicating a packet "
+                     "has been completely received from the channel medium "
+                     "by the device",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyRxEndTrace),
+                     "ns3::Packet::TracedCallback")
+    .AddTraceSource ("PhyRxDrop",
+                     "Trace source indicating a packet "
+                     "has been dropped by the device during reception",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyRxDropTrace),
+                     "ns3::Packet::TracedCallback")
+    .AddTraceSource ("MonitorSnifferRx",
+                     "Trace source simulating a wifi device in monitor mode "
+                     "sniffing all received frames",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyMonitorSniffRxTrace),
+                     "ns3::WifiPhy::MonitorSnifferRxTracedCallback")
+    .AddTraceSource ("MonitorSnifferTx",
+                     "Trace source simulating the capability of a wifi device "
+                     "in monitor mode to sniff all frames being transmitted",
+                     MakeTraceSourceAccessor (&WifiPhy::m_phyMonitorSniffTxTrace),
+                     "ns3::WifiPhy::MonitorSnifferTxTracedCallback")
+  ;
+  return tid;
+}
+
+WifiPhy::WifiPhy ()
+  : m_txMpduReferenceNumber (0xffffffff),
+    m_rxMpduReferenceNumber (0xffffffff),
+    m_endPhyRxEvent (),
+    m_endTxEvent (),
+    m_currentEvent (0),
+    m_previouslyRxPpduUid (UINT64_MAX),
+    m_standard (WIFI_STANDARD_UNSPECIFIED),
+    m_band (WIFI_PHY_BAND_UNSPECIFIED),
+    m_sifs (Seconds (0)),
+    m_slot (Seconds (0)),
+    m_pifs (Seconds (0)),
+    m_ackTxTime (Seconds (0)),
+    m_blockAckTxTime (Seconds (0)),
+    m_powerRestricted (false),
+    m_channelAccessRequested (false),
+    m_txSpatialStreams (0),
+    m_rxSpatialStreams (0),
+    m_wifiRadioEnergyModel (0),
+    m_timeLastPreambleDetected (Seconds (0))
+{
+  NS_LOG_FUNCTION (this);
+  m_random = CreateObject<UniformRandomVariable> ();
+  m_state = CreateObject<WifiPhyStateHelper> ();
+}
+
+WifiPhy::~WifiPhy ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+void
+WifiPhy::DoDispose (void)
+{
+  NS_LOG_FUNCTION (this);
+  m_endTxEvent.Cancel ();
+  m_endPhyRxEvent.Cancel ();
+  for (auto & phyEntity : m_phyEntities)
+    {
+      phyEntity.second->CancelAllEvents ();
+    }
+  m_device = 0;
+  m_mobility = 0;
+  m_frameCaptureModel = 0;
+  m_preambleDetectionModel = 0;
+  m_wifiRadioEnergyModel = 0;
+  m_postReceptionErrorModel = 0;
+  m_supportedChannelWidthSet.clear ();
+  if (m_interference != nullptr)
+    {
+      m_interference->Dispose ();
+    }
+  m_interference = 0;
+  m_random = 0;
+  m_state = 0;
+  m_currentEvent = 0;
+  for (auto & preambleEvent : m_currentPreambleEvents)
+    {
+      preambleEvent.second = 0;
+    }
+  m_currentPreambleEvents.clear ();
+
+  for (auto & phyEntity : m_phyEntities)
+    {
+      phyEntity.second = 0;
+    }
+  m_phyEntities.clear ();
+}
+
+std::map<WifiModulationClass, Ptr<PhyEntity> > &
+WifiPhy::GetStaticPhyEntities (void)
+{
+    static std::map<WifiModulationClass, Ptr<PhyEntity> > g_staticPhyEntities;
+    return g_staticPhyEntities;
+}
+
+Ptr<WifiPhyStateHelper>
+WifiPhy::GetState (void) const
+{
+  return m_state;
+}
+
+void
+WifiPhy::SetReceiveOkCallback (RxOkCallback callback)
+{
+  m_state->SetReceiveOkCallback (callback);
+}
+
+void
+WifiPhy::SetReceiveErrorCallback (RxErrorCallback callback)
+{
+  m_state->SetReceiveErrorCallback (callback);
+}
+
+void
+WifiPhy::RegisterListener (WifiPhyListener *listener)
+{
+  m_state->RegisterListener (listener);
+}
+
+void
+WifiPhy::UnregisterListener (WifiPhyListener *listener)
+{
+  m_state->UnregisterListener (listener);
+}
+
+void
+WifiPhy::SetCapabilitiesChangedCallback (Callback<void> callback)
+{
+  m_capabilitiesChangedCallback = callback;
+}
+
+void
+WifiPhy::SetRxSensitivity (double threshold)
+{
+  NS_LOG_FUNCTION (this << threshold);
+  m_rxSensitivityW = DbmToW (threshold);
+}
+
+double
+WifiPhy::GetRxSensitivity (void) const
+{
+  return WToDbm (m_rxSensitivityW);
+}
+
+void
+WifiPhy::SetCcaEdThreshold (double threshold)
+{
+  NS_LOG_FUNCTION (this << threshold);
+  m_ccaEdThresholdW = DbmToW (threshold);
+}
+
+double
+WifiPhy::GetCcaEdThreshold (void) const
+{
+  return WToDbm (m_ccaEdThresholdW);
+}
+
+void
+WifiPhy::SetRxNoiseFigure (double noiseFigureDb)
+{
+  NS_LOG_FUNCTION (this << noiseFigureDb);
+  if (m_interference)
+    {
+      m_interference->SetNoiseFigure (DbToRatio (noiseFigureDb));
+    }
+  m_noiseFigureDb = noiseFigureDb;
+}
+
+void
+WifiPhy::SetTxPowerStart (double start)
+{
+  NS_LOG_FUNCTION (this << start);
+  m_txPowerBaseDbm = start;
+}
+
+double
+WifiPhy::GetTxPowerStart (void) const
+{
+  return m_txPowerBaseDbm;
+}
+
+void
+WifiPhy::SetTxPowerEnd (double end)
+{
+  NS_LOG_FUNCTION (this << end);
+  m_txPowerEndDbm = end;
+}
+
+double
+WifiPhy::GetTxPowerEnd (void) const
+{
+  return m_txPowerEndDbm;
+}
+
+void
+WifiPhy::SetNTxPower (uint8_t n)
+{
+  NS_LOG_FUNCTION (this << +n);
+  m_nTxPower = n;
+}
+
+uint8_t
+WifiPhy::GetNTxPower (void) const
+{
+  return m_nTxPower;
+}
+
+void
+WifiPhy::SetTxGain (double gain)
+{
+  NS_LOG_FUNCTION (this << gain);
+  m_txGainDb = gain;
+}
+
+double
+WifiPhy::GetTxGain (void) const
+{
+  return m_txGainDb;
+}
+
+void
+WifiPhy::SetRxGain (double gain)
+{
+  NS_LOG_FUNCTION (this << gain);
+  m_rxGainDb = gain;
+}
+
+double
+WifiPhy::GetRxGain (void) const
+{
+  return m_rxGainDb;
+}
+
+void
+WifiPhy::SetShortPhyPreambleSupported (bool enable)
+{
+  NS_LOG_FUNCTION (this << enable);
+  m_shortPreamble = enable;
+}
+
+bool
+WifiPhy::GetShortPhyPreambleSupported (void) const
+{
+  return m_shortPreamble;
+}
+
+void
+WifiPhy::SetDevice (const Ptr<WifiNetDevice> device)
+{
+  m_device = device;
+}
+
+Ptr<WifiNetDevice>
+WifiPhy::GetDevice (void) const
+{
+  return m_device;
+}
+
+void
+WifiPhy::SetMobility (const Ptr<MobilityModel> mobility)
+{
+  m_mobility = mobility;
+}
+
+Ptr<MobilityModel>
+WifiPhy::GetMobility (void) const
+{
+  if (m_mobility != 0)
+    {
+      return m_mobility;
+    }
+  else
+    {
+      return m_device->GetNode ()->GetObject<MobilityModel> ();
+    }
+}
+
+void
+WifiPhy::SetInterferenceHelper (const Ptr<InterferenceHelper> helper)
+{
+  m_interference = helper;
+  m_interference->SetNoiseFigure (DbToRatio (m_noiseFigureDb));
+  m_interference->SetNumberOfReceiveAntennas (m_numberOfAntennas);
+}
+
+void
+WifiPhy::SetErrorRateModel (const Ptr<ErrorRateModel> model)
+{
+  NS_ASSERT (m_interference != nullptr);
+  m_interference->SetErrorRateModel (model);
+}
+
+void
+WifiPhy::SetPostReceptionErrorModel (const Ptr<ErrorModel> em)
+{
+  NS_LOG_FUNCTION (this << em);
+  m_postReceptionErrorModel = em;
+}
+
+void
+WifiPhy::SetFrameCaptureModel (const Ptr<FrameCaptureModel> model)
+{
+  m_frameCaptureModel = model;
+}
+
+void
+WifiPhy::SetPreambleDetectionModel (const Ptr<PreambleDetectionModel> model)
+{
+  m_preambleDetectionModel = model;
+}
+
+void
+WifiPhy::SetWifiRadioEnergyModel (const Ptr<WifiRadioEnergyModel> wifiRadioEnergyModel)
+{
+  m_wifiRadioEnergyModel = wifiRadioEnergyModel;
+}
+
+double
+WifiPhy::GetPowerDbm (uint8_t power) const
+{
+  NS_ASSERT (m_txPowerBaseDbm <= m_txPowerEndDbm);
+  NS_ASSERT (m_nTxPower > 0);
+  double dbm;
+  if (m_nTxPower > 1)
+    {
+      dbm = m_txPowerBaseDbm + power * (m_txPowerEndDbm - m_txPowerBaseDbm) / (m_nTxPower - 1);
+    }
+  else
+    {
+      NS_ASSERT_MSG (m_txPowerBaseDbm == m_txPowerEndDbm, "cannot have TxPowerEnd != TxPowerStart with TxPowerLevels == 1");
+      dbm = m_txPowerBaseDbm;
+    }
+  return dbm;
+}
+
+Time
+WifiPhy::GetChannelSwitchDelay (void) const
+{
+  return m_channelSwitchDelay;
+}
+
+double
+WifiPhy::CalculateSnr (const WifiTxVector& txVector, double ber) const
+{
+  return m_interference->GetErrorRateModel ()->CalculateSnr (txVector, ber);
+}
+
+const Ptr<const PhyEntity>
+WifiPhy::GetStaticPhyEntity (WifiModulationClass modulation)
+{
+  const auto it = GetStaticPhyEntities ().find (modulation);
+  NS_ABORT_MSG_IF (it == GetStaticPhyEntities ().end (), "Unimplemented Wi-Fi modulation class");
+  return it->second;
+}
+
+Ptr<PhyEntity>
+WifiPhy::GetPhyEntity (WifiModulationClass modulation) const
+{
+  const auto it = m_phyEntities.find (modulation);
+  NS_ABORT_MSG_IF (it == m_phyEntities.end (), "Unsupported Wi-Fi modulation class " << modulation);
+  return it->second;
+}
+
+void
+WifiPhy::AddStaticPhyEntity (WifiModulationClass modulation, Ptr<PhyEntity> phyEntity)
+{
+  NS_LOG_FUNCTION (modulation);
+  NS_ASSERT_MSG (GetStaticPhyEntities ().find (modulation) == GetStaticPhyEntities ().end (), "The PHY entity has already been added. The setting should only be done once per modulation class");
+    GetStaticPhyEntities ()[modulation] = phyEntity;
+}
+
+void
+WifiPhy::AddPhyEntity (WifiModulationClass modulation, Ptr<PhyEntity> phyEntity)
+{
+  NS_LOG_FUNCTION (this << modulation);
+  NS_ABORT_MSG_IF (GetStaticPhyEntities ().find (modulation) == GetStaticPhyEntities ().end (), "Cannot add an unimplemented PHY to supported list. Update the former first.");
+  NS_ASSERT_MSG (m_phyEntities.find (modulation) == m_phyEntities.end (), "The PHY entity has already been added. The setting should only be done once per modulation class");
+  phyEntity->SetOwner (this);
+  m_phyEntities[modulation] = phyEntity;
+}
+
+void
+WifiPhy::SetSifs (Time sifs)
+{
+  m_sifs = sifs;
+}
+
+Time
+WifiPhy::GetSifs (void) const
+{
+  return m_sifs;
+}
+
+void
+WifiPhy::SetSlot (Time slot)
+{
+  m_slot = slot;
+}
+
+Time
+WifiPhy::GetSlot (void) const
+{
+  return m_slot;
+}
+
+void
+WifiPhy::SetPifs (Time pifs)
+{
+  m_pifs = pifs;
+}
+
+Time
+WifiPhy::GetPifs (void) const
+{
+  return m_pifs;
+}
+
+Time
+WifiPhy::GetAckTxTime (void) const
+{
+  return m_ackTxTime;
+}
+
+Time
+WifiPhy::GetBlockAckTxTime (void) const
+{
+  return m_blockAckTxTime;
+}
+
+void
+WifiPhy::Configure80211a (void)
+{
+  NS_LOG_FUNCTION (this);
+  AddPhyEntity (WIFI_MOD_CLASS_OFDM, Create<OfdmPhy> ());
+
+  // See Table 17-21 "OFDM PHY characteristics" of 802.11-2016
+  SetSifs (MicroSeconds (16));
+  SetSlot (MicroSeconds (9));
+  SetPifs (GetSifs () + GetSlot ());
+  // See Table 10-5 "Determination of the EstimatedAckTxTime based on properties
+  // of the PPDU causing the EIFS" of 802.11-2016
+  m_ackTxTime = MicroSeconds (44);
+}
+
+void
+WifiPhy::Configure80211b (void)
+{
+  NS_LOG_FUNCTION (this);
+  Ptr<DsssPhy> phyEntity = Create<DsssPhy> ();
+  AddPhyEntity (WIFI_MOD_CLASS_HR_DSSS, phyEntity);
+  AddPhyEntity (WIFI_MOD_CLASS_DSSS, phyEntity); //when plain DSSS modes are used
+
+  // See Table 16-4 "HR/DSSS PHY characteristics" of 802.11-2016
+  SetSifs (MicroSeconds (10));
+  SetSlot (MicroSeconds (20));
+  SetPifs (GetSifs () + GetSlot ());
+  // See Table 10-5 "Determination of the EstimatedAckTxTime based on properties
+  // of the PPDU causing the EIFS" of 802.11-2016
+  m_ackTxTime = MicroSeconds (304);
+}
+
+void
+WifiPhy::Configure80211g (void)
+{
+  NS_LOG_FUNCTION (this);
+  // See Table 18-5 "ERP characteristics" of 802.11-2016
+  // Slot time defaults to the "long slot time" of 20 us in the standard
+  // according to mixed 802.11b/g deployments.  Short slot time is enabled
+  // if the user sets the ShortSlotTimeSupported flag to true and when the BSS
+  // consists of only ERP STAs capable of supporting this option.
+  Configure80211b ();
+  AddPhyEntity (WIFI_MOD_CLASS_ERP_OFDM, Create<ErpOfdmPhy> ());
+}
+
+void
+WifiPhy::Configure80211p (void)
+{
+  NS_LOG_FUNCTION (this);
+  if (GetChannelWidth () == 10)
+    {
+      AddPhyEntity (WIFI_MOD_CLASS_OFDM, Create<OfdmPhy> (OFDM_PHY_10_MHZ));
+
+      // See Table 17-21 "OFDM PHY characteristics" of 802.11-2016
+      SetSifs (MicroSeconds (32));
+      SetSlot (MicroSeconds (13));
+      SetPifs (GetSifs () + GetSlot ());
+      m_ackTxTime = MicroSeconds (88);
+    }
+  else if (GetChannelWidth () == 5)
+    {
+      AddPhyEntity (WIFI_MOD_CLASS_OFDM, Create<OfdmPhy> (OFDM_PHY_5_MHZ));
+
+      // See Table 17-21 "OFDM PHY characteristics" of 802.11-2016
+      SetSifs (MicroSeconds (64));
+      SetSlot (MicroSeconds (21));
+      SetPifs (GetSifs () + GetSlot ());
+      m_ackTxTime = MicroSeconds (176);
+    }
+  else
+    {
+      NS_FATAL_ERROR ("802.11p configured with a wrong channel width!");
+    }
+}
+
+void
+WifiPhy::Configure80211n (void)
+{
+  NS_LOG_FUNCTION (this);
+  if (m_band == WIFI_PHY_BAND_2_4GHZ)
+    {
+      Configure80211g ();
+    }
+  else
+    {
+      Configure80211a ();
+    }
+  AddPhyEntity (WIFI_MOD_CLASS_HT, Create<HtPhy> (m_txSpatialStreams));
+
+  // See Table 10-5 "Determination of the EstimatedAckTxTime based on properties
+  // of the PPDU causing the EIFS" of 802.11-2016
+  m_blockAckTxTime = MicroSeconds (68);
+}
+
+void
+WifiPhy::Configure80211ac (void)
+{
+  NS_LOG_FUNCTION (this);
+  Configure80211n ();
+  AddPhyEntity (WIFI_MOD_CLASS_VHT, Create<VhtPhy> ());
+}
+
+void
+WifiPhy::Configure80211ax (void)
+{
+  NS_LOG_FUNCTION (this);
+  if (m_band == WIFI_PHY_BAND_2_4GHZ)
+    {
+      Configure80211n ();
+    }
+  else
+    {
+      Configure80211ac ();
+    }
+  AddPhyEntity (WIFI_MOD_CLASS_HE, Create<HePhy> ());
+}
+
+void
+WifiPhy::ConfigureStandard (WifiStandard standard)
+{
+  NS_LOG_FUNCTION (this << standard);
+
+  NS_ABORT_MSG_IF (m_standard != WIFI_STANDARD_UNSPECIFIED && standard != m_standard,
+                   "Cannot change standard");
+
+  m_standard = standard;
+
+  if (!m_operatingChannel.IsSet ())
+    {
+      NS_LOG_DEBUG ("Setting the operating channel first");
+      SetOperatingChannel (m_channelSettings);
+      // return because we are called back by SetOperatingChannel
+      return;
+    }
+
+  // this function is called when changing PHY band, hence we have to delete
+  // the previous PHY entities
+  m_phyEntities.clear ();
+
+  switch (standard)
+    {
+    case WIFI_STANDARD_80211a:
+      Configure80211a ();
+      break;
+    case WIFI_STANDARD_80211b:
+      Configure80211b ();
+      break;
+    case WIFI_STANDARD_80211g:
+      Configure80211g ();
+      break;
+    case WIFI_STANDARD_80211p:
+      Configure80211p ();
+      break;
+    case WIFI_STANDARD_80211bd:
+      if (GetChannelWidth () == 20)
+        {
+          AddPhyEntity (WIFI_MOD_CLASS_OFDM, Create<OfdmPhy> (OFDM_PHY_10_MHZ));
+          SetSifs (MicroSeconds (32));
+          SetSlot (MicroSeconds (13));
+          SetPifs (GetSifs () + GetSlot ());
+          m_ackTxTime = MicroSeconds (88);
+        }
+      else
+        {
+          Configure80211p ();
+        }
+      AddPhyEntity (WIFI_MOD_CLASS_NGV, Create<NgvPhy> ());
+      break;
+    case WIFI_STANDARD_80211n:
+      Configure80211n ();
+      break;
+    case WIFI_STANDARD_80211ac:
+      Configure80211ac ();
+      break;
+    case WIFI_STANDARD_80211ax:
+      Configure80211ax ();
+      break;
+    case WIFI_STANDARD_UNSPECIFIED:
+    default:
+      NS_ASSERT_MSG (false, "Unsupported standard");
+      break;
+    }
+}
+
+WifiPhyBand
+WifiPhy::GetPhyBand (void) const
+{
+  return m_band;
+}
+
+
+WifiStandard
+WifiPhy::GetStandard (void) const
+{
+  return m_standard;
+}
+
+const WifiPhyOperatingChannel&
+WifiPhy::GetOperatingChannel (void) const
+{
+  return m_operatingChannel;
+}
+
+uint16_t
+WifiPhy::GetFrequency (void) const
+{
+  return m_operatingChannel.GetFrequency ();
+}
+
+uint8_t
+WifiPhy::GetChannelNumber (void) const
+{
+  return m_operatingChannel.GetNumber ();
+}
+
+uint16_t
+WifiPhy::GetChannelWidth (void) const
+{
+  return m_operatingChannel.GetWidth ();
+}
+
+uint8_t
+WifiPhy::GetPrimary20Index (void) const
+{
+  return m_operatingChannel.GetPrimaryChannelIndex (20);
+}
+
+void
+WifiPhy::SetOperatingChannel (const ChannelTuple& channelTuple)
+{
+  // the generic operator<< for tuples does not give a pretty result
+  NS_LOG_FUNCTION (this << +std::get<0> (channelTuple) << std::get<1> (channelTuple)
+                   << static_cast<WifiPhyBand> (std::get<2> (channelTuple))
+                   << +std::get<3> (channelTuple));
+
+  m_channelSettings = channelTuple;
+
+  if (m_standard == WIFI_STANDARD_UNSPECIFIED)
+    {
+      NS_LOG_DEBUG ("Channel information will be applied when a standard is configured");
+      return;
+    }
+
+  Time delay = Seconds (0);
+
+  if (IsInitialized ())
+    {
+      delay = GetDelayUntilChannelSwitch ();
+    }
+
+  if (delay.IsStrictlyNegative ())
+    {
+      // switching channel is not possible now
+      return;
+    }
+  if (delay.IsStrictlyPositive ())
+    {
+      // switching channel has been postponed
+      void (WifiPhy::*fp) (const ChannelTuple&) = &WifiPhy::SetOperatingChannel;
+      Simulator::Schedule (delay, fp, this, channelTuple);
+      return;
+    }
+
+  // channel can be switched now.
+  DoChannelSwitch ();
+}
+
+Time
+WifiPhy::GetDelayUntilChannelSwitch (void)
+{
+  m_powerRestricted = false;
+  m_channelAccessRequested = false;
+  m_currentEvent = 0;
+  m_currentPreambleEvents.clear ();
+  if (!IsInitialized ())
+    {
+      //this is not channel switch, this is initialization
+      NS_LOG_DEBUG ("Before initialization, nothing to do");
+      return Seconds (0);
+    }
+
+  Time delay = Seconds (0);
+
+  NS_ASSERT (!IsStateSwitching ());
+  switch (m_state->GetState ())
+    {
+    case WifiPhyState::RX:
+      NS_LOG_DEBUG ("drop packet because of channel switching while reception");
+      m_endPhyRxEvent.Cancel ();
+      for (auto & phyEntity : m_phyEntities)
+        {
+          phyEntity.second->CancelAllEvents ();
+        }
+      break;
+    case WifiPhyState::TX:
+      NS_LOG_DEBUG ("channel switching postponed until end of current transmission");
+      delay = GetDelayUntilIdle ();
+      break;
+    case WifiPhyState::CCA_BUSY:
+    case WifiPhyState::IDLE:
+      m_endPhyRxEvent.Cancel ();
+      for (auto & phyEntity : m_phyEntities)
+        {
+          phyEntity.second->CancelAllEvents ();
+        }
+      break;
+    case WifiPhyState::SLEEP:
+      NS_LOG_DEBUG ("channel switching ignored in sleep mode");
+      delay = Seconds (-1);  // negative value to indicate switching not possible
+      break;
+    default:
+      NS_ASSERT (false);
+      break;
+    }
+
+  return delay;
+}
+
+void
+WifiPhy::DoChannelSwitch (void)
+{
+  NS_LOG_FUNCTION (this);
+
+  // Update unspecified parameters with default values
+  if (auto& [number, width, band, primary20] = m_channelSettings; true)
+    {
+      if (band == static_cast<int> (WIFI_PHY_BAND_UNSPECIFIED))
+        {
+          band = static_cast<int> (GetDefaultPhyBand (m_standard));
+        }
+      if (width == 0 && number == 0)
+        {
+          width = GetDefaultChannelWidth (m_standard, static_cast<WifiPhyBand> (band));
+        }
+      if (number == 0)
+        {
+          number = WifiPhyOperatingChannel::GetDefaultChannelNumber (width, m_standard, static_cast<WifiPhyBand> (band));
+        }
+    }
+
+  // We need to call SetStandard if this is the first time we set a channel or we
+  // are changing PHY band. Checking if the new PHY band is different than the
+  // previous one covers both cases because initially the PHY band is unspecified
+  bool changingPhyBand = (static_cast<WifiPhyBand> (std::get<2> (m_channelSettings)) != m_band);
+
+  m_band = static_cast<WifiPhyBand> (std::get<2> (m_channelSettings));
+
+  NS_LOG_DEBUG ("switching channel");
+  m_operatingChannel.Set (std::get<0> (m_channelSettings), 0, std::get<1> (m_channelSettings),
+                          m_standard, m_band);
+  m_operatingChannel.SetPrimary20Index (std::get<3> (m_channelSettings));
+
+  if (changingPhyBand)
+    {
+      ConfigureStandard (m_standard);
+    }
+
+  AddSupportedChannelWidth (GetChannelWidth ());
+
+  if (IsInitialized ())
+    {
+      // notify channel switching
+      m_state->SwitchToChannelSwitching (GetChannelSwitchDelay ());
+      m_interference->EraseEvents ();
+      /*
+      * Needed here to be able to correctly sensed the medium for the first
+      * time after the switching. The actual switching is not performed until
+      * after m_channelSwitchDelay. Packets received during the switching
+      * state are added to the event list and are employed later to figure
+      * out the state of the medium after the switching.
+      */
+    }
+}
+
+void
+WifiPhy::SetNumberOfAntennas (uint8_t antennas)
+{
+  NS_LOG_FUNCTION (this << +antennas);
+  NS_ASSERT_MSG (antennas > 0 && antennas <= 4, "unsupported number of antennas");
+  m_numberOfAntennas = antennas;
+  if (m_interference)
+    {
+      m_interference->SetNumberOfReceiveAntennas (antennas);
+    }
+}
+
+uint8_t
+WifiPhy::GetNumberOfAntennas (void) const
+{
+  return m_numberOfAntennas;
+}
+
+void
+WifiPhy::SetMaxSupportedTxSpatialStreams (uint8_t streams)
+{
+  NS_ASSERT (streams <= GetNumberOfAntennas ());
+  bool changed = (m_txSpatialStreams != streams);
+  m_txSpatialStreams = streams;
+  if (changed)
+    {
+      auto phyEntity = m_phyEntities.find (WIFI_MOD_CLASS_HT);
+      if (phyEntity != m_phyEntities.end ())
+        {
+          Ptr<HtPhy> htPhy = DynamicCast<HtPhy> (phyEntity->second);
+          if (htPhy)
+            {
+              htPhy->SetMaxSupportedNss (m_txSpatialStreams); //this is essential to have the right MCSs configured
+            }
+
+          if (!m_capabilitiesChangedCallback.IsNull ())
+            {
+              m_capabilitiesChangedCallback ();
+            }
+        }
+    }
+}
+
+uint8_t
+WifiPhy::GetMaxSupportedTxSpatialStreams (void) const
+{
+  return m_txSpatialStreams;
+}
+
+void
+WifiPhy::SetMaxSupportedRxSpatialStreams (uint8_t streams)
+{
+  NS_ASSERT (streams <= GetNumberOfAntennas ());
+  bool changed = (m_rxSpatialStreams != streams);
+  m_rxSpatialStreams = streams;
+  if (changed && !m_capabilitiesChangedCallback.IsNull ())
+    {
+      m_capabilitiesChangedCallback ();
+    }
+}
+
+uint8_t
+WifiPhy::GetMaxSupportedRxSpatialStreams (void) const
+{
+  return m_rxSpatialStreams;
+}
+
+std::list<uint8_t>
+WifiPhy::GetBssMembershipSelectorList (void) const
+{
+  std::list<uint8_t> list;
+  for (const auto & phyEntity : m_phyEntities)
+    {
+      Ptr<HtPhy> htPhy = DynamicCast<HtPhy> (phyEntity.second);
+      if (htPhy)
+        {
+          list.emplace_back (htPhy->GetBssMembershipSelector ());
+        }
+    }
+  return list;
+}
+
+void
+WifiPhy::AddSupportedChannelWidth (uint16_t width)
+{
+  NS_LOG_FUNCTION (this << width);
+  for (std::vector<uint32_t>::size_type i = 0; i != m_supportedChannelWidthSet.size (); i++)
+    {
+      if (m_supportedChannelWidthSet[i] == width)
+        {
+          return;
+        }
+    }
+  NS_LOG_FUNCTION ("Adding " << width << " to supported channel width set");
+  m_supportedChannelWidthSet.push_back (width);
+}
+
+std::vector<uint16_t>
+WifiPhy::GetSupportedChannelWidthSet (void) const
+{
+  return m_supportedChannelWidthSet;
+}
+
+void
+WifiPhy::SetSleepMode (void)
+{
+  NS_LOG_FUNCTION (this);
+  m_powerRestricted = false;
+  m_channelAccessRequested = false;
+  switch (m_state->GetState ())
+    {
+    case WifiPhyState::TX:
+      NS_LOG_DEBUG ("setting sleep mode postponed until end of current transmission");
+      Simulator::Schedule (GetDelayUntilIdle (), &WifiPhy::SetSleepMode, this);
+      break;
+    case WifiPhyState::RX:
+      NS_LOG_DEBUG ("setting sleep mode postponed until end of current reception");
+      Simulator::Schedule (GetDelayUntilIdle (), &WifiPhy::SetSleepMode, this);
+      break;
+    case WifiPhyState::SWITCHING:
+      NS_LOG_DEBUG ("setting sleep mode postponed until end of channel switching");
+      Simulator::Schedule (GetDelayUntilIdle (), &WifiPhy::SetSleepMode, this);
+      break;
+    case WifiPhyState::CCA_BUSY:
+    case WifiPhyState::IDLE:
+      NS_LOG_DEBUG ("setting sleep mode");
+      m_state->SwitchToSleep ();
+      break;
+    case WifiPhyState::SLEEP:
+      NS_LOG_DEBUG ("already in sleep mode");
+      break;
+    default:
+      NS_ASSERT (false);
+      break;
+    }
+}
+
+void
+WifiPhy::SetOffMode (void)
+{
+  NS_LOG_FUNCTION (this);
+  m_powerRestricted = false;
+  m_channelAccessRequested = false;
+  m_endPhyRxEvent.Cancel ();
+  m_endTxEvent.Cancel ();
+  for (auto & phyEntity : m_phyEntities)
+    {
+      phyEntity.second->CancelAllEvents ();
+    }
+  m_state->SwitchToOff ();
+}
+
+void
+WifiPhy::ResumeFromSleep (void)
+{
+  NS_LOG_FUNCTION (this);
+  m_currentPreambleEvents.clear ();
+  switch (m_state->GetState ())
+    {
+    case WifiPhyState::TX:
+    case WifiPhyState::RX:
+    case WifiPhyState::IDLE:
+    case WifiPhyState::CCA_BUSY:
+    case WifiPhyState::SWITCHING:
+      {
+        NS_LOG_DEBUG ("not in sleep mode, there is nothing to resume");
+        break;
+      }
+    case WifiPhyState::SLEEP:
+      {
+        NS_LOG_DEBUG ("resuming from sleep mode");
+        m_state->SwitchFromSleep ();
+        SwitchMaybeToCcaBusy (GetMeasurementChannelWidth (nullptr));
+        break;
+      }
+    default:
+      {
+        NS_ASSERT (false);
+        break;
+      }
+    }
+}
+
+void
+WifiPhy::ResumeFromOff (void)
+{
+  NS_LOG_FUNCTION (this);
+  switch (m_state->GetState ())
+    {
+    case WifiPhyState::TX:
+    case WifiPhyState::RX:
+    case WifiPhyState::IDLE:
+    case WifiPhyState::CCA_BUSY:
+    case WifiPhyState::SWITCHING:
+    case WifiPhyState::SLEEP:
+      {
+        NS_LOG_DEBUG ("not in off mode, there is nothing to resume");
+        break;
+      }
+    case WifiPhyState::OFF:
+      {
+        NS_LOG_DEBUG ("resuming from off mode");
+        m_state->SwitchFromOff ();
+        SwitchMaybeToCcaBusy (GetMeasurementChannelWidth (nullptr));
+        break;
+      }
+    default:
+      {
+        NS_ASSERT (false);
+        break;
+      }
+    }
+}
+
+Time
+WifiPhy::GetPreambleDetectionDuration (void)
+{
+  return MicroSeconds (4);
+}
+
+Time
+WifiPhy::GetStartOfPacketDuration (const WifiTxVector& txVector)
+{
+  return MicroSeconds (4);
+}
+
+Time
+WifiPhy::GetPayloadDuration (uint32_t size, const WifiTxVector& txVector, WifiPhyBand band, MpduType mpdutype, uint16_t staId)
+{
+  uint32_t totalAmpduSize;
+  double totalAmpduNumSymbols;
+  return GetPayloadDuration (size, txVector, band, mpdutype, false, totalAmpduSize, totalAmpduNumSymbols, staId);
+}
+
+Time
+WifiPhy::GetPayloadDuration (uint32_t size, const WifiTxVector& txVector, WifiPhyBand band, MpduType mpdutype,
+                             bool incFlag, uint32_t &totalAmpduSize, double &totalAmpduNumSymbols,
+                             uint16_t staId)
+{
+  return GetStaticPhyEntity (txVector.GetModulationClass ())->GetPayloadDuration (size, txVector, band, mpdutype,
+                                                                                  incFlag, totalAmpduSize, totalAmpduNumSymbols,
+                                                                                  staId);
+}
+
+Time
+WifiPhy::CalculatePhyPreambleAndHeaderDuration (const WifiTxVector& txVector)
+{
+  if (txVector.IsNonNgv20Duplicate ())
+    {
+      WifiTxVector durationTxVector (txVector);
+      durationTxVector.SetChannelWidth (10);
+      return GetStaticPhyEntity (durationTxVector.GetModulationClass ())->
+          CalculatePhyPreambleAndHeaderDuration (durationTxVector);
+    }
+  return GetStaticPhyEntity (txVector.GetModulationClass ())->CalculatePhyPreambleAndHeaderDuration (txVector);
+}
+
+Time
+WifiPhy::CalculateTxDuration (uint32_t size, const WifiTxVector& txVector, WifiPhyBand band, uint16_t staId)
+{
+  WifiTxVector durationTxVector (txVector);
+  if (txVector.IsNonNgv20Duplicate ())
+    {
+      durationTxVector.SetChannelWidth (10);
+    }
+  Time duration = CalculatePhyPreambleAndHeaderDuration (durationTxVector)
+    + GetPayloadDuration (size, durationTxVector, band, NORMAL_MPDU, staId);
+  NS_ASSERT (duration.IsStrictlyPositive ());
+  return duration;
+}
+
+Time
+WifiPhy::CalculateTxDuration (Ptr<const WifiPsdu> psdu, const WifiTxVector& txVector, WifiPhyBand band)
+{
+  return CalculateTxDuration (GetWifiConstPsduMap (psdu, txVector), txVector, band);
+}
+
+Time
+WifiPhy::CalculateTxDuration (WifiConstPsduMap psduMap, const WifiTxVector& txVector, WifiPhyBand band)
+{
+  if (txVector.IsNonNgv20Duplicate ())
+    {
+      WifiTxVector durationTxVector (txVector);
+      durationTxVector.SetChannelWidth (10);
+      return GetStaticPhyEntity (durationTxVector.GetModulationClass ())->
+          CalculateTxDuration (psduMap, durationTxVector, band);
+    }
+  return GetStaticPhyEntity (txVector.GetModulationClass ())->CalculateTxDuration (psduMap, txVector, band);
+}
+
+uint32_t
+WifiPhy::GetMaxPsduSize (WifiModulationClass modulation)
+{
+  return GetStaticPhyEntity (modulation)->GetMaxPsduSize ();
+}
+
+void
+WifiPhy::NotifyTxBegin (WifiConstPsduMap psdus, double txPowerW)
+{
+  if (!m_phyTxBeginTrace.IsEmpty ())
+    {
+      for (auto const& psdu : psdus)
+        {
+          for (auto& mpdu : *PeekPointer (psdu.second))
+            {
+              m_phyTxBeginTrace (mpdu->GetProtocolDataUnit (), txPowerW);
+            }
+        }
+    }
+}
+
+void
+WifiPhy::NotifyTxEnd (WifiConstPsduMap psdus)
+{
+  if (!m_phyTxEndTrace.IsEmpty ())
+    {
+      for (auto const& psdu : psdus)
+        {
+          for (auto& mpdu : *PeekPointer (psdu.second))
+            {
+              m_phyTxEndTrace (mpdu->GetProtocolDataUnit ());
+            }
+        }
+    }
+}
+
+void
+WifiPhy::NotifyTxDrop (Ptr<const WifiPsdu> psdu)
+{
+  if (!m_phyTxDropTrace.IsEmpty ())
+    {
+      for (auto& mpdu : *PeekPointer (psdu))
+        {
+          m_phyTxDropTrace (mpdu->GetProtocolDataUnit ());
+        }
+    }
+}
+
+void
+WifiPhy::NotifyRxBegin (Ptr<const WifiPsdu> psdu, const RxPowerWattPerChannelBand& rxPowersW)
+{
+  if (psdu && !m_phyRxBeginTrace.IsEmpty ())
+    {
+      for (auto& mpdu : *PeekPointer (psdu))
+        {
+          m_phyRxBeginTrace (mpdu->GetProtocolDataUnit (), rxPowersW);
+        }
+    }
+}
+
+void
+WifiPhy::NotifyRxEnd (Ptr<const WifiPsdu> psdu)
+{
+  if (psdu && !m_phyRxEndTrace.IsEmpty ())
+    {
+      for (auto& mpdu : *PeekPointer (psdu))
+        {
+          m_phyRxEndTrace (mpdu->GetProtocolDataUnit ());
+        }
+    }
+}
+
+void
+WifiPhy::NotifyRxDrop (Ptr<const WifiPsdu> psdu, WifiPhyRxfailureReason reason)
+{
+  if (psdu && !m_phyRxDropTrace.IsEmpty ())
+    {
+      for (auto& mpdu : *PeekPointer (psdu))
+        {
+          m_phyRxDropTrace (mpdu->GetProtocolDataUnit (), reason);
+        }
+    }
+}
+
+void
+WifiPhy::NotifyMonitorSniffRx (Ptr<const WifiPsdu> psdu, uint16_t channelFreqMhz, WifiTxVector txVector,
+                               SignalNoiseDbm signalNoise, std::vector<bool> statusPerMpdu, uint16_t staId)
+{
+  MpduInfo aMpdu;
+  if (psdu->IsAggregate ())
+    {
+      //Expand A-MPDU
+      NS_ASSERT_MSG (txVector.IsAggregation (), "TxVector with aggregate flag expected here according to PSDU");
+      aMpdu.mpduRefNumber = ++m_rxMpduReferenceNumber;
+      size_t nMpdus = psdu->GetNMpdus ();
+      NS_ASSERT_MSG (statusPerMpdu.size () == nMpdus, "Should have one reception status per MPDU");
+      if (!m_phyMonitorSniffRxTrace.IsEmpty ())
+        {
+          aMpdu.type = (psdu->IsSingle ()) ? SINGLE_MPDU : FIRST_MPDU_IN_AGGREGATE;
+          for (size_t i = 0; i < nMpdus;)
+            {
+              if (statusPerMpdu.at (i)) //packet received without error, hand over to sniffer
+                {
+                  m_phyMonitorSniffRxTrace (psdu->GetAmpduSubframe (i), channelFreqMhz, txVector, aMpdu, signalNoise, staId);
+                }
+              ++i;
+              aMpdu.type = (i == (nMpdus - 1)) ? LAST_MPDU_IN_AGGREGATE : MIDDLE_MPDU_IN_AGGREGATE;
+            }
+        }
+    }
+  else
+    {
+      NS_ASSERT_MSG (statusPerMpdu.size () == 1, "Should have one reception status for normal MPDU");
+      if (!m_phyMonitorSniffRxTrace.IsEmpty ())
+        {
+          aMpdu.type = NORMAL_MPDU;
+          m_phyMonitorSniffRxTrace (psdu->GetPacket (), channelFreqMhz, txVector, aMpdu, signalNoise, staId);
+        }
+    }
+}
+
+void
+WifiPhy::NotifyMonitorSniffTx (Ptr<const WifiPsdu> psdu, uint16_t channelFreqMhz, WifiTxVector txVector, uint16_t staId)
+{
+  MpduInfo aMpdu;
+  if (psdu->IsAggregate ())
+    {
+      //Expand A-MPDU
+      NS_ASSERT_MSG (txVector.IsAggregation (), "TxVector with aggregate flag expected here according to PSDU");
+      aMpdu.mpduRefNumber = ++m_rxMpduReferenceNumber;
+      if (!m_phyMonitorSniffTxTrace.IsEmpty ())
+        {
+          size_t nMpdus = psdu->GetNMpdus ();
+          aMpdu.type = (psdu->IsSingle ()) ? SINGLE_MPDU: FIRST_MPDU_IN_AGGREGATE;
+          for (size_t i = 0; i < nMpdus;)
+            {
+              m_phyMonitorSniffTxTrace (psdu->GetAmpduSubframe (i), channelFreqMhz, txVector, aMpdu, staId);
+              ++i;
+              aMpdu.type = (i == (nMpdus - 1)) ? LAST_MPDU_IN_AGGREGATE : MIDDLE_MPDU_IN_AGGREGATE;
+            }
+        }
+    }
+  else
+    {
+      if (!m_phyMonitorSniffTxTrace.IsEmpty ())
+        {
+          aMpdu.type = NORMAL_MPDU;
+          m_phyMonitorSniffTxTrace (psdu->GetPacket (), channelFreqMhz, txVector, aMpdu, staId);
+        }
+    }
+}
+
+WifiConstPsduMap
+WifiPhy::GetWifiConstPsduMap (Ptr<const WifiPsdu> psdu, const WifiTxVector& txVector)
+{
+  return GetStaticPhyEntity (txVector.GetModulationClass ())->GetWifiConstPsduMap (psdu, txVector);
+}
+
+void
+WifiPhy::Send (Ptr<const WifiPsdu> psdu, const WifiTxVector& txVector)
+{
+  NS_LOG_FUNCTION (this << *psdu << txVector);
+  Send (GetWifiConstPsduMap (psdu, txVector), txVector);
+}
+
+void
+WifiPhy::Send (WifiConstPsduMap psdus, const WifiTxVector& txVector)
+{
+  NS_LOG_FUNCTION (this << psdus << txVector);
+  /* Transmission can happen if:
+   *  - we are syncing on a packet. It is the responsibility of the
+   *    MAC layer to avoid doing this but the PHY does nothing to
+   *    prevent it.
+   *  - we are idle
+   */
+  NS_ASSERT (!m_state->IsStateTx () && !m_state->IsStateSwitching ());
+  NS_ASSERT (m_endTxEvent.IsExpired ());
+
+  if (txVector.GetNssMax () > GetMaxSupportedTxSpatialStreams ())
+    {
+      NS_FATAL_ERROR ("Unsupported number of spatial streams!");
+    }
+
+  if (m_state->IsStateSleep ())
+    {
+      NS_LOG_DEBUG ("Dropping packet because in sleep mode");
+      for (auto const& psdu : psdus)
+        {
+          NotifyTxDrop (psdu.second);
+        }
+      return;
+    }
+
+  Time txDuration = CalculateTxDuration (psdus, txVector, GetPhyBand ());
+
+  bool noEndPreambleDetectionEvent = true;
+  for (const auto & it : m_phyEntities)
+    {
+      noEndPreambleDetectionEvent &= it.second->NoEndPreambleDetectionEvents ();
+    }
+  if (!noEndPreambleDetectionEvent || ((m_currentEvent != 0) && (m_currentEvent->GetEndTime () > (Simulator::Now () + m_state->GetDelayUntilIdle ()))))
+    {
+      AbortCurrentReception (RECEPTION_ABORTED_BY_TX);
+    }
+
+  for (auto & it : m_phyEntities)
+    {
+      it.second->CancelRunningEndPreambleDetectionEvents ();
+    }
+  m_currentPreambleEvents.clear ();
+  m_endPhyRxEvent.Cancel ();
+
+  if (m_powerRestricted)
+    {
+      NS_LOG_DEBUG ("Transmitting with power restriction for " << txDuration.As (Time::NS));
+    }
+  else
+    {
+      NS_LOG_DEBUG ("Transmitting without power restriction for " << txDuration.As (Time::NS));
+    }
+
+  if (m_state->GetState () == WifiPhyState::OFF)
+    {
+      NS_LOG_DEBUG ("Transmission canceled because device is OFF");
+      return;
+    }
+
+  Ptr<WifiPpdu> ppdu = GetPhyEntity (txVector.GetModulationClass ())->BuildPpdu (psdus, txVector, txDuration);
+  m_previouslyRxPpduUid = UINT64_MAX; //reset (after creation of PPDU) to use it only once
+
+  double txPowerW = DbmToW (GetTxPowerForTransmission (ppdu) + GetTxGain ());
+  NotifyTxBegin (psdus, txPowerW);
+  if (!m_phyTxPsduBeginTrace.IsEmpty ())
+    {
+      m_phyTxPsduBeginTrace (psdus, txVector, txPowerW);
+    }
+  for (auto const& psdu : psdus)
+    {
+      NotifyMonitorSniffTx (psdu.second, GetFrequency (), txVector, psdu.first);
+    }
+  m_state->SwitchToTx (txDuration, psdus, GetPowerDbm (txVector.GetTxPowerLevel ()), txVector);
+
+  if (m_wifiRadioEnergyModel != 0 && m_wifiRadioEnergyModel->GetMaximumTimeInState (WifiPhyState::TX) < txDuration)
+    {
+      ppdu->SetTruncatedTx ();
+    }
+
+  m_endTxEvent = Simulator::Schedule (txDuration, &WifiPhy::NotifyTxEnd, this, psdus); //TODO: fix for MU
+
+  StartTx (ppdu);
+
+  if (!g_nonNgv10PpduRepeatInProgress && txVector.IsNonNgv10 () && txVector.GetNgvPpduRepetitions () > 0)
+    {
+      const Time repeatInterval = txDuration + GetSifs ();
+      for (uint8_t repetition = 1; repetition <= txVector.GetNgvPpduRepetitions (); ++repetition)
+        {
+          Simulator::Schedule (repeatInterval * repetition,
+                               &SendNonNgv10RepeatedPpdu,
+                               this,
+                               psdus,
+                               txVector);
+        }
+    }
+
+  m_channelAccessRequested = false;
+  m_powerRestricted = false;
+
+  Simulator::Schedule (txDuration, &WifiPhy::Reset, this);
+}
+
+uint64_t
+WifiPhy::GetPreviouslyRxPpduUid (void) const
+{
+  return m_previouslyRxPpduUid;
+}
+
+void
+WifiPhy::Reset (void)
+{
+  NS_LOG_FUNCTION (this);
+  m_currentPreambleEvents.clear ();
+  m_currentEvent = 0;
+  for (auto & phyEntity : m_phyEntities)
+    {
+      phyEntity.second->CancelAllEvents ();
+    }
+  SwitchMaybeToCcaBusy (GetMeasurementChannelWidth (nullptr));
+}
+
+void
+WifiPhy::StartReceivePreamble (Ptr<WifiPpdu> ppdu, RxPowerWattPerChannelBand& rxPowersW, Time rxDuration)
+{
+  WifiModulationClass modulation = ppdu->GetTxVector ().GetModulationClass ();
+  auto it = m_phyEntities.find (modulation);
+  if (it != m_phyEntities.end ())
+    {
+      it->second->StartReceivePreamble (ppdu, rxPowersW, rxDuration);
+    }
+  else
+    {
+      //TODO find a fallback PHY for receiving the PPDU (e.g. 11a for 11ax due to preamble structure)
+      NS_LOG_DEBUG ("Unsupported modulation received (" << modulation << "), consider as noise");
+      m_interference->Add (ppdu, ppdu->GetTxVector (), rxDuration, rxPowersW);
+      SwitchMaybeToCcaBusy (GetMeasurementChannelWidth (nullptr));
+    }
+}
+
+WifiSpectrumBand
+WifiPhy::ConvertHeRuSubcarriers (uint16_t bandWidth, uint16_t guardBandwidth,
+                                 HeRu::SubcarrierRange range, uint8_t bandIndex) const
+{
+  NS_ASSERT_MSG (false, "802.11ax can only be used with SpectrumWifiPhy");
+  WifiSpectrumBand convertedSubcarriers;
+  return convertedSubcarriers;
+}
+
+void
+WifiPhy::EndReceiveInterBss (void)
+{
+  NS_LOG_FUNCTION (this);
+  if (!m_channelAccessRequested)
+    {
+      m_powerRestricted = false;
+    }
+}
+
+void
+WifiPhy::ResetReceive (Ptr<Event> event)
+{
+  NS_LOG_FUNCTION (this << *event);
+  NS_ASSERT (!IsStateRx ());
+  m_interference->NotifyRxEnd (Simulator::Now ());
+  m_currentEvent = 0;
+  m_currentPreambleEvents.clear ();
+  SwitchMaybeToCcaBusy (GetMeasurementChannelWidth (event->GetPpdu ()));
+}
+
+void
+WifiPhy::NotifyChannelAccessRequested (void)
+{
+  NS_LOG_FUNCTION (this);
+  m_channelAccessRequested = true;
+}
+
+bool
+WifiPhy::IsModeSupported (WifiMode mode) const
+{
+  for (const auto & phyEntity : m_phyEntities)
+    {
+      if (phyEntity.second->IsModeSupported (mode))
+        {
+          return true;
+        }
+    }
+  return false;
+}
+
+WifiMode
+WifiPhy::GetDefaultMode (void) const
+{
+  //Start from oldest standards and move up (guaranteed by fact that WifModulationClass is ordered)
+  for (const auto & phyEntity : m_phyEntities)
+    {
+      for (const auto & mode : *(phyEntity.second))
+        {
+          return mode;
+        }
+    }
+  NS_ASSERT_MSG (false, "Should have found at least one default mode");
+  return WifiMode ();
+}
+
+bool
+WifiPhy::IsMcsSupported (WifiModulationClass modulation, uint8_t mcs) const
+{
+  const auto phyEntity = m_phyEntities.find (modulation);
+  if (phyEntity == m_phyEntities.end ())
+    {
+      return false;
+    }
+  return phyEntity->second->IsMcsSupported (mcs);
+}
+
+std::list<WifiMode>
+WifiPhy::GetModeList (void) const
+{
+  std::list<WifiMode> list;
+  for (const auto & phyEntity : m_phyEntities)
+    {
+      if (!phyEntity.second->HandlesMcsModes ()) //to exclude MCSs from search
+        {
+          for (const auto & mode : *(phyEntity.second))
+            {
+              list.emplace_back (mode);
+            }
+        }
+    }
+  return list;
+}
+
+std::list<WifiMode>
+WifiPhy::GetModeList (WifiModulationClass modulation) const
+{
+  std::list<WifiMode> list;
+  const auto phyEntity = m_phyEntities.find (modulation);
+  if (phyEntity != m_phyEntities.end ())
+    {
+      if (!phyEntity->second->HandlesMcsModes ()) //to exclude MCSs from search
+        {
+          for (const auto & mode : *(phyEntity->second))
+            {
+              list.emplace_back (mode);
+            }
+        }
+    }
+  return list;
+}
+
+uint16_t
+WifiPhy::GetNMcs (void) const
+{
+  uint16_t numMcs = 0;
+  for (const auto & phyEntity : m_phyEntities)
+    {
+      if (phyEntity.second->HandlesMcsModes ()) //to exclude non-MCS modes from search
+        {
+          numMcs += phyEntity.second->GetNumModes ();
+        }
+    }
+  return numMcs;
+}
+
+std::list<WifiMode>
+WifiPhy::GetMcsList (void) const
+{
+  std::list<WifiMode> list;
+  for (const auto & phyEntity : m_phyEntities)
+    {
+      if (phyEntity.second->HandlesMcsModes ()) //to exclude non-MCS modes from search
+        {
+          for (const auto & mode : *(phyEntity.second))
+            {
+              list.emplace_back (mode);
+            }
+        }
+    }
+  return list;
+}
+
+std::list<WifiMode>
+WifiPhy::GetMcsList (WifiModulationClass modulation) const
+{
+  std::list<WifiMode> list;
+  auto phyEntity = m_phyEntities.find (modulation);
+  if (phyEntity != m_phyEntities.end ())
+    {
+      if (phyEntity->second->HandlesMcsModes ()) //to exclude non-MCS modes from search
+        {
+          for (const auto & mode : *(phyEntity->second))
+            {
+              list.emplace_back (mode);
+            }
+        }
+    }
+  return list;
+}
+
+WifiMode
+WifiPhy::GetMcs (WifiModulationClass modulation, uint8_t mcs) const
+{
+  NS_ASSERT_MSG (IsMcsSupported (modulation, mcs), "Unsupported MCS");
+  return m_phyEntities.at (modulation)->GetMcs (mcs);
+}
+
+bool
+WifiPhy::IsStateCcaBusy (void) const
+{
+  return m_state->IsStateCcaBusy ();
+}
+
+bool
+WifiPhy::IsStateIdle (void) const
+{
+  return m_state->IsStateIdle ();
+}
+
+bool
+WifiPhy::IsStateRx (void) const
+{
+  return m_state->IsStateRx ();
+}
+
+bool
+WifiPhy::IsStateTx (void) const
+{
+  return m_state->IsStateTx ();
+}
+
+bool
+WifiPhy::IsStateSwitching (void) const
+{
+  return m_state->IsStateSwitching ();
+}
+
+bool
+WifiPhy::IsStateSleep (void) const
+{
+  return m_state->IsStateSleep ();
+}
+
+bool
+WifiPhy::IsStateOff (void) const
+{
+  return m_state->IsStateOff ();
+}
+
+Time
+WifiPhy::GetDelayUntilIdle (void)
+{
+  return m_state->GetDelayUntilIdle ();
+}
+
+Time
+WifiPhy::GetLastRxStartTime (void) const
+{
+  return m_state->GetLastRxStartTime ();
+}
+
+Time
+WifiPhy::GetLastRxEndTime (void) const
+{
+  return m_state->GetLastRxEndTime ();
+}
+
+void
+WifiPhy::SwitchMaybeToCcaBusy (uint16_t channelWidth)
+{
+  NS_LOG_FUNCTION (this << channelWidth);
+  //We are here because we have received the first bit of a packet and we are
+  //not going to be able to synchronize on it
+  //In this model, CCA becomes busy when the aggregation of all signals as
+  //tracked by the InterferenceHelper class is higher than the CcaBusyThreshold
+  Time delayUntilCcaEnd = m_interference->GetEnergyDuration (m_ccaEdThresholdW, GetPrimaryBand (channelWidth));
+  if (!delayUntilCcaEnd.IsZero ())
+    {
+      NS_LOG_DEBUG ("Calling SwitchMaybeToCcaBusy for " << delayUntilCcaEnd.As (Time::S));
+      m_state->SwitchMaybeToCcaBusy (delayUntilCcaEnd);
+    }
+}
+
+void
+WifiPhy::AbortCurrentReception (WifiPhyRxfailureReason reason)
+{
+  NS_LOG_FUNCTION (this << reason);
+  if (reason != OBSS_PD_CCA_RESET || m_currentEvent) //Otherwise abort has already been called previously
+    {
+      for (auto & phyEntity : m_phyEntities)
+        {
+          phyEntity.second->CancelAllEvents ();
+        }
+      if (m_endPhyRxEvent.IsRunning ())
+        {
+          m_endPhyRxEvent.Cancel ();
+        }
+      m_interference->NotifyRxEnd (Simulator::Now ());
+      if (!m_currentEvent)
+        {
+          return;
+        }
+      NotifyRxDrop (GetAddressedPsduInPpdu (m_currentEvent->GetPpdu ()), reason);
+      if (reason == OBSS_PD_CCA_RESET)
+        {
+          m_state->SwitchFromRxAbort ();
+        }
+      for (auto it = m_currentPreambleEvents.begin (); it != m_currentPreambleEvents.end (); ++it)
+        {
+          if (it->second == m_currentEvent)
+            {
+              it = m_currentPreambleEvents.erase (it);
+              break;
+            }
+        }
+      m_currentEvent = 0;
+    }
+}
+
+void
+WifiPhy::ResetCca (bool powerRestricted, double txPowerMaxSiso, double txPowerMaxMimo)
+{
+  NS_LOG_FUNCTION (this << powerRestricted << txPowerMaxSiso << txPowerMaxMimo);
+  // This method might be called multiple times when receiving TB PPDUs with a BSS color
+  // different than the one of the receiver. The first time this method is called, the call
+  // to AbortCurrentReception sets m_currentEvent to 0. Therefore, we need to check whether
+  // m_currentEvent is not 0 before executing the instructions below.
+  if (m_currentEvent != 0)
+    {
+      m_powerRestricted = powerRestricted;
+      m_txPowerMaxSiso = txPowerMaxSiso;
+      m_txPowerMaxMimo = txPowerMaxMimo;
+      NS_ASSERT ((m_currentEvent->GetEndTime () - Simulator::Now ()).IsPositive ());
+      Simulator::Schedule (m_currentEvent->GetEndTime () - Simulator::Now (), &WifiPhy::EndReceiveInterBss, this);
+      Simulator::ScheduleNow (&WifiPhy::AbortCurrentReception, this, OBSS_PD_CCA_RESET); //finish processing field first
+    }
+}
+
+double
+WifiPhy::GetTxPowerForTransmission (Ptr<const WifiPpdu> ppdu) const
+{
+  NS_LOG_FUNCTION (this << m_powerRestricted << ppdu);
+  const WifiTxVector& txVector = ppdu->GetTxVector ();
+  // Get transmit power before antenna gain
+  double txPowerDbm;
+  if (!m_powerRestricted)
+    {
+      txPowerDbm = GetPowerDbm (txVector.GetTxPowerLevel ());
+    }
+  else
+    {
+      if (txVector.GetNssMax () > 1)
+        {
+          txPowerDbm = std::min (m_txPowerMaxMimo, GetPowerDbm (txVector.GetTxPowerLevel ()));
+        }
+      else
+        {
+          txPowerDbm = std::min (m_txPowerMaxSiso, GetPowerDbm (txVector.GetTxPowerLevel ()));
+        }
+    }
+
+  //Apply power density constraint on EIRP
+  uint16_t channelWidth = ppdu->GetTransmissionChannelWidth ();
+  double txPowerDbmPerMhz = (txPowerDbm + GetTxGain ()) - RatioToDb (channelWidth); //account for antenna gain since EIRP
+  NS_LOG_INFO ("txPowerDbm=" << txPowerDbm << " with txPowerDbmPerMhz=" << txPowerDbmPerMhz << " over " << channelWidth << " MHz");
+  txPowerDbm = std::min (txPowerDbmPerMhz, m_powerDensityLimit) + RatioToDb (channelWidth);
+  txPowerDbm -= GetTxGain (); //remove antenna gain since will be added right afterwards
+  NS_LOG_INFO ("txPowerDbm=" << txPowerDbm << " after applying m_powerDensityLimit=" << m_powerDensityLimit);
+  return txPowerDbm;
+}
+
+Ptr<const WifiPsdu>
+WifiPhy::GetAddressedPsduInPpdu (Ptr<const WifiPpdu> ppdu) const
+{
+  //TODO: wrapper. See if still needed
+  return GetPhyEntity (ppdu->GetModulation ())->GetAddressedPsduInPpdu (ppdu);
+}
+
+uint16_t
+WifiPhy::GetMeasurementChannelWidth (const Ptr<const WifiPpdu> ppdu) const
+{
+  if (ppdu == nullptr)
+    {
+      // Here because PHY was not receiving anything (e.g. resuming from OFF) nor expecting anything (e.g. sleep)
+      // nor processing a Wi-Fi signal.
+      return GetChannelWidth () >= 40 ? 20 : GetChannelWidth ();
+    }
+  return GetPhyEntity (ppdu->GetModulation ())->GetMeasurementChannelWidth (ppdu);
+}
+
+WifiSpectrumBand
+WifiPhy::GetBand (uint16_t /*bandWidth*/, uint8_t /*bandIndex*/)
+{
+  WifiSpectrumBand band;
+  band.first = 0;
+  band.second = 0;
+  return band;
+}
+
+WifiSpectrumBand
+WifiPhy::GetPrimaryBand (uint16_t bandWidth)
+{
+  if (GetChannelWidth () % 20 != 0)
+    {
+      return GetBand (bandWidth);
+    }
+
+  return GetBand (bandWidth, m_operatingChannel.GetPrimaryChannelIndex (bandWidth));
+}
+
+int64_t
+WifiPhy::AssignStreams (int64_t stream)
+{
+  NS_LOG_FUNCTION (this << stream);
+  int64_t currentStream = stream;
+  m_random->SetStream (currentStream++);
+  currentStream += m_interference->GetErrorRateModel ()->AssignStreams (currentStream);
+  return (currentStream - stream);
+}
+
+std::ostream& operator<< (std::ostream& os, RxSignalInfo rxSignalInfo)
+{
+  os << "SNR:" << RatioToDb (rxSignalInfo.snr) << " dB"
+     << ", RSSI:" << rxSignalInfo.rssi << " dBm";
+  return os;
+}
+
+uint8_t
+WifiPhy::GetPrimaryChannelNumber (uint16_t primaryChannelWidth) const
+{
+  return m_operatingChannel.GetPrimaryChannelNumber (primaryChannelWidth, m_standard);
+}
+
+} //namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/wifi-remote-station-manager.cc
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-remote-station-manager.cc
@@ -1,0 +1,1990 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006,2007 INRIA
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ */
+
+#include "ns3/log.h"
+#include "ns3/boolean.h"
+#include "ns3/uinteger.h"
+#include "ns3/enum.h"
+#include "ns3/simulator.h"
+#include "wifi-remote-station-manager.h"
+#include "wifi-phy.h"
+#include "ap-wifi-mac.h"
+#include "sta-wifi-mac.h"
+#include "wifi-mac-header.h"
+#include "wifi-mac-queue-item.h"
+#include "wifi-mac-trailer.h"
+#include "wifi-tx-vector.h"
+#include "ns3/ht-configuration.h"
+#include "ns3/ht-phy.h"
+#include "ns3/vht-configuration.h"
+#include "ns3/he-configuration.h"
+#include "wifi-net-device.h"
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("WifiRemoteStationManager");
+
+NS_OBJECT_ENSURE_REGISTERED (WifiRemoteStationManager);
+
+TypeId
+WifiRemoteStationManager::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::WifiRemoteStationManager")
+    .SetParent<Object> ()
+    .SetGroupName ("Wifi")
+    .AddAttribute ("MaxSsrc",
+                   "The maximum number of retransmission attempts for any packet with size <= RtsCtsThreshold. "
+                   "This value will not have any effect on some rate control algorithms.",
+                   UintegerValue (7),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::SetMaxSsrc),
+                   MakeUintegerChecker<uint32_t> ())
+    .AddAttribute ("MaxSlrc",
+                   "The maximum number of retransmission attempts for any packet with size > RtsCtsThreshold. "
+                   "This value will not have any effect on some rate control algorithms.",
+                   UintegerValue (4),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::SetMaxSlrc),
+                   MakeUintegerChecker<uint32_t> ())
+    .AddAttribute ("RtsCtsThreshold",
+                   "If the size of the PSDU is bigger than this value, we use an RTS/CTS handshake before sending the data frame."
+                   "This value will not have any effect on some rate control algorithms.",
+                   UintegerValue (65535),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::SetRtsCtsThreshold),
+                   MakeUintegerChecker<uint32_t> ())
+    .AddAttribute ("FragmentationThreshold",
+                   "If the size of the PSDU is bigger than this value, we fragment it such that the size of the fragments are equal or smaller. "
+                   "This value does not apply when it is carried in an A-MPDU. "
+                   "This value will not have any effect on some rate control algorithms.",
+                   UintegerValue (65535),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::DoSetFragmentationThreshold,
+                                         &WifiRemoteStationManager::DoGetFragmentationThreshold),
+                   MakeUintegerChecker<uint32_t> ())
+    .AddAttribute ("NonUnicastMode",
+                   "Wifi mode used for non-unicast transmissions.",
+                   WifiModeValue (),
+                   MakeWifiModeAccessor (&WifiRemoteStationManager::m_nonUnicastMode),
+                   MakeWifiModeChecker ())
+    .AddAttribute ("NgvPpduFormat",
+                   "802.11bd PPDU format for data transmissions: 0=NON_NGV_10, 1=NGV, 2=NON_NGV_20_DUPLICATE.",
+                   UintegerValue (1),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::m_ngvPpduFormat),
+                   MakeUintegerChecker<uint8_t> (0, 2))
+    .AddAttribute ("NgvMcs",
+                   "802.11bd NGV-MCS index for NGV data transmissions.",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::m_ngvMcs),
+                   MakeUintegerChecker<uint8_t> (0, 15))
+    .AddAttribute ("NgvSpatialStreams",
+                   "802.11bd NGV spatial stream count for data transmissions.",
+                   UintegerValue (1),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::m_ngvSpatialStreams),
+                   MakeUintegerChecker<uint8_t> (1, 2))
+    .AddAttribute ("NgvMidamblePeriodicity",
+                   "802.11bd NGV midamble periodicity for data transmissions.",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::m_ngvMidamblePeriodicity),
+                   MakeUintegerChecker<uint16_t> ())
+    .AddAttribute ("NgvLtfType",
+                   "802.11bd NGV-LTF type for data transmissions: 0=1x, 1=2x, 2=2x-repeat.",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::m_ngvLtfType),
+                   MakeUintegerChecker<uint8_t> (0, 2))
+    .AddAttribute ("NgvPpduRepetitions",
+                   "802.11bd N_PPDU_REP value for data transmissions.",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::m_ngvPpduRepetitions),
+                   MakeUintegerChecker<uint8_t> ())
+    .AddAttribute ("DefaultTxPowerLevel",
+                   "Default power level to be used for transmissions. "
+                   "This is the power level that is used by all those WifiManagers that do not implement TX power control.",
+                   UintegerValue (0),
+                   MakeUintegerAccessor (&WifiRemoteStationManager::m_defaultTxPowerLevel),
+                   MakeUintegerChecker<uint8_t> ())
+    .AddAttribute ("ErpProtectionMode",
+                   "Protection mode used when non-ERP STAs are connected to an ERP AP: Rts-Cts or Cts-To-Self",
+                   EnumValue (WifiRemoteStationManager::CTS_TO_SELF),
+                   MakeEnumAccessor (&WifiRemoteStationManager::m_erpProtectionMode),
+                   MakeEnumChecker (WifiRemoteStationManager::RTS_CTS, "Rts-Cts",
+                                    WifiRemoteStationManager::CTS_TO_SELF, "Cts-To-Self"))
+    .AddAttribute ("HtProtectionMode",
+                   "Protection mode used when non-HT STAs are connected to a HT AP: Rts-Cts or Cts-To-Self",
+                   EnumValue (WifiRemoteStationManager::CTS_TO_SELF),
+                   MakeEnumAccessor (&WifiRemoteStationManager::m_htProtectionMode),
+                   MakeEnumChecker (WifiRemoteStationManager::RTS_CTS, "Rts-Cts",
+                                    WifiRemoteStationManager::CTS_TO_SELF, "Cts-To-Self"))
+    .AddTraceSource ("MacTxRtsFailed",
+                     "The transmission of a RTS by the MAC layer has failed",
+                     MakeTraceSourceAccessor (&WifiRemoteStationManager::m_macTxRtsFailed),
+                     "ns3::Mac48Address::TracedCallback")
+    .AddTraceSource ("MacTxDataFailed",
+                     "The transmission of a data packet by the MAC layer has failed",
+                     MakeTraceSourceAccessor (&WifiRemoteStationManager::m_macTxDataFailed),
+                     "ns3::Mac48Address::TracedCallback")
+    .AddTraceSource ("MacTxFinalRtsFailed",
+                     "The transmission of a RTS has exceeded the maximum number of attempts",
+                     MakeTraceSourceAccessor (&WifiRemoteStationManager::m_macTxFinalRtsFailed),
+                     "ns3::Mac48Address::TracedCallback")
+    .AddTraceSource ("MacTxFinalDataFailed",
+                     "The transmission of a data packet has exceeded the maximum number of attempts",
+                     MakeTraceSourceAccessor (&WifiRemoteStationManager::m_macTxFinalDataFailed),
+                     "ns3::Mac48Address::TracedCallback")
+  ;
+  return tid;
+}
+
+WifiRemoteStationManager::WifiRemoteStationManager ()
+  : m_ngvPpduFormat (static_cast<uint8_t> (WifiNgvPpduFormat::NON_NGV_10)),
+    m_ngvMcs (0),
+    m_ngvSpatialStreams (1),
+    m_ngvMidamblePeriodicity (0),
+    m_ngvLtfType (static_cast<uint8_t> (WifiNgvLtfType::NGV_LTF_2X)),
+    m_ngvPpduRepetitions (0),
+    m_useNonErpProtection (false),
+    m_useNonHtProtection (false),
+    m_shortPreambleEnabled (false),
+    m_shortSlotTimeEnabled (false)
+{
+  NS_LOG_FUNCTION (this);
+}
+
+WifiRemoteStationManager::~WifiRemoteStationManager ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+void
+WifiRemoteStationManager::DoDispose (void)
+{
+  NS_LOG_FUNCTION (this);
+  Reset ();
+}
+
+void
+WifiRemoteStationManager::SetupPhy (const Ptr<WifiPhy> phy)
+{
+  NS_LOG_FUNCTION (this << phy);
+  //We need to track our PHY because it is the object that knows the
+  //full set of transmit rates that are supported. We need to know
+  //this in order to find the relevant mandatory rates when choosing a
+  //transmit rate for automatic control responses like
+  //acknowledgments.
+  m_wifiPhy = phy;
+  m_defaultTxMode = phy->GetDefaultMode ();
+  NS_ASSERT (m_defaultTxMode.IsMandatory ());
+  if (GetHtSupported ())
+    {
+      m_defaultTxMcs = HtPhy::GetHtMcs (0);
+    }
+  Reset ();
+}
+
+void
+WifiRemoteStationManager::SetupMac (const Ptr<WifiMac> mac)
+{
+  NS_LOG_FUNCTION (this << mac);
+  //We need to track our MAC because it is the object that knows the
+  //full set of interframe spaces.
+  m_wifiMac = mac;
+  Reset ();
+}
+
+int64_t
+WifiRemoteStationManager::AssignStreams (int64_t stream)
+{
+  NS_LOG_FUNCTION (this << stream);
+  return 0;
+}
+
+void
+WifiRemoteStationManager::SetMaxSsrc (uint32_t maxSsrc)
+{
+  NS_LOG_FUNCTION (this << maxSsrc);
+  m_maxSsrc = maxSsrc;
+}
+
+void
+WifiRemoteStationManager::SetMaxSlrc (uint32_t maxSlrc)
+{
+  NS_LOG_FUNCTION (this << maxSlrc);
+  m_maxSlrc = maxSlrc;
+}
+
+void
+WifiRemoteStationManager::SetRtsCtsThreshold (uint32_t threshold)
+{
+  NS_LOG_FUNCTION (this << threshold);
+  m_rtsCtsThreshold = threshold;
+}
+
+void
+WifiRemoteStationManager::SetFragmentationThreshold (uint32_t threshold)
+{
+  NS_LOG_FUNCTION (this << threshold);
+  DoSetFragmentationThreshold (threshold);
+}
+
+void
+WifiRemoteStationManager::SetShortPreambleEnabled (bool enable)
+{
+  NS_LOG_FUNCTION (this << enable);
+  m_shortPreambleEnabled = enable;
+}
+
+void
+WifiRemoteStationManager::SetShortSlotTimeEnabled (bool enable)
+{
+  NS_LOG_FUNCTION (this << enable);
+  m_shortSlotTimeEnabled = enable;
+}
+
+bool
+WifiRemoteStationManager::GetShortSlotTimeEnabled (void) const
+{
+  return m_shortSlotTimeEnabled;
+}
+
+bool
+WifiRemoteStationManager::GetShortPreambleEnabled (void) const
+{
+  return m_shortPreambleEnabled;
+}
+
+bool
+WifiRemoteStationManager::GetHtSupported (void) const
+{
+  return m_wifiPhy->GetDevice ()->GetHtConfiguration () != nullptr;
+}
+
+bool
+WifiRemoteStationManager::GetVhtSupported (void) const
+{
+  return m_wifiPhy->GetDevice ()->GetVhtConfiguration () != nullptr;
+}
+
+bool
+WifiRemoteStationManager::GetHeSupported (void) const
+{
+  return m_wifiPhy->GetDevice ()->GetHeConfiguration () != nullptr;
+}
+
+bool
+WifiRemoteStationManager::GetLdpcSupported (void) const
+{
+  if (GetHtSupported ())
+    {
+      Ptr<HtConfiguration> htConfiguration = m_wifiPhy->GetDevice ()->GetHtConfiguration ();
+      NS_ASSERT (htConfiguration); //If HT is supported, we should have a HT configuration attached
+      return htConfiguration->GetLdpcSupported ();
+    }
+  return false;
+}
+
+bool
+WifiRemoteStationManager::GetShortGuardIntervalSupported (void) const
+{
+  if (GetHtSupported ())
+    {
+      Ptr<HtConfiguration> htConfiguration = m_wifiPhy->GetDevice ()->GetHtConfiguration ();
+      NS_ASSERT (htConfiguration); //If HT is supported, we should have a HT configuration attached
+      if (htConfiguration->GetShortGuardIntervalSupported ())
+        {
+          return true;
+        }
+    }
+  return false;
+}
+
+uint16_t
+WifiRemoteStationManager::GetGuardInterval (void) const
+{
+  uint16_t gi = 0;
+  if (GetHeSupported ())
+    {
+      Ptr<HeConfiguration> heConfiguration = m_wifiPhy->GetDevice ()->GetHeConfiguration ();
+      NS_ASSERT (heConfiguration); //If HE is supported, we should have a HE configuration attached
+      gi = static_cast<uint16_t>(heConfiguration->GetGuardInterval ().GetNanoSeconds ());
+    }
+  return gi;
+}
+
+uint32_t
+WifiRemoteStationManager::GetFragmentationThreshold (void) const
+{
+  return DoGetFragmentationThreshold ();
+}
+
+void
+WifiRemoteStationManager::AddSupportedPhyPreamble (Mac48Address address, bool isShortPreambleSupported)
+{
+  NS_LOG_FUNCTION (this << address << isShortPreambleSupported);
+  NS_ASSERT (!address.IsGroup ());
+  WifiRemoteStationState *state = LookupState (address);
+  state->m_shortPreamble = isShortPreambleSupported;
+}
+
+void
+WifiRemoteStationManager::AddSupportedErpSlotTime (Mac48Address address, bool isShortSlotTimeSupported)
+{
+  NS_LOG_FUNCTION (this << address << isShortSlotTimeSupported);
+  NS_ASSERT (!address.IsGroup ());
+  WifiRemoteStationState *state = LookupState (address);
+  state->m_shortSlotTime = isShortSlotTimeSupported;
+}
+
+void
+WifiRemoteStationManager::AddSupportedMode (Mac48Address address, WifiMode mode)
+{
+  NS_LOG_FUNCTION (this << address << mode);
+  NS_ASSERT (!address.IsGroup ());
+  WifiRemoteStationState *state = LookupState (address);
+  for (WifiModeListIterator i = state->m_operationalRateSet.begin (); i != state->m_operationalRateSet.end (); i++)
+    {
+      if ((*i) == mode)
+        {
+          //already in.
+          return;
+        }
+    }
+  if ((mode.GetModulationClass () == WIFI_MOD_CLASS_DSSS) || (mode.GetModulationClass () == WIFI_MOD_CLASS_HR_DSSS))
+    {
+      state->m_dsssSupported = true;
+    }
+  else if (mode.GetModulationClass () == WIFI_MOD_CLASS_ERP_OFDM)
+    {
+      state->m_erpOfdmSupported = true;
+    }
+  else if (mode.GetModulationClass () == WIFI_MOD_CLASS_OFDM)
+    {
+      state->m_ofdmSupported = true;
+    }
+  state->m_operationalRateSet.push_back (mode);
+}
+
+void
+WifiRemoteStationManager::AddAllSupportedModes (Mac48Address address)
+{
+  NS_LOG_FUNCTION (this << address);
+  NS_ASSERT (!address.IsGroup ());
+  WifiRemoteStationState *state = LookupState (address);
+  state->m_operationalRateSet.clear ();
+  for (const auto & mode : m_wifiPhy->GetModeList ())
+    {
+      state->m_operationalRateSet.push_back (mode);
+      if (mode.IsMandatory ())
+        {
+          AddBasicMode (mode);
+        }
+    }
+}
+
+void
+WifiRemoteStationManager::AddAllSupportedMcs (Mac48Address address)
+{
+  NS_LOG_FUNCTION (this << address);
+  NS_ASSERT (!address.IsGroup ());
+  WifiRemoteStationState *state = LookupState (address);
+  state->m_operationalMcsSet.clear ();
+  for (const auto & mcs : m_wifiPhy->GetMcsList ())
+    {
+      state->m_operationalMcsSet.push_back (mcs);
+    }
+}
+
+void
+WifiRemoteStationManager::RemoveAllSupportedMcs (Mac48Address address)
+{
+  NS_LOG_FUNCTION (this << address);
+  NS_ASSERT (!address.IsGroup ());
+  WifiRemoteStationState *state = LookupState (address);
+  state->m_operationalMcsSet.clear ();
+}
+
+void
+WifiRemoteStationManager::AddSupportedMcs (Mac48Address address, WifiMode mcs)
+{
+  NS_LOG_FUNCTION (this << address << mcs);
+  NS_ASSERT (!address.IsGroup ());
+  WifiRemoteStationState *state = LookupState (address);
+  for (WifiModeListIterator i = state->m_operationalMcsSet.begin (); i != state->m_operationalMcsSet.end (); i++)
+    {
+      if ((*i) == mcs)
+        {
+          //already in.
+          return;
+        }
+    }
+  state->m_operationalMcsSet.push_back (mcs);
+}
+
+bool
+WifiRemoteStationManager::GetShortPreambleSupported (Mac48Address address) const
+{
+  return LookupState (address)->m_shortPreamble;
+}
+
+bool
+WifiRemoteStationManager::GetShortSlotTimeSupported (Mac48Address address) const
+{
+  return LookupState (address)->m_shortSlotTime;
+}
+
+bool
+WifiRemoteStationManager::GetQosSupported (Mac48Address address) const
+{
+  return LookupState (address)->m_qosSupported;
+}
+
+bool
+WifiRemoteStationManager::IsBrandNew (Mac48Address address) const
+{
+  if (address.IsGroup ())
+    {
+      return false;
+    }
+  return LookupState (address)->m_state == WifiRemoteStationState::BRAND_NEW;
+}
+
+bool
+WifiRemoteStationManager::IsAssociated (Mac48Address address) const
+{
+  if (address.IsGroup ())
+    {
+      return true;
+    }
+  return LookupState (address)->m_state == WifiRemoteStationState::GOT_ASSOC_TX_OK;
+}
+
+bool
+WifiRemoteStationManager::IsWaitAssocTxOk (Mac48Address address) const
+{
+  if (address.IsGroup ())
+    {
+      return false;
+    }
+  return LookupState (address)->m_state == WifiRemoteStationState::WAIT_ASSOC_TX_OK;
+}
+
+void
+WifiRemoteStationManager::RecordWaitAssocTxOk (Mac48Address address)
+{
+  NS_ASSERT (!address.IsGroup ());
+  LookupState (address)->m_state = WifiRemoteStationState::WAIT_ASSOC_TX_OK;
+}
+
+void
+WifiRemoteStationManager::RecordGotAssocTxOk (Mac48Address address)
+{
+  NS_ASSERT (!address.IsGroup ());
+  LookupState (address)->m_state = WifiRemoteStationState::GOT_ASSOC_TX_OK;
+}
+
+void
+WifiRemoteStationManager::RecordGotAssocTxFailed (Mac48Address address)
+{
+  NS_ASSERT (!address.IsGroup ());
+  LookupState (address)->m_state = WifiRemoteStationState::DISASSOC;
+}
+
+void
+WifiRemoteStationManager::RecordDisassociated (Mac48Address address)
+{
+  NS_ASSERT (!address.IsGroup ());
+  LookupState (address)->m_state = WifiRemoteStationState::DISASSOC;
+}
+
+uint16_t
+WifiRemoteStationManager::GetAssociationId (Mac48Address remoteAddress) const
+{
+  WifiRemoteStationState* state;
+  if (!remoteAddress.IsGroup ()
+      && (state = LookupState (remoteAddress))->m_state == WifiRemoteStationState::GOT_ASSOC_TX_OK)
+    {
+      return state->m_aid;
+    }
+  return SU_STA_ID;
+}
+
+uint16_t
+WifiRemoteStationManager::GetStaId (Mac48Address address, const WifiTxVector& txVector) const
+{
+  NS_LOG_FUNCTION (this << address << txVector);
+
+  uint16_t staId = SU_STA_ID;
+
+  if (txVector.IsMu ())
+    {
+      if (m_wifiMac->GetTypeOfStation () == AP)
+        {
+          staId = GetAssociationId (address);
+        }
+      else if (m_wifiMac->GetTypeOfStation () == STA)
+        {
+          Ptr<StaWifiMac> staMac = StaticCast<StaWifiMac> (m_wifiMac);
+          if (staMac->IsAssociated ())
+            {
+              staId = staMac->GetAssociationId ();
+            }
+        }
+    }
+
+  NS_LOG_DEBUG ("Returning STAID = " << staId);
+  return staId;
+}
+
+void
+WifiRemoteStationManager::ApplyNgvTxVectorParameters (WifiTxVector& txVector) const
+{
+  if (m_wifiPhy == nullptr || m_wifiPhy->GetStandard () != WIFI_STANDARD_80211bd)
+    {
+      return;
+    }
+
+  WifiNgvPpduFormat ppduFormat = WifiNgvPpduFormat::NON_NGV_10;
+  if (m_ngvPpduFormat == 1)
+    {
+      ppduFormat = WifiNgvPpduFormat::NGV;
+    }
+  else if (m_ngvPpduFormat == 2)
+    {
+      ppduFormat = WifiNgvPpduFormat::NON_NGV_20_DUPLICATE;
+    }
+  WifiNgvLtfType ltfType = WifiNgvLtfType::NGV_LTF_1X;
+  if (m_ngvLtfType == 1)
+    {
+      ltfType = WifiNgvLtfType::NGV_LTF_2X;
+    }
+  else if (m_ngvLtfType == 2)
+    {
+      ltfType = WifiNgvLtfType::NGV_LTF_2X_REPEAT;
+    }
+  if (ppduFormat == WifiNgvPpduFormat::NGV && m_wifiPhy->GetChannelWidth () == 10 &&
+      m_ngvSpatialStreams == 1 && m_ngvMcs == 15)
+    {
+      ltfType = WifiNgvLtfType::NGV_LTF_2X_REPEAT;
+    }
+
+  txVector.SetNgvPpduFormat (ppduFormat);
+  txVector.SetNgvMcs (m_ngvMcs);
+  txVector.SetNgvMidamblePeriodicity (m_ngvMidamblePeriodicity);
+  txVector.SetNgvLtfType (ltfType);
+  txVector.SetNgvPpduRepetitions (m_ngvPpduRepetitions);
+
+  if (ppduFormat == WifiNgvPpduFormat::NGV)
+    {
+      txVector.SetChannelWidth (m_wifiPhy->GetChannelWidth ());
+      txVector.SetNss (m_ngvSpatialStreams);
+      txVector.SetLdpc (true);
+    }
+  else if (ppduFormat == WifiNgvPpduFormat::NON_NGV_20_DUPLICATE)
+    {
+      txVector.SetChannelWidth (20);
+      txVector.SetNss (1);
+      txVector.SetLdpc (false);
+    }
+}
+
+WifiTxVector
+WifiRemoteStationManager::GetDataTxVector (const WifiMacHeader &header)
+{
+  NS_LOG_FUNCTION (this << header);
+  Mac48Address address = header.GetAddr1 ();
+  if (!header.IsMgt () && address.IsGroup ())
+    {
+      WifiMode mode = GetNonUnicastMode ();
+      WifiTxVector v;
+      v.SetMode (mode);
+      v.SetPreambleType (GetPreambleForTransmission (mode.GetModulationClass (), GetShortPreambleEnabled ()));
+      v.SetTxPowerLevel (m_defaultTxPowerLevel);
+      v.SetChannelWidth (GetChannelWidthForTransmission (mode, m_wifiPhy->GetChannelWidth ()));
+      v.SetGuardInterval (ConvertGuardIntervalToNanoSeconds (mode, m_wifiPhy->GetDevice ()));
+      v.SetNTx (GetNumberOfAntennas ());
+      v.SetNss (1);
+      v.SetNess (0);
+      ApplyNgvTxVectorParameters (v);
+      return v;
+    }
+  WifiTxVector txVector;
+  if (header.IsMgt ())
+    {
+      //Use the lowest basic rate for management frames
+      WifiMode mgtMode;
+      if (GetNBasicModes () > 0)
+        {
+          mgtMode = GetBasicMode (0);
+        }
+      else
+        {
+          mgtMode = GetDefaultMode ();
+        }
+      txVector.SetMode (mgtMode);
+      txVector.SetPreambleType (GetPreambleForTransmission (mgtMode.GetModulationClass (), GetShortPreambleEnabled ()));
+      txVector.SetTxPowerLevel (m_defaultTxPowerLevel);
+      uint16_t channelWidth = m_wifiPhy->GetChannelWidth ();
+      if (!header.GetAddr1 ().IsGroup ())
+        {
+          if (uint16_t rxWidth = GetChannelWidthSupported (header.GetAddr1 ());
+              rxWidth < channelWidth)
+            {
+              channelWidth = rxWidth;
+            }
+        }
+
+      txVector.SetChannelWidth (GetChannelWidthForTransmission (mgtMode, channelWidth));
+      txVector.SetGuardInterval (ConvertGuardIntervalToNanoSeconds (mgtMode, m_wifiPhy->GetDevice ()));
+    }
+  else
+    {
+      txVector = DoGetDataTxVector (Lookup (address));
+      txVector.SetLdpc (txVector.GetMode ().GetModulationClass () < WIFI_MOD_CLASS_HT ? 0 : UseLdpcForDestination (address));
+      ApplyNgvTxVectorParameters (txVector);
+    }
+  Ptr<HeConfiguration> heConfiguration = m_wifiPhy->GetDevice ()->GetHeConfiguration ();
+  if (heConfiguration)
+    {
+      txVector.SetBssColor (heConfiguration->GetBssColor ());
+    }
+  return txVector;
+}
+
+WifiTxVector
+WifiRemoteStationManager::GetCtsToSelfTxVector (void)
+{
+  WifiMode defaultMode = GetDefaultMode ();
+  WifiPreamble defaultPreamble;
+  if (defaultMode.GetModulationClass () == WIFI_MOD_CLASS_HE)
+    {
+      defaultPreamble = WIFI_PREAMBLE_HE_SU;
+    }
+  else if (defaultMode.GetModulationClass () == WIFI_MOD_CLASS_VHT)
+    {
+      defaultPreamble = WIFI_PREAMBLE_VHT_SU;
+    }
+  else if (defaultMode.GetModulationClass () == WIFI_MOD_CLASS_HT)
+    {
+      defaultPreamble = WIFI_PREAMBLE_HT_MF;
+    }
+  else
+    {
+      defaultPreamble = WIFI_PREAMBLE_LONG;
+    }
+
+  return WifiTxVector (defaultMode,
+                       GetDefaultTxPowerLevel (),
+                       defaultPreamble,
+                       ConvertGuardIntervalToNanoSeconds (defaultMode, m_wifiPhy->GetDevice ()),
+                       GetNumberOfAntennas (),
+                       1,
+                       0,
+                       GetChannelWidthForTransmission (defaultMode, m_wifiPhy->GetChannelWidth ()),
+                       false);
+}
+
+WifiTxVector
+WifiRemoteStationManager::GetRtsTxVector (Mac48Address address)
+{
+  NS_LOG_FUNCTION (this << address);
+  if (address.IsGroup ())
+    {
+        WifiMode mode = GetNonUnicastMode ();
+        WifiTxVector v;
+        v.SetMode (mode);
+        v.SetPreambleType (GetPreambleForTransmission (mode.GetModulationClass (), GetShortPreambleEnabled ()));
+        v.SetTxPowerLevel (m_defaultTxPowerLevel);
+        v.SetChannelWidth (GetChannelWidthForTransmission (mode, m_wifiPhy->GetChannelWidth ()));
+        v.SetGuardInterval (ConvertGuardIntervalToNanoSeconds (mode, m_wifiPhy->GetDevice ()));
+        v.SetNTx (GetNumberOfAntennas ());
+        v.SetNss (1);
+        v.SetNess (0);
+        return v;
+    }
+  return DoGetRtsTxVector (Lookup (address));
+}
+
+WifiTxVector
+WifiRemoteStationManager::GetCtsTxVector (Mac48Address to, WifiMode rtsTxMode) const
+{
+  NS_ASSERT (!to.IsGroup ());
+  WifiMode ctsMode = GetControlAnswerMode (rtsTxMode);
+  WifiTxVector v;
+  v.SetMode (ctsMode);
+  v.SetPreambleType (GetPreambleForTransmission (ctsMode.GetModulationClass (), GetShortPreambleEnabled ()));
+  v.SetTxPowerLevel (GetDefaultTxPowerLevel ());
+  v.SetChannelWidth (GetChannelWidthForTransmission (ctsMode, m_wifiPhy->GetChannelWidth ()));
+  uint16_t ctsTxGuardInterval = ConvertGuardIntervalToNanoSeconds (ctsMode, m_wifiPhy->GetDevice ());
+  v.SetGuardInterval (ctsTxGuardInterval);
+  v.SetNss (1);
+  return v;
+}
+
+WifiTxVector
+WifiRemoteStationManager::GetAckTxVector (Mac48Address to, const WifiTxVector& dataTxVector) const
+{
+  NS_ASSERT (!to.IsGroup ());
+  WifiMode ackMode = GetControlAnswerMode (dataTxVector.GetMode (GetStaId (to, dataTxVector)));
+  WifiTxVector v;
+  v.SetMode (ackMode);
+  v.SetPreambleType (GetPreambleForTransmission (ackMode.GetModulationClass (), GetShortPreambleEnabled ()));
+  v.SetTxPowerLevel (GetDefaultTxPowerLevel ());
+  v.SetChannelWidth (GetChannelWidthForTransmission (ackMode, m_wifiPhy->GetChannelWidth ()));
+  uint16_t ackTxGuardInterval = ConvertGuardIntervalToNanoSeconds (ackMode, m_wifiPhy->GetDevice ());
+  v.SetGuardInterval (ackTxGuardInterval);
+  v.SetNss (1);
+  return v;
+}
+
+WifiTxVector
+WifiRemoteStationManager::GetBlockAckTxVector (Mac48Address to, const WifiTxVector& dataTxVector) const
+{
+  NS_ASSERT (!to.IsGroup ());
+  WifiMode blockAckMode = GetControlAnswerMode (dataTxVector.GetMode (GetStaId (to, dataTxVector)));
+  WifiTxVector v;
+  v.SetMode (blockAckMode);
+  v.SetPreambleType (GetPreambleForTransmission (blockAckMode.GetModulationClass (), GetShortPreambleEnabled ()));
+  v.SetTxPowerLevel (GetDefaultTxPowerLevel ());
+  v.SetChannelWidth (GetChannelWidthForTransmission (blockAckMode, m_wifiPhy->GetChannelWidth ()));
+  uint16_t blockAckTxGuardInterval = ConvertGuardIntervalToNanoSeconds (blockAckMode, m_wifiPhy->GetDevice ());
+  v.SetGuardInterval (blockAckTxGuardInterval);
+  v.SetNss (1);
+  return v;
+}
+
+WifiMode
+WifiRemoteStationManager::GetControlAnswerMode (WifiMode reqMode) const
+{
+  /**
+   * The standard has relatively unambiguous rules for selecting a
+   * control response rate (the below is quoted from IEEE 802.11-2012,
+   * Section 9.7):
+   *
+   * To allow the transmitting STA to calculate the contents of the
+   * Duration/ID field, a STA responding to a received frame shall
+   * transmit its Control Response frame (either CTS or Ack), other
+   * than the BlockAck control frame, at the highest rate in the
+   * BSSBasicRateSet parameter that is less than or equal to the
+   * rate of the immediately previous frame in the frame exchange
+   * sequence (as defined in Annex G) and that is of the same
+   * modulation class (see Section 9.7.8) as the received frame...
+   */
+  NS_LOG_FUNCTION (this << reqMode);
+  WifiMode mode = GetDefaultMode ();
+  bool found = false;
+  //First, search the BSS Basic Rate set
+  for (uint8_t i = 0; i < GetNBasicModes (); i++)
+    {
+      WifiMode testMode = GetBasicMode (i);
+      if ((!found || testMode.IsHigherDataRate (mode))
+          && (!testMode.IsHigherDataRate (reqMode))
+          && (IsAllowedControlAnswerModulationClass (reqMode.GetModulationClass (), testMode.GetModulationClass ())))
+        {
+          mode = testMode;
+          //We've found a potentially-suitable transmit rate, but we
+          //need to continue and consider all the basic rates before
+          //we can be sure we've got the right one.
+          found = true;
+        }
+    }
+  if (GetHtSupported ())
+    {
+      if (!found)
+        {
+          mode = GetDefaultMcs ();
+          for (uint8_t i = 0; i != GetNBasicMcs (); i++)
+            {
+              WifiMode testMode = GetBasicMcs (i);
+              if ((!found || testMode.IsHigherDataRate (mode))
+                  && (!testMode.IsHigherDataRate (reqMode))
+                  && (testMode.GetModulationClass () == reqMode.GetModulationClass ()))
+                {
+                  mode = testMode;
+                  //We've found a potentially-suitable transmit rate, but we
+                  //need to continue and consider all the basic rates before
+                  //we can be sure we've got the right one.
+                  found = true;
+                }
+            }
+        }
+    }
+  //If we found a suitable rate in the BSSBasicRateSet, then we are
+  //done and can return that mode.
+  if (found)
+    {
+      NS_LOG_DEBUG ("WifiRemoteStationManager::GetControlAnswerMode returning " << mode);
+      return mode;
+    }
+
+  /**
+   * If no suitable basic rate was found, we search the mandatory
+   * rates. The standard (IEEE 802.11-2007, Section 9.6) says:
+   *
+   *   ...If no rate contained in the BSSBasicRateSet parameter meets
+   *   these conditions, then the control frame sent in response to a
+   *   received frame shall be transmitted at the highest mandatory
+   *   rate of the PHY that is less than or equal to the rate of the
+   *   received frame, and that is of the same modulation class as the
+   *   received frame. In addition, the Control Response frame shall
+   *   be sent using the same PHY options as the received frame,
+   *   unless they conflict with the requirement to use the
+   *   BSSBasicRateSet parameter.
+   *
+   * \todo Note that we're ignoring the last sentence for now, because
+   * there is not yet any manipulation here of PHY options.
+   */
+  for (const auto & thismode : m_wifiPhy->GetModeList ())
+    {
+      /* If the rate:
+       *
+       *  - is a mandatory rate for the PHY, and
+       *  - is equal to or faster than our current best choice, and
+       *  - is less than or equal to the rate of the received frame, and
+       *  - is of the same modulation class as the received frame
+       *
+       * ...then it's our best choice so far.
+       */
+      if (thismode.IsMandatory ()
+          && (!found || thismode.IsHigherDataRate (mode))
+          && (!thismode.IsHigherDataRate (reqMode))
+          && (IsAllowedControlAnswerModulationClass (reqMode.GetModulationClass (), thismode.GetModulationClass ())))
+        {
+          mode = thismode;
+          //As above; we've found a potentially-suitable transmit
+          //rate, but we need to continue and consider all the
+          //mandatory rates before we can be sure we've got the right one.
+          found = true;
+        }
+    }
+  if (GetHtSupported () )
+    {
+      for (const auto & thismode : m_wifiPhy->GetMcsList ())
+        {
+          if (thismode.IsMandatory ()
+              && (!found || thismode.IsHigherDataRate (mode))
+              && (!thismode.IsHigherCodeRate (reqMode))
+              && (thismode.GetModulationClass () == reqMode.GetModulationClass ()))
+            {
+              mode = thismode;
+              //As above; we've found a potentially-suitable transmit
+              //rate, but we need to continue and consider all the
+              //mandatory rates before we can be sure we've got the right one.
+              found = true;
+            }
+        }
+    }
+
+  /**
+   * If we still haven't found a suitable rate for the response then
+   * someone has messed up the simulation configuration. This probably means
+   * that the WifiPhyStandard is not set correctly, or that a rate that
+   * is not supported by the PHY has been explicitly requested.
+   *
+   * Either way, it is serious - we can either disobey the standard or
+   * fail, and I have chosen to do the latter...
+   */
+  if (!found)
+    {
+      NS_FATAL_ERROR ("Can't find response rate for " << reqMode);
+    }
+
+  NS_LOG_DEBUG ("WifiRemoteStationManager::GetControlAnswerMode returning " << mode);
+  return mode;
+}
+
+void
+WifiRemoteStationManager::ReportRtsFailed (const WifiMacHeader& header)
+{
+  NS_LOG_FUNCTION (this << header);
+  NS_ASSERT (!header.GetAddr1 ().IsGroup ());
+  AcIndex ac = QosUtilsMapTidToAc ((header.IsQosData ()) ? header.GetQosTid () : 0);
+  m_ssrc[ac]++;
+  m_macTxRtsFailed (header.GetAddr1 ());
+  DoReportRtsFailed (Lookup (header.GetAddr1 ()));
+}
+
+void
+WifiRemoteStationManager::ReportDataFailed (Ptr<const WifiMacQueueItem> mpdu)
+{
+  NS_LOG_FUNCTION (this << *mpdu);
+  NS_ASSERT (!mpdu->GetHeader ().GetAddr1 ().IsGroup ());
+  AcIndex ac = QosUtilsMapTidToAc ((mpdu->GetHeader ().IsQosData ()) ? mpdu->GetHeader ().GetQosTid () : 0);
+  bool longMpdu = (mpdu->GetSize () > m_rtsCtsThreshold);
+  if (longMpdu)
+    {
+      m_slrc[ac]++;
+    }
+  else
+    {
+      m_ssrc[ac]++;
+    }
+  m_macTxDataFailed (mpdu->GetHeader ().GetAddr1 ());
+  DoReportDataFailed (Lookup (mpdu->GetHeader ().GetAddr1 ()));
+}
+
+void
+WifiRemoteStationManager::ReportRtsOk (const WifiMacHeader& header,
+                                       double ctsSnr, WifiMode ctsMode, double rtsSnr)
+{
+  NS_LOG_FUNCTION (this << header << ctsSnr << ctsMode << rtsSnr);
+  NS_ASSERT (!header.GetAddr1 ().IsGroup ());
+  WifiRemoteStation *station = Lookup (header.GetAddr1 ());
+  AcIndex ac = QosUtilsMapTidToAc ((header.IsQosData ()) ? header.GetQosTid () : 0);
+  station->m_state->m_info.NotifyTxSuccess (m_ssrc[ac]);
+  m_ssrc[ac] = 0;
+  DoReportRtsOk (station, ctsSnr, ctsMode, rtsSnr);
+}
+
+void
+WifiRemoteStationManager::ReportDataOk (Ptr<const WifiMacQueueItem> mpdu, double ackSnr,
+                                        WifiMode ackMode, double dataSnr, WifiTxVector dataTxVector)
+{
+  NS_LOG_FUNCTION (this << *mpdu << ackSnr << ackMode << dataSnr << dataTxVector);
+  const WifiMacHeader& hdr = mpdu->GetHeader ();
+  NS_ASSERT (!hdr.GetAddr1 ().IsGroup ());
+  WifiRemoteStation *station = Lookup (hdr.GetAddr1 ());
+  AcIndex ac = QosUtilsMapTidToAc ((hdr.IsQosData ()) ? hdr.GetQosTid () : 0);
+  bool longMpdu = (mpdu->GetSize () > m_rtsCtsThreshold);
+  if (longMpdu)
+    {
+      station->m_state->m_info.NotifyTxSuccess (m_slrc[ac]);
+      m_slrc[ac] = 0;
+    }
+  else
+    {
+      station->m_state->m_info.NotifyTxSuccess (m_ssrc[ac]);
+      m_ssrc[ac] = 0;
+    }
+  DoReportDataOk (station, ackSnr, ackMode, dataSnr, dataTxVector.GetChannelWidth (),
+                  dataTxVector.GetNss (GetStaId (hdr.GetAddr1 (), dataTxVector)));
+}
+
+void
+WifiRemoteStationManager::ReportFinalRtsFailed (const WifiMacHeader& header)
+{
+  NS_LOG_FUNCTION (this << header);
+  NS_ASSERT (!header.GetAddr1 ().IsGroup ());
+  WifiRemoteStation *station = Lookup (header.GetAddr1 ());
+  AcIndex ac = QosUtilsMapTidToAc ((header.IsQosData ()) ? header.GetQosTid () : 0);
+  station->m_state->m_info.NotifyTxFailed ();
+  m_ssrc[ac] = 0;
+  m_macTxFinalRtsFailed (header.GetAddr1 ());
+  DoReportFinalRtsFailed (station);
+}
+
+void
+WifiRemoteStationManager::ReportFinalDataFailed (Ptr<const WifiMacQueueItem> mpdu)
+{
+  NS_LOG_FUNCTION (this << *mpdu);
+  NS_ASSERT (!mpdu->GetHeader ().GetAddr1 ().IsGroup ());
+  WifiRemoteStation *station = Lookup (mpdu->GetHeader ().GetAddr1 ());
+  AcIndex ac = QosUtilsMapTidToAc ((mpdu->GetHeader ().IsQosData ()) ? mpdu->GetHeader ().GetQosTid () : 0);
+  station->m_state->m_info.NotifyTxFailed ();
+  bool longMpdu = (mpdu->GetSize () > m_rtsCtsThreshold);
+  if (longMpdu)
+    {
+      m_slrc[ac] = 0;
+    }
+  else
+    {
+      m_ssrc[ac] = 0;
+    }
+  m_macTxFinalDataFailed (mpdu->GetHeader ().GetAddr1 ());
+  DoReportFinalDataFailed (station);
+}
+
+void
+WifiRemoteStationManager::ReportRxOk (Mac48Address address, RxSignalInfo rxSignalInfo, WifiTxVector txVector)
+{
+  NS_LOG_FUNCTION (this << address << rxSignalInfo << txVector);
+  if (address.IsGroup ())
+    {
+      return;
+    }
+  WifiRemoteStation *station = Lookup (address);
+  DoReportRxOk (station, rxSignalInfo.snr, txVector.GetMode (GetStaId (address, txVector)));
+  station->m_rssiAndUpdateTimePair = std::make_pair (rxSignalInfo.rssi, Simulator::Now ());
+}
+
+void
+WifiRemoteStationManager::ReportAmpduTxStatus (Mac48Address address,
+                                               uint16_t nSuccessfulMpdus, uint16_t nFailedMpdus,
+                                               double rxSnr, double dataSnr, WifiTxVector dataTxVector)
+{
+  NS_LOG_FUNCTION (this << address << nSuccessfulMpdus << nFailedMpdus << rxSnr << dataSnr << dataTxVector);
+  NS_ASSERT (!address.IsGroup ());
+  for (uint8_t i = 0; i < nFailedMpdus; i++)
+    {
+      m_macTxDataFailed (address);
+    }
+  DoReportAmpduTxStatus (Lookup (address), nSuccessfulMpdus, nFailedMpdus, rxSnr, dataSnr, dataTxVector.GetChannelWidth (), dataTxVector.GetNss (GetStaId (address, dataTxVector)));
+}
+
+bool
+WifiRemoteStationManager::NeedRts (const WifiMacHeader &header, uint32_t size)
+{
+  NS_LOG_FUNCTION (this << header << size);
+  Mac48Address address = header.GetAddr1 ();
+  WifiTxVector txVector = GetDataTxVector (header);
+  WifiMode mode = txVector.GetMode ();
+  if (address.IsGroup ())
+    {
+      return false;
+    }
+  if (m_erpProtectionMode == RTS_CTS
+      && ((mode.GetModulationClass () == WIFI_MOD_CLASS_ERP_OFDM)
+          || (mode.GetModulationClass () == WIFI_MOD_CLASS_HT)
+          || (mode.GetModulationClass () == WIFI_MOD_CLASS_VHT)
+          || (mode.GetModulationClass () == WIFI_MOD_CLASS_HE))
+      && m_useNonErpProtection)
+    {
+      NS_LOG_DEBUG ("WifiRemoteStationManager::NeedRTS returning true to protect non-ERP stations");
+      return true;
+    }
+  else if (m_htProtectionMode == RTS_CTS
+           && ((mode.GetModulationClass () == WIFI_MOD_CLASS_HT)
+               || (mode.GetModulationClass () == WIFI_MOD_CLASS_VHT))
+           && m_useNonHtProtection
+           && !(m_erpProtectionMode != RTS_CTS && m_useNonErpProtection))
+    {
+      NS_LOG_DEBUG ("WifiRemoteStationManager::NeedRTS returning true to protect non-HT stations");
+      return true;
+    }
+  bool normally = (size > m_rtsCtsThreshold);
+  return DoNeedRts (Lookup (address), size, normally);
+}
+
+bool
+WifiRemoteStationManager::NeedCtsToSelf (WifiTxVector txVector)
+{
+  WifiMode mode = txVector.GetMode ();
+  NS_LOG_FUNCTION (this << mode);
+  if (m_erpProtectionMode == CTS_TO_SELF
+      && ((mode.GetModulationClass () == WIFI_MOD_CLASS_ERP_OFDM)
+          || (mode.GetModulationClass () == WIFI_MOD_CLASS_HT)
+          || (mode.GetModulationClass () == WIFI_MOD_CLASS_VHT)
+          || (mode.GetModulationClass () == WIFI_MOD_CLASS_HE))
+      && m_useNonErpProtection)
+    {
+      NS_LOG_DEBUG ("WifiRemoteStationManager::NeedCtsToSelf returning true to protect non-ERP stations");
+      return true;
+    }
+  else if (m_htProtectionMode == CTS_TO_SELF
+           && ((mode.GetModulationClass () == WIFI_MOD_CLASS_HT)
+               || (mode.GetModulationClass () == WIFI_MOD_CLASS_VHT))
+           && m_useNonHtProtection
+           && !(m_erpProtectionMode != CTS_TO_SELF && m_useNonErpProtection))
+    {
+      NS_LOG_DEBUG ("WifiRemoteStationManager::NeedCtsToSelf returning true to protect non-HT stations");
+      return true;
+    }
+  else if (!m_useNonErpProtection)
+    {
+      //search for the BSS Basic Rate set, if the used mode is in the basic set then there is no need for CTS To Self
+      for (WifiModeListIterator i = m_bssBasicRateSet.begin (); i != m_bssBasicRateSet.end (); i++)
+        {
+          if (mode == *i)
+            {
+              NS_LOG_DEBUG ("WifiRemoteStationManager::NeedCtsToSelf returning false");
+              return false;
+            }
+        }
+      if (GetHtSupported ())
+        {
+          //search for the BSS Basic MCS set, if the used mode is in the basic set then there is no need for CTS To Self
+          for (WifiModeListIterator i = m_bssBasicMcsSet.begin (); i != m_bssBasicMcsSet.end (); i++)
+            {
+              if (mode == *i)
+                {
+                  NS_LOG_DEBUG ("WifiRemoteStationManager::NeedCtsToSelf returning false");
+                  return false;
+                }
+            }
+        }
+      NS_LOG_DEBUG ("WifiRemoteStationManager::NeedCtsToSelf returning true");
+      return true;
+    }
+  return false;
+}
+
+void
+WifiRemoteStationManager::SetUseNonErpProtection (bool enable)
+{
+  NS_LOG_FUNCTION (this << enable);
+  m_useNonErpProtection = enable;
+}
+
+bool
+WifiRemoteStationManager::GetUseNonErpProtection (void) const
+{
+  return m_useNonErpProtection;
+}
+
+void
+WifiRemoteStationManager::SetUseNonHtProtection (bool enable)
+{
+  NS_LOG_FUNCTION (this << enable);
+  m_useNonHtProtection = enable;
+}
+
+bool
+WifiRemoteStationManager::GetUseNonHtProtection (void) const
+{
+  return m_useNonHtProtection;
+}
+
+bool
+WifiRemoteStationManager::NeedRetransmission (Ptr<const WifiMacQueueItem> mpdu)
+{
+  NS_LOG_FUNCTION (this << *mpdu);
+  NS_ASSERT (!mpdu->GetHeader ().GetAddr1 ().IsGroup ());
+  AcIndex ac = QosUtilsMapTidToAc ((mpdu->GetHeader ().IsQosData ()) ? mpdu->GetHeader ().GetQosTid () : 0);
+  bool longMpdu = (mpdu->GetSize () > m_rtsCtsThreshold);
+  uint32_t retryCount, maxRetryCount;
+  if (longMpdu)
+    {
+      retryCount = m_slrc[ac];
+      maxRetryCount = m_maxSlrc;
+    }
+  else
+    {
+      retryCount = m_ssrc[ac];
+      maxRetryCount = m_maxSsrc;
+    }
+  bool normally = retryCount < maxRetryCount;
+  NS_LOG_DEBUG ("WifiRemoteStationManager::NeedRetransmission count: " << retryCount << " result: " << std::boolalpha << normally);
+  return DoNeedRetransmission (Lookup (mpdu->GetHeader ().GetAddr1 ()), mpdu->GetPacket (), normally);
+}
+
+bool
+WifiRemoteStationManager::NeedFragmentation (Ptr<const WifiMacQueueItem> mpdu)
+{
+  NS_LOG_FUNCTION (this << *mpdu);
+  if (mpdu->GetHeader ().GetAddr1 ().IsGroup ())
+    {
+      return false;
+    }
+  bool normally = mpdu->GetSize () > GetFragmentationThreshold ();
+  NS_LOG_DEBUG ("WifiRemoteStationManager::NeedFragmentation result: " << std::boolalpha << normally);
+  return DoNeedFragmentation (Lookup (mpdu->GetHeader ().GetAddr1 ()), mpdu->GetPacket (), normally);
+}
+
+void
+WifiRemoteStationManager::DoSetFragmentationThreshold (uint32_t threshold)
+{
+  NS_LOG_FUNCTION (this << threshold);
+  if (threshold < 256)
+    {
+      /*
+       * ASN.1 encoding of the MAC and PHY MIB (256 ... 8000)
+       */
+      NS_LOG_WARN ("Fragmentation threshold should be larger than 256. Setting to 256.");
+      m_fragmentationThreshold = 256;
+    }
+  else
+    {
+      /*
+       * The length of each fragment shall be an even number of octets, except for the last fragment if an MSDU or
+       * MMPDU, which may be either an even or an odd number of octets.
+       */
+      if (threshold % 2 != 0)
+        {
+          NS_LOG_WARN ("Fragmentation threshold should be an even number. Setting to " << threshold - 1);
+          m_fragmentationThreshold = threshold - 1;
+        }
+      else
+        {
+          m_fragmentationThreshold = threshold;
+        }
+    }
+}
+
+uint32_t
+WifiRemoteStationManager::DoGetFragmentationThreshold (void) const
+{
+  return m_fragmentationThreshold;
+}
+
+uint32_t
+WifiRemoteStationManager::GetNFragments (Ptr<const WifiMacQueueItem> mpdu)
+{
+  NS_LOG_FUNCTION (this << *mpdu);
+  //The number of bytes a fragment can support is (Threshold - WIFI_HEADER_SIZE - WIFI_FCS).
+  uint32_t nFragments = (mpdu->GetPacket ()->GetSize () / (GetFragmentationThreshold () - mpdu->GetHeader ().GetSize () - WIFI_MAC_FCS_LENGTH));
+
+  //If the size of the last fragment is not 0.
+  if ((mpdu->GetPacket ()->GetSize () % (GetFragmentationThreshold () - mpdu->GetHeader ().GetSize () - WIFI_MAC_FCS_LENGTH)) > 0)
+    {
+      nFragments++;
+    }
+  NS_LOG_DEBUG ("WifiRemoteStationManager::GetNFragments returning " << nFragments);
+  return nFragments;
+}
+
+uint32_t
+WifiRemoteStationManager::GetFragmentSize (Ptr<const WifiMacQueueItem> mpdu, uint32_t fragmentNumber)
+{
+  NS_LOG_FUNCTION (this << *mpdu << fragmentNumber);
+  NS_ASSERT (!mpdu->GetHeader ().GetAddr1 ().IsGroup ());
+  uint32_t nFragment = GetNFragments (mpdu);
+  if (fragmentNumber >= nFragment)
+    {
+      NS_LOG_DEBUG ("WifiRemoteStationManager::GetFragmentSize returning 0");
+      return 0;
+    }
+  //Last fragment
+  if (fragmentNumber == nFragment - 1)
+    {
+      uint32_t lastFragmentSize = mpdu->GetPacket ()->GetSize () - (fragmentNumber * (GetFragmentationThreshold () - mpdu->GetHeader ().GetSize () - WIFI_MAC_FCS_LENGTH));
+      NS_LOG_DEBUG ("WifiRemoteStationManager::GetFragmentSize returning " << lastFragmentSize);
+      return lastFragmentSize;
+    }
+  //All fragments but the last, the number of bytes is (Threshold - WIFI_HEADER_SIZE - WIFI_FCS).
+  else
+    {
+      uint32_t fragmentSize = GetFragmentationThreshold () - mpdu->GetHeader ().GetSize () - WIFI_MAC_FCS_LENGTH;
+      NS_LOG_DEBUG ("WifiRemoteStationManager::GetFragmentSize returning " << fragmentSize);
+      return fragmentSize;
+    }
+}
+
+uint32_t
+WifiRemoteStationManager::GetFragmentOffset (Ptr<const WifiMacQueueItem> mpdu, uint32_t fragmentNumber)
+{
+  NS_LOG_FUNCTION (this << *mpdu << fragmentNumber);
+  NS_ASSERT (!mpdu->GetHeader ().GetAddr1 ().IsGroup ());
+  NS_ASSERT (fragmentNumber < GetNFragments (mpdu));
+  uint32_t fragmentOffset = fragmentNumber * (GetFragmentationThreshold () - mpdu->GetHeader ().GetSize () - WIFI_MAC_FCS_LENGTH);
+  NS_LOG_DEBUG ("WifiRemoteStationManager::GetFragmentOffset returning " << fragmentOffset);
+  return fragmentOffset;
+}
+
+bool
+WifiRemoteStationManager::IsLastFragment (Ptr<const WifiMacQueueItem> mpdu, uint32_t fragmentNumber)
+{
+  NS_LOG_FUNCTION (this << *mpdu << fragmentNumber);
+  NS_ASSERT (!mpdu->GetHeader ().GetAddr1 ().IsGroup ());
+  bool isLast = fragmentNumber == (GetNFragments (mpdu) - 1);
+  NS_LOG_DEBUG ("WifiRemoteStationManager::IsLastFragment returning " << std::boolalpha << isLast);
+  return isLast;
+}
+
+uint8_t
+WifiRemoteStationManager::GetDefaultTxPowerLevel (void) const
+{
+  return m_defaultTxPowerLevel;
+}
+
+WifiRemoteStationInfo
+WifiRemoteStationManager::GetInfo (Mac48Address address)
+{
+  WifiRemoteStationState *state = LookupState (address);
+  return state->m_info;
+}
+
+double
+WifiRemoteStationManager::GetMostRecentRssi (Mac48Address address) const
+{
+  auto stationIt = m_stations.find (address);
+  NS_ASSERT_MSG (stationIt != m_stations.end(), "Address: " << address << " not found");
+  auto station = stationIt->second;
+  auto rssi = station->m_rssiAndUpdateTimePair.first;
+  auto ts = station->m_rssiAndUpdateTimePair.second;
+  NS_ASSERT_MSG (ts.IsStrictlyPositive(), "address: " << address << " ts:" << ts);
+  return rssi;
+}
+
+WifiRemoteStationState *
+WifiRemoteStationManager::LookupState (Mac48Address address) const
+{
+  NS_LOG_FUNCTION (this << address);
+  auto stateIt = m_states.find (address);
+
+  if (stateIt != m_states.end ())
+    {
+      NS_LOG_DEBUG ("WifiRemoteStationManager::LookupState returning existing state");
+      return stateIt->second;
+    }
+
+  WifiRemoteStationState *state = new WifiRemoteStationState ();
+  state->m_state = WifiRemoteStationState::BRAND_NEW;
+  state->m_address = address;
+  state->m_aid = 0;
+  state->m_operationalRateSet.push_back (GetDefaultMode ());
+  state->m_operationalMcsSet.push_back (GetDefaultMcs ());
+  state->m_dsssSupported = false;
+  state->m_erpOfdmSupported = false;
+  state->m_ofdmSupported = false;
+  state->m_htCapabilities = 0;
+  state->m_vhtCapabilities = 0;
+  state->m_heCapabilities = 0;
+  state->m_channelWidth = m_wifiPhy->GetChannelWidth ();
+  state->m_guardInterval = GetGuardInterval ();
+  state->m_ness = 0;
+  state->m_aggregation = false;
+  state->m_qosSupported = false;
+  const_cast<WifiRemoteStationManager *> (this)->m_states.insert ({address, state});
+  NS_LOG_DEBUG ("WifiRemoteStationManager::LookupState returning new state");
+  return state;
+}
+
+WifiRemoteStation *
+WifiRemoteStationManager::Lookup (Mac48Address address) const
+{
+  NS_LOG_FUNCTION (this << address);
+  auto stationIt = m_stations.find (address);
+
+  if (stationIt != m_stations.end ())
+    {
+      return stationIt->second;
+    }
+
+  WifiRemoteStationState *state = LookupState (address);
+
+  WifiRemoteStation *station = DoCreateStation ();
+  station->m_state = state;
+  station->m_rssiAndUpdateTimePair = std::make_pair (0, Seconds (0));
+  const_cast<WifiRemoteStationManager *> (this)->m_stations.insert ({address, station});
+  return station;
+}
+
+void
+WifiRemoteStationManager::SetAssociationId (Mac48Address remoteAddress, uint16_t aid)
+{
+  NS_LOG_FUNCTION (this << remoteAddress << aid);
+  LookupState (remoteAddress)->m_aid = aid;
+}
+
+void
+WifiRemoteStationManager::SetQosSupport (Mac48Address from, bool qosSupported)
+{
+  NS_LOG_FUNCTION (this << from << qosSupported);
+  WifiRemoteStationState *state;
+  state = LookupState (from);
+  state->m_qosSupported = qosSupported;
+}
+
+void
+WifiRemoteStationManager::AddStationHtCapabilities (Mac48Address from, HtCapabilities htCapabilities)
+{
+  //Used by all stations to record HT capabilities of remote stations
+  NS_LOG_FUNCTION (this << from << htCapabilities);
+  WifiRemoteStationState *state;
+  state = LookupState (from);
+  if (htCapabilities.GetSupportedChannelWidth () == 1)
+    {
+      state->m_channelWidth = 40;
+    }
+  else
+    {
+      state->m_channelWidth = 20;
+    }
+  SetQosSupport (from, true);
+  for (const auto & mcs : m_wifiPhy->GetMcsList (WIFI_MOD_CLASS_HT))
+    {
+      if (htCapabilities.IsSupportedMcs (mcs.GetMcsValue ()))
+        {
+          AddSupportedMcs (from, mcs);
+        }
+    }
+  state->m_htCapabilities = Create<const HtCapabilities> (htCapabilities);
+}
+
+void
+WifiRemoteStationManager::AddStationVhtCapabilities (Mac48Address from, VhtCapabilities vhtCapabilities)
+{
+  //Used by all stations to record VHT capabilities of remote stations
+  NS_LOG_FUNCTION (this << from << vhtCapabilities);
+  WifiRemoteStationState *state;
+  state = LookupState (from);
+  if (vhtCapabilities.GetSupportedChannelWidthSet () == 1)
+    {
+      state->m_channelWidth = 160;
+    }
+  else
+    {
+      state->m_channelWidth = 80;
+    }
+  //This is a workaround to enable users to force a 20 or 40 MHz channel for a VHT-compliant device,
+  //since IEEE 802.11ac standard says that 20, 40 and 80 MHz channels are mandatory.
+  if (m_wifiPhy->GetChannelWidth () < state->m_channelWidth)
+    {
+      state->m_channelWidth = m_wifiPhy->GetChannelWidth ();
+    }
+  for (uint8_t i = 1; i <= m_wifiPhy->GetMaxSupportedTxSpatialStreams (); i++)
+    {
+      for (const auto & mcs : m_wifiPhy->GetMcsList (WIFI_MOD_CLASS_VHT))
+        {
+          if (vhtCapabilities.IsSupportedMcs (mcs.GetMcsValue (), i))
+            {
+              AddSupportedMcs (from, mcs);
+            }
+        }
+    }
+  state->m_vhtCapabilities = Create<const VhtCapabilities> (vhtCapabilities);
+}
+
+void
+WifiRemoteStationManager::AddStationHeCapabilities (Mac48Address from, HeCapabilities heCapabilities)
+{
+  //Used by all stations to record HE capabilities of remote stations
+  NS_LOG_FUNCTION (this << from << heCapabilities);
+  WifiRemoteStationState *state;
+  state = LookupState (from);
+  if ((m_wifiPhy->GetPhyBand () == WIFI_PHY_BAND_5GHZ) || (m_wifiPhy->GetPhyBand () == WIFI_PHY_BAND_6GHZ))
+    {
+      if (heCapabilities.GetChannelWidthSet () & 0x04)
+        {
+          state->m_channelWidth = 160;
+        }
+      else if (heCapabilities.GetChannelWidthSet () & 0x02)
+        {
+          state->m_channelWidth = 80;
+        }
+      //For other cases at 5 GHz, the supported channel width is set by the VHT capabilities
+    }
+  else if (m_wifiPhy->GetPhyBand () == WIFI_PHY_BAND_2_4GHZ)
+    {
+      if (heCapabilities.GetChannelWidthSet () & 0x01)
+        {
+          state->m_channelWidth = 40;
+        }
+      else
+        {
+          state->m_channelWidth = 20;
+        }
+    }
+  if (heCapabilities.GetHeSuPpdu1xHeLtf800nsGi () == 1)
+    {
+      state->m_guardInterval = 800;
+    }
+  else
+    {
+      //todo: Using 3200ns, default value for HeConfiguration::GuardInterval
+      state->m_guardInterval = 3200;
+    }
+  for (uint8_t i = 1; i <= m_wifiPhy->GetMaxSupportedTxSpatialStreams (); i++)
+    {
+      for (const auto & mcs : m_wifiPhy->GetMcsList (WIFI_MOD_CLASS_HE))
+        {
+          if (heCapabilities.GetHighestNssSupported () >= i
+              && heCapabilities.GetHighestMcsSupported () >= mcs.GetMcsValue ())
+            {
+              AddSupportedMcs (from, mcs);
+            }
+        }
+    }
+  state->m_heCapabilities = Create<const HeCapabilities> (heCapabilities);
+  SetQosSupport (from, true);
+}
+
+Ptr<const HtCapabilities>
+WifiRemoteStationManager::GetStationHtCapabilities (Mac48Address from)
+{
+  return LookupState (from)->m_htCapabilities;
+}
+
+Ptr<const VhtCapabilities>
+WifiRemoteStationManager::GetStationVhtCapabilities (Mac48Address from)
+{
+  return LookupState (from)->m_vhtCapabilities;
+}
+
+Ptr<const HeCapabilities>
+WifiRemoteStationManager::GetStationHeCapabilities (Mac48Address from)
+{
+  return LookupState (from)->m_heCapabilities;
+}
+
+bool
+WifiRemoteStationManager::GetLdpcSupported (Mac48Address address) const
+{
+  Ptr<const HtCapabilities> htCapabilities = LookupState (address)->m_htCapabilities;
+  Ptr<const VhtCapabilities> vhtCapabilities = LookupState (address)->m_vhtCapabilities;
+  Ptr<const HeCapabilities> heCapabilities = LookupState (address)->m_heCapabilities;
+  bool supported = false;
+  if (htCapabilities)
+    {
+      supported |= htCapabilities->GetLdpc ();
+    }
+  if (vhtCapabilities)
+    {
+      supported |= vhtCapabilities->GetRxLdpc ();
+    }
+  if (heCapabilities)
+    {
+      supported |= heCapabilities->GetLdpcCodingInPayload ();
+    }
+  return supported;
+}
+
+WifiMode
+WifiRemoteStationManager::GetDefaultMode (void) const
+{
+  return m_defaultTxMode;
+}
+
+WifiMode
+WifiRemoteStationManager::GetDefaultMcs (void) const
+{
+  return m_defaultTxMcs;
+}
+
+WifiMode
+WifiRemoteStationManager::GetDefaultModeForSta (const WifiRemoteStation *st) const
+{
+  NS_LOG_FUNCTION (this << st);
+
+  if (!GetHtSupported () || !GetHtSupported (st))
+    {
+      return GetDefaultMode ();
+    }
+
+  // find the highest modulation class supported by both stations
+  WifiModulationClass modClass = WIFI_MOD_CLASS_HT;
+  if (GetHeSupported () && GetHeSupported (st))
+    {
+      modClass = WIFI_MOD_CLASS_HE;
+    }
+  else if (GetVhtSupported () && GetVhtSupported (st))
+    {
+      modClass = WIFI_MOD_CLASS_VHT;
+    }
+
+  // return the MCS with lowest index
+  return *m_wifiPhy->GetPhyEntity (modClass)->begin ();
+}
+
+void
+WifiRemoteStationManager::Reset (void)
+{
+  NS_LOG_FUNCTION (this);
+  for (auto& state : m_states)
+    {
+      delete (state.second);
+    }
+  m_states.clear ();
+  for (auto& state: m_stations)
+    {
+      delete (state.second);
+    }
+  m_stations.clear ();
+  m_bssBasicRateSet.clear ();
+  m_bssBasicMcsSet.clear ();
+  m_ssrc.fill (0);
+  m_slrc.fill (0);
+}
+
+void
+WifiRemoteStationManager::AddBasicMode (WifiMode mode)
+{
+  NS_LOG_FUNCTION (this << mode);
+  if (mode.GetModulationClass () >= WIFI_MOD_CLASS_HT)
+    {
+      NS_FATAL_ERROR ("It is not allowed to add a HT rate in the BSSBasicRateSet!");
+    }
+  for (uint8_t i = 0; i < GetNBasicModes (); i++)
+    {
+      if (GetBasicMode (i) == mode)
+        {
+          return;
+        }
+    }
+  m_bssBasicRateSet.push_back (mode);
+}
+
+uint8_t
+WifiRemoteStationManager::GetNBasicModes (void) const
+{
+  return static_cast<uint8_t> (m_bssBasicRateSet.size ());
+}
+
+WifiMode
+WifiRemoteStationManager::GetBasicMode (uint8_t i) const
+{
+  NS_ASSERT (i < GetNBasicModes ());
+  return m_bssBasicRateSet[i];
+}
+
+uint32_t
+WifiRemoteStationManager::GetNNonErpBasicModes (void) const
+{
+  uint32_t size = 0;
+  for (WifiModeListIterator i = m_bssBasicRateSet.begin (); i != m_bssBasicRateSet.end (); i++)
+    {
+      if (i->GetModulationClass () == WIFI_MOD_CLASS_ERP_OFDM)
+        {
+          continue;
+        }
+      size++;
+    }
+  return size;
+}
+
+WifiMode
+WifiRemoteStationManager::GetNonErpBasicMode (uint8_t i) const
+{
+  NS_ASSERT (i < GetNNonErpBasicModes ());
+  uint32_t index = 0;
+  bool found = false;
+  for (WifiModeListIterator j = m_bssBasicRateSet.begin (); j != m_bssBasicRateSet.end (); )
+    {
+      if (i == index)
+        {
+          found = true;
+        }
+      if (j->GetModulationClass () != WIFI_MOD_CLASS_ERP_OFDM)
+        {
+          if (found)
+            {
+              break;
+            }
+        }
+      index++;
+      j++;
+    }
+  return m_bssBasicRateSet[index];
+}
+
+void
+WifiRemoteStationManager::AddBasicMcs (WifiMode mcs)
+{
+  NS_LOG_FUNCTION (this << +mcs.GetMcsValue ());
+  for (uint8_t i = 0; i < GetNBasicMcs (); i++)
+    {
+      if (GetBasicMcs (i) == mcs)
+        {
+          return;
+        }
+    }
+  m_bssBasicMcsSet.push_back (mcs);
+}
+
+uint8_t
+WifiRemoteStationManager::GetNBasicMcs (void) const
+{
+  return static_cast<uint8_t> (m_bssBasicMcsSet.size ());
+}
+
+WifiMode
+WifiRemoteStationManager::GetBasicMcs (uint8_t i) const
+{
+  NS_ASSERT (i < GetNBasicMcs ());
+  return m_bssBasicMcsSet[i];
+}
+
+WifiMode
+WifiRemoteStationManager::GetNonUnicastMode (void) const
+{
+  if (m_nonUnicastMode == WifiMode ())
+    {
+      if (GetNBasicModes () > 0)
+        {
+          return GetBasicMode (0);
+        }
+      else
+        {
+          return GetDefaultMode ();
+        }
+    }
+  else
+    {
+      return m_nonUnicastMode;
+    }
+}
+
+bool
+WifiRemoteStationManager::DoNeedRts (WifiRemoteStation *station,
+                                     uint32_t size, bool normally)
+{
+  return normally;
+}
+
+bool
+WifiRemoteStationManager::DoNeedRetransmission (WifiRemoteStation *station,
+                                                Ptr<const Packet> packet, bool normally)
+{
+  return normally;
+}
+
+bool
+WifiRemoteStationManager::DoNeedFragmentation (WifiRemoteStation *station,
+                                               Ptr<const Packet> packet, bool normally)
+{
+  return normally;
+}
+
+void
+WifiRemoteStationManager::DoReportAmpduTxStatus (WifiRemoteStation *station, uint16_t nSuccessfulMpdus, uint16_t nFailedMpdus, double rxSnr, double dataSnr, uint16_t dataChannelWidth, uint8_t dataNss)
+{
+  NS_LOG_DEBUG ("DoReportAmpduTxStatus received but the manager does not handle A-MPDUs!");
+}
+
+WifiMode
+WifiRemoteStationManager::GetSupported (const WifiRemoteStation *station, uint8_t i) const
+{
+  NS_ASSERT (i < GetNSupported (station));
+  return station->m_state->m_operationalRateSet[i];
+}
+
+WifiMode
+WifiRemoteStationManager::GetMcsSupported (const WifiRemoteStation *station, uint8_t i) const
+{
+  NS_ASSERT (i < GetNMcsSupported (station));
+  return station->m_state->m_operationalMcsSet[i];
+}
+
+WifiMode
+WifiRemoteStationManager::GetNonErpSupported (const WifiRemoteStation *station, uint8_t i) const
+{
+  NS_ASSERT (i < GetNNonErpSupported (station));
+  //IEEE 802.11g standard defines that if the protection mechanism is enabled, RTS, CTS and CTS-To-Self
+  //frames should select a rate in the BSSBasicRateSet that corresponds to an 802.11b basic rate.
+  //This is a implemented here to avoid changes in every RAA, but should maybe be moved in case it breaks standard rules.
+  uint32_t index = 0;
+  bool found = false;
+  for (WifiModeListIterator j = station->m_state->m_operationalRateSet.begin (); j != station->m_state->m_operationalRateSet.end (); )
+    {
+      if (i == index)
+        {
+          found = true;
+        }
+      if (j->GetModulationClass () != WIFI_MOD_CLASS_ERP_OFDM)
+        {
+          if (found)
+            {
+              break;
+            }
+        }
+      index++;
+      j++;
+    }
+  return station->m_state->m_operationalRateSet[index];
+}
+
+Mac48Address
+WifiRemoteStationManager::GetAddress (const WifiRemoteStation *station) const
+{
+  return station->m_state->m_address;
+}
+
+uint16_t
+WifiRemoteStationManager::GetChannelWidth (const WifiRemoteStation *station) const
+{
+  return station->m_state->m_channelWidth;
+}
+
+bool
+WifiRemoteStationManager::GetShortGuardIntervalSupported (const WifiRemoteStation *station) const
+{
+  Ptr<const HtCapabilities> htCapabilities = station->m_state->m_htCapabilities;
+
+  if (!htCapabilities)
+    {
+      return false;
+    }
+  return htCapabilities->GetShortGuardInterval20 ();
+}
+
+uint16_t
+WifiRemoteStationManager::GetGuardInterval (const WifiRemoteStation *station) const
+{
+  return station->m_state->m_guardInterval;
+}
+
+bool
+WifiRemoteStationManager::GetAggregation (const WifiRemoteStation *station) const
+{
+  return station->m_state->m_aggregation;
+}
+
+uint8_t
+WifiRemoteStationManager::GetNumberOfSupportedStreams (const WifiRemoteStation *station) const
+{
+  Ptr<const HtCapabilities> htCapabilities = station->m_state->m_htCapabilities;
+
+  if (!htCapabilities)
+    {
+      return 1;
+    }
+  return htCapabilities->GetRxHighestSupportedAntennas ();
+}
+
+uint8_t
+WifiRemoteStationManager::GetNess (const WifiRemoteStation *station) const
+{
+  return station->m_state->m_ness;
+}
+
+Ptr<WifiPhy>
+WifiRemoteStationManager::GetPhy (void) const
+{
+  return m_wifiPhy;
+}
+
+Ptr<WifiMac>
+WifiRemoteStationManager::GetMac (void) const
+{
+  return m_wifiMac;
+}
+
+uint8_t
+WifiRemoteStationManager::GetNSupported (const WifiRemoteStation *station) const
+{
+  return static_cast<uint8_t> (station->m_state->m_operationalRateSet.size ());
+}
+
+bool
+WifiRemoteStationManager::GetQosSupported (const WifiRemoteStation *station) const
+{
+  return station->m_state->m_qosSupported;
+}
+
+bool
+WifiRemoteStationManager::GetHtSupported (const WifiRemoteStation *station) const
+{
+  return (station->m_state->m_htCapabilities != 0);
+}
+
+bool
+WifiRemoteStationManager::GetVhtSupported (const WifiRemoteStation *station) const
+{
+  return (station->m_state->m_vhtCapabilities != 0);
+}
+
+bool
+WifiRemoteStationManager::GetHeSupported (const WifiRemoteStation *station) const
+{
+  return (station->m_state->m_heCapabilities != 0);
+}
+
+uint8_t
+WifiRemoteStationManager::GetNMcsSupported (const WifiRemoteStation *station) const
+{
+  return static_cast<uint8_t> (station->m_state->m_operationalMcsSet.size ());
+}
+
+uint32_t
+WifiRemoteStationManager::GetNNonErpSupported (const WifiRemoteStation *station) const
+{
+  uint32_t size = 0;
+  for (WifiModeListIterator i = station->m_state->m_operationalRateSet.begin (); i != station->m_state->m_operationalRateSet.end (); i++)
+    {
+      if (i->GetModulationClass () == WIFI_MOD_CLASS_ERP_OFDM)
+        {
+          continue;
+        }
+      size++;
+    }
+  return size;
+}
+
+uint16_t
+WifiRemoteStationManager::GetChannelWidthSupported (Mac48Address address) const
+{
+  return LookupState (address)->m_channelWidth;
+}
+
+bool
+WifiRemoteStationManager::GetShortGuardIntervalSupported (Mac48Address address) const
+{
+  Ptr<const HtCapabilities> htCapabilities = LookupState (address)->m_htCapabilities;
+
+  if (!htCapabilities)
+    {
+      return false;
+    }
+  return htCapabilities->GetShortGuardInterval20 ();
+}
+
+uint8_t
+WifiRemoteStationManager::GetNumberOfSupportedStreams (Mac48Address address) const
+{
+  Ptr<const HtCapabilities> htCapabilities = LookupState (address)->m_htCapabilities;
+
+  if (!htCapabilities)
+    {
+      return 1;
+    }
+  return htCapabilities->GetRxHighestSupportedAntennas ();
+}
+
+uint8_t
+WifiRemoteStationManager::GetNMcsSupported (Mac48Address address) const
+{
+  return static_cast<uint8_t> (LookupState (address)->m_operationalMcsSet.size ());
+}
+
+bool
+WifiRemoteStationManager::GetDsssSupported (const Mac48Address& address) const
+{
+  return (LookupState (address)->m_dsssSupported);
+}
+
+bool
+WifiRemoteStationManager::GetErpOfdmSupported (const Mac48Address& address) const
+{
+  return (LookupState (address)->m_erpOfdmSupported);
+}
+
+bool
+WifiRemoteStationManager::GetOfdmSupported (const Mac48Address& address) const
+{
+  return (LookupState (address)->m_ofdmSupported);
+}
+
+bool
+WifiRemoteStationManager::GetHtSupported (Mac48Address address) const
+{
+  return (LookupState (address)->m_htCapabilities != 0);
+}
+
+bool
+WifiRemoteStationManager::GetVhtSupported (Mac48Address address) const
+{
+  return (LookupState (address)->m_vhtCapabilities != 0);
+}
+
+bool
+WifiRemoteStationManager::GetHeSupported (Mac48Address address) const
+{
+  return (LookupState (address)->m_heCapabilities != 0);
+}
+
+void
+WifiRemoteStationManager::SetDefaultTxPowerLevel (uint8_t txPower)
+{
+  m_defaultTxPowerLevel = txPower;
+}
+
+uint8_t
+WifiRemoteStationManager::GetNumberOfAntennas (void) const
+{
+  return m_wifiPhy->GetNumberOfAntennas ();
+}
+
+uint8_t
+WifiRemoteStationManager::GetMaxNumberOfTransmitStreams (void) const
+{
+  return m_wifiPhy->GetMaxSupportedTxSpatialStreams ();
+}
+
+bool
+WifiRemoteStationManager::UseLdpcForDestination (Mac48Address dest) const
+{
+  return (GetLdpcSupported () && GetLdpcSupported (dest));
+}
+
+} //namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/wifi-remote-station-manager.h
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-remote-station-manager.h
@@ -1,0 +1,1369 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2005,2006,2007 INRIA
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ */
+
+#ifndef WIFI_REMOTE_STATION_MANAGER_H
+#define WIFI_REMOTE_STATION_MANAGER_H
+
+#include <array>
+#include <unordered_map>
+#include "ns3/traced-callback.h"
+#include "ns3/object.h"
+#include "ns3/data-rate.h"
+#include "ns3/mac48-address.h"
+#include "wifi-mode.h"
+#include "wifi-utils.h"
+#include "qos-utils.h"
+#include "wifi-remote-station-info.h"
+#include "ns3/ht-capabilities.h"
+#include "ns3/vht-capabilities.h"
+#include "ns3/he-capabilities.h"
+
+namespace ns3 {
+
+class WifiPhy;
+class WifiMac;
+class WifiMacHeader;
+class Packet;
+class WifiMacQueueItem;
+class WifiTxVector;
+
+struct WifiRemoteStationState;
+struct RxSignalInfo;
+
+/**
+ * \brief hold per-remote-station state.
+ *
+ * The state in this class is used to keep track
+ * of association status if we are in an infrastructure
+ * network and to perform the selection of TX parameters
+ * on a per-packet basis.
+ *
+ * This class is typically subclassed and extended by
+ * rate control implementations
+ */
+struct WifiRemoteStation
+{
+  virtual ~WifiRemoteStation () {};
+  WifiRemoteStationState *m_state;                 //!< Remote station state
+  std::pair<double, Time> m_rssiAndUpdateTimePair; //!< RSSI (in dBm) of the most recent packet received from the remote station along with update time
+};
+
+/**
+ * A struct that holds information about each remote station.
+ */
+struct WifiRemoteStationState
+{
+  /**
+   * State of the station
+   */
+  enum
+  {
+    BRAND_NEW,
+    DISASSOC,
+    WAIT_ASSOC_TX_OK,
+    GOT_ASSOC_TX_OK
+  } m_state;
+
+  /**
+   * This member is the list of WifiMode objects that comprise the
+   * OperationalRateSet parameter for this remote station. This list
+   * is constructed through calls to
+   * WifiRemoteStationManager::AddSupportedMode(), and an API that
+   * allows external access to it is available through
+   * WifiRemoteStationManager::GetNSupported() and
+   * WifiRemoteStationManager::GetSupported().
+   */
+  WifiModeList m_operationalRateSet; //!< operational rate set
+  WifiModeList m_operationalMcsSet;  //!< operational MCS set
+  Mac48Address m_address;            //!< Mac48Address of the remote station
+  uint16_t m_aid;                    /**< AID of the remote station (unused if this object
+                                          is installed on a non-AP station) */
+  WifiRemoteStationInfo m_info;      //!< remote station info
+  bool m_dsssSupported;              //!< Flag if DSSS is supported by the remote station
+  bool m_erpOfdmSupported;           //!< Flag if ERP OFDM is supported by the remote station
+  bool m_ofdmSupported;              //!< Flag if OFDM is supported by the remote station
+  Ptr<const HtCapabilities> m_htCapabilities;   //!< remote station HT capabilities
+  Ptr<const VhtCapabilities> m_vhtCapabilities; //!< remote station VHT capabilities
+  Ptr<const HeCapabilities> m_heCapabilities;   //!< remote station HE capabilities
+  uint16_t m_channelWidth;    //!< Channel width (in MHz) supported by the remote station
+  uint16_t m_guardInterval;   //!< HE Guard interval duration (in nanoseconds) supported by the remote station
+  uint8_t m_ness;             //!< Number of extended spatial streams of the remote station
+  bool m_aggregation;         //!< Flag if MPDU aggregation is used by the remote station
+  bool m_shortPreamble;       //!< Flag if short PHY preamble is supported by the remote station
+  bool m_shortSlotTime;       //!< Flag if short ERP slot time is supported by the remote station
+  bool m_qosSupported;        //!< Flag if QoS is supported by the station
+};
+
+/**
+ * \ingroup wifi
+ * \brief hold a list of per-remote-station state.
+ *
+ * \sa ns3::WifiRemoteStation.
+ */
+class WifiRemoteStationManager : public Object
+{
+public:
+  /**
+   * \brief Get the type ID.
+   * \return the object TypeId
+   */
+  static TypeId GetTypeId (void);
+
+  WifiRemoteStationManager ();
+  virtual ~WifiRemoteStationManager ();
+
+  /// ProtectionMode enumeration
+  enum ProtectionMode
+  {
+    RTS_CTS,
+    CTS_TO_SELF
+  };
+
+  /**
+   * A map of WifiRemoteStations with Mac48Address as key
+   */
+  using Stations = std::unordered_map <Mac48Address, WifiRemoteStation *, WifiAddressHash>;
+  /**
+   * A map of WifiRemoteStationStates with Mac48Address as key
+   */
+  using StationStates = std::unordered_map <Mac48Address, WifiRemoteStationState *, WifiAddressHash>;
+
+  /**
+   * Set up PHY associated with this device since it is the object that
+   * knows the full set of transmit rates that are supported.
+   *
+   * \param phy the PHY of this device
+   */
+  virtual void SetupPhy (const Ptr<WifiPhy> phy);
+  /**
+   * Set up MAC associated with this device since it is the object that
+   * knows the full set of timing parameters (e.g. IFS).
+   *
+   * \param mac the MAC of this device
+   */
+  virtual void SetupMac (const Ptr<WifiMac> mac);
+
+  /**
+   * Assign a fixed random variable stream number to the random variables
+   * used by this model.  Return the number of streams (possibly zero) that
+   * have been assigned.
+   *
+   * \param stream first stream index to use
+   * \return the number of stream indices assigned by this model
+   */
+  virtual int64_t AssignStreams (int64_t stream);
+
+  /**
+   * Sets the maximum STA short retry count (SSRC).
+   *
+   * \param maxSsrc the maximum SSRC
+   */
+  void SetMaxSsrc (uint32_t maxSsrc);
+  /**
+   * Sets the maximum STA long retry count (SLRC).
+   *
+   * \param maxSlrc the maximum SLRC
+   */
+  void SetMaxSlrc (uint32_t maxSlrc);
+  /**
+   * Sets the RTS threshold.
+   *
+   * \param threshold the RTS threshold
+   */
+  void SetRtsCtsThreshold (uint32_t threshold);
+
+  /**
+   * Return the fragmentation threshold.
+   *
+   * \return the fragmentation threshold
+   */
+  uint32_t GetFragmentationThreshold (void) const;
+  /**
+   * Sets a fragmentation threshold. The method calls a private method
+   * DoSetFragmentationThreshold that checks the validity of the value given.
+   *
+   * \param threshold the fragmentation threshold
+   */
+  void SetFragmentationThreshold (uint32_t threshold);
+
+  /**
+   * Record the AID of a remote station. Should only be called by APs.
+   *
+   * \param remoteAddress the MAC address of the remote station
+   * \param aid the Association ID
+   */
+  void SetAssociationId (Mac48Address remoteAddress, uint16_t aid);
+  /**
+   * Records QoS support of the remote station.
+   *
+   * \param from the address of the station being recorded
+   * \param qosSupported whether the station supports QoS
+   */
+  void SetQosSupport (Mac48Address from, bool qosSupported);
+  /**
+   * Records HT capabilities of the remote station.
+   *
+   * \param from the address of the station being recorded
+   * \param htCapabilities the HT capabilities of the station
+   */
+  void AddStationHtCapabilities (Mac48Address from, HtCapabilities htCapabilities);
+  /**
+   * Records VHT capabilities of the remote station.
+   *
+   * \param from the address of the station being recorded
+   * \param vhtCapabilities the VHT capabilities of the station
+   */
+  void AddStationVhtCapabilities (Mac48Address from, VhtCapabilities vhtCapabilities);
+  /**
+   * Records HE capabilities of the remote station.
+   *
+   * \param from the address of the station being recorded
+   * \param heCapabilities the HE capabilities of the station
+   */
+  void AddStationHeCapabilities (Mac48Address from, HeCapabilities heCapabilities);
+  /**
+   * Return the HT capabilities sent by the remote station.
+   *
+   * \param from the address of the remote station
+   * \return the HT capabilities sent by the remote station
+   */
+  Ptr<const HtCapabilities> GetStationHtCapabilities (Mac48Address from);
+  /**
+   * Return the VHT capabilities sent by the remote station.
+   *
+   * \param from the address of the remote station
+   * \return the VHT capabilities sent by the remote station
+   */
+  Ptr<const VhtCapabilities> GetStationVhtCapabilities (Mac48Address from);
+  /**
+   * Return the HE capabilities sent by the remote station.
+   *
+   * \param from the address of the remote station
+   * \return the HE capabilities sent by the remote station
+   */
+  Ptr<const HeCapabilities> GetStationHeCapabilities (Mac48Address from);
+  /**
+   * Return whether the device has HT capability support enabled.
+   *
+   * \return true if HT capability support is enabled, false otherwise
+   */
+  bool GetHtSupported (void) const;
+  /**
+   * Return whether the device has VHT capability support enabled.
+   *
+   * \return true if VHT capability support is enabled, false otherwise
+   */
+  bool GetVhtSupported (void) const;
+  /**
+   * Return whether the device has HE capability support enabled.
+   *
+   * \return true if HE capability support is enabled, false otherwise
+   */
+  bool GetHeSupported (void) const;
+  /**
+   * Return whether the device has LDPC support enabled.
+   *
+   * \return true if LDPC support is enabled, false otherwise
+   */
+  bool GetLdpcSupported (void) const;
+  /**
+   * Return whether the device has SGI support enabled.
+   *
+   * \return true if SGI support is enabled, false otherwise
+   */
+  bool GetShortGuardIntervalSupported (void) const;
+  /**
+   * Return the supported HE guard interval duration (in nanoseconds).
+   *
+   * \return the supported HE guard interval duration (in nanoseconds)
+   */
+  uint16_t GetGuardInterval (void) const;
+  /**
+   * Enable or disable protection for non-ERP stations.
+   *
+   * \param enable enable or disable protection for non-ERP stations
+   */
+  void SetUseNonErpProtection (bool enable);
+  /**
+   * Return whether the device supports protection of non-ERP stations.
+   *
+   * \return true if protection for non-ERP stations is enabled,
+   *         false otherwise
+   */
+  bool GetUseNonErpProtection (void) const;
+  /**
+   * Enable or disable protection for non-HT stations.
+   *
+   * \param enable enable or disable protection for non-HT stations
+   */
+  void SetUseNonHtProtection (bool enable);
+  /**
+   * Return whether the device supports protection of non-HT stations.
+   *
+   * \return true if protection for non-HT stations is enabled,
+   *         false otherwise
+   */
+  bool GetUseNonHtProtection (void) const;
+  /**
+   * Enable or disable short PHY preambles.
+   *
+   * \param enable enable or disable short PHY preambles
+   */
+  void SetShortPreambleEnabled (bool enable);
+  /**
+   * Return whether the device uses short PHY preambles.
+   *
+   * \return true if short PHY preambles are enabled,
+   *         false otherwise
+   */
+  bool GetShortPreambleEnabled (void) const;
+  /**
+   * Enable or disable short slot time.
+   *
+   * \param enable enable or disable short slot time
+   */
+  void SetShortSlotTimeEnabled (bool enable);
+  /**
+   * Return whether the device uses short slot time.
+   *
+   * \return true if short slot time is enabled,
+   *         false otherwise
+   */
+  bool GetShortSlotTimeEnabled (void) const;
+
+  /**
+   * Reset the station, invoked in a STA upon dis-association or in an AP upon reboot.
+   */
+  void Reset (void);
+
+  /**
+   * Invoked in a STA upon association to store the set of rates which belong to the
+   * BSSBasicRateSet of the associated AP and which are supported locally.
+   * Invoked in an AP to configure the BSSBasicRateSet.
+   *
+   * \param mode the WifiMode to be added to the basic mode set
+   */
+  void AddBasicMode (WifiMode mode);
+  /**
+   * Return the default transmission mode.
+   *
+   * \return WifiMode the default transmission mode
+   */
+  WifiMode GetDefaultMode (void) const;
+  /**
+   * Return the number of basic modes we support.
+   *
+   * \return the number of basic modes we support
+   */
+  uint8_t GetNBasicModes (void) const;
+  /**
+   * Return a basic mode from the set of basic modes.
+   *
+   * \param i index of the basic mode in the basic mode set
+   *
+   * \return the basic mode at the given index
+   */
+  WifiMode GetBasicMode (uint8_t i) const;
+  /**
+   * Return the number of non-ERP basic modes we support.
+   *
+   * \return the number of basic modes we support
+   */
+  uint32_t GetNNonErpBasicModes (void) const;
+  /**
+   * Return a basic mode from the set of basic modes that is not an ERP mode.
+   *
+   * \param i index of the basic mode in the basic mode set
+   *
+   * \return the basic mode at the given index
+   */
+  WifiMode GetNonErpBasicMode (uint8_t i) const;
+  /**
+   * Return whether the station supports LDPC or not.
+   *
+   * \param address the address of the station
+   *
+   * \return true if LDPC is supported by the station,
+   *         false otherwise
+   */
+  bool GetLdpcSupported (Mac48Address address) const;
+  /**
+   * Return whether the station supports short PHY preamble or not.
+   *
+   * \param address the address of the station
+   *
+   * \return true if short PHY preamble is supported by the station,
+   *         false otherwise
+   */
+  bool GetShortPreambleSupported (Mac48Address address) const;
+  /**
+   * Return whether the station supports short ERP slot time or not.
+   *
+   * \param address the address of the station
+   *
+   * \return true if short ERP slot time is supported by the station,
+   *         false otherwise
+   */
+  bool GetShortSlotTimeSupported (Mac48Address address) const;
+  /**
+   * Return whether the given station is QoS capable.
+   *
+   * \param address the address of the station
+   *
+   * \return true if the station has QoS capabilities,
+   *         false otherwise
+   */
+  bool GetQosSupported (Mac48Address address) const;
+  /**
+   * Get the AID of a remote station. Should only be called by APs.
+   *
+   * \param remoteAddress the MAC address of the remote station
+   * \return the Association ID if the station is associated, SU_STA_ID otherwise
+   */
+  uint16_t GetAssociationId (Mac48Address remoteAddress) const;
+  /**
+   * Add a given Modulation and Coding Scheme (MCS) index to
+   * the set of basic MCS.
+   *
+   * \param mcs the WifiMode to be added to the basic MCS set
+   */
+  void AddBasicMcs (WifiMode mcs);
+  /**
+   * Return the default Modulation and Coding Scheme (MCS) index.
+   *
+   * \return the default WifiMode
+   */
+  WifiMode GetDefaultMcs (void) const;
+  /**
+   * Return the default MCS to use to transmit frames to the given station.
+   *
+   * \param st the given station
+   * \return the default MCS to use to transmit frames to the given station
+   */
+  WifiMode GetDefaultModeForSta (const WifiRemoteStation *st) const;
+  /**
+   * Return the number of basic MCS index.
+   *
+   * \return the number of basic MCS index
+   */
+  uint8_t GetNBasicMcs (void) const;
+  /**
+   * Return the MCS at the given <i>list</i> index.
+   *
+   * \param i the position in the list
+   *
+   * \return the basic MCS at the given list index
+   */
+  WifiMode GetBasicMcs (uint8_t i) const;
+  /**
+   * Record the MCS index supported by the station.
+   *
+   * \param address the address of the station
+   * \param mcs the WifiMode supported by the station
+   */
+  void AddSupportedMcs (Mac48Address address, WifiMode mcs);
+  /**
+   * Return the channel width supported by the station.
+   *
+   * \param address the address of the station
+   *
+   * \return the channel width supported by the station
+   */
+  uint16_t GetChannelWidthSupported (Mac48Address address) const;
+  /**
+   * Return whether the station supports HT/VHT short guard interval.
+   *
+   * \param address the address of the station
+   *
+   * \return true if the station supports HT/VHT short guard interval,
+   *         false otherwise
+   */
+  bool GetShortGuardIntervalSupported (Mac48Address address) const;
+  /**
+   * Return the number of spatial streams supported by the station.
+   *
+   * \param address the address of the station
+   *
+   * \return the number of spatial streams supported by the station
+   */
+  uint8_t GetNumberOfSupportedStreams (Mac48Address address) const;
+  /**
+   * Return the number of MCS supported by the station.
+   *
+   * \param address the address of the station
+   *
+   * \return the number of MCS supported by the station
+   */
+  uint8_t GetNMcsSupported (Mac48Address address) const;
+  /**
+   * Return whether the station supports DSSS or not.
+   *
+   * \param address the address of the station
+   *
+   * \return true if DSSS is supported by the station,
+   *         false otherwise
+   */
+  bool GetDsssSupported (const Mac48Address& address) const;
+  /**
+   * Return whether the station supports ERP OFDM or not.
+   *
+   * \param address the address of the station
+   *
+   * \return true if ERP OFDM is supported by the station,
+   *         false otherwise
+   */
+  bool GetErpOfdmSupported (const Mac48Address& address) const;
+  /**
+   * Return whether the station supports OFDM or not.
+   *
+   * \param address the address of the station
+   *
+   * \return true if OFDM is supported by the station,
+   *         false otherwise
+   */
+  bool GetOfdmSupported (const Mac48Address& address) const;
+  /**
+   * Return whether the station supports HT or not.
+   *
+   * \param address the address of the station
+   *
+   * \return true if HT is supported by the station,
+   *         false otherwise
+   */
+  bool GetHtSupported (Mac48Address address) const;
+  /**
+   * Return whether the station supports VHT or not.
+   *
+   * \param address the address of the station
+   *
+   * \return true if VHT is supported by the station,
+   *         false otherwise
+   */
+  bool GetVhtSupported (Mac48Address address) const;
+  /**
+   * Return whether the station supports HE or not.
+   *
+   * \param address the address of the station
+   *
+   * \return true if HE is supported by the station,
+   *         false otherwise
+   */
+  bool GetHeSupported (Mac48Address address) const;
+
+  /**
+   * Return a mode for non-unicast packets.
+   *
+   * \return WifiMode for non-unicast packets
+   */
+  WifiMode GetNonUnicastMode (void) const;
+
+  /**
+   * Invoked in a STA or AP to store the set of
+   * modes supported by a destination which is
+   * also supported locally.
+   * The set of supported modes includes
+   * the BSSBasicRateSet.
+   *
+   * \param address the address of the station being recorded
+   * \param mode the WifiMode supports by the station
+   */
+  void AddSupportedMode (Mac48Address address, WifiMode mode);
+  /**
+   * Invoked in a STA or AP to store all of the modes supported
+   * by a destination which is also supported locally.
+   * The set of supported modes includes the BSSBasicRateSet.
+   *
+   * \param address the address of the station being recorded
+   */
+  void AddAllSupportedModes (Mac48Address address);
+  /**
+   * Invoked in a STA or AP to store all of the MCS supported
+   * by a destination which is also supported locally.
+   *
+   * \param address the address of the station being recorded
+   */
+  void AddAllSupportedMcs (Mac48Address address);
+  /**
+   * Invoked in a STA or AP to delete all of the supported MCS by a destination.
+   *
+   * \param address the address of the station being recorded
+   */
+  void RemoveAllSupportedMcs (Mac48Address address);
+  /**
+   * Record whether the short PHY preamble is supported by the station.
+   *
+   * \param address the address of the station
+   * \param isShortPreambleSupported whether or not short PHY preamble is supported by the station
+   */
+  void AddSupportedPhyPreamble (Mac48Address address, bool isShortPreambleSupported);
+  /**
+   * Record whether the short ERP slot time is supported by the station.
+   *
+   * \param address the address of the station
+   * \param isShortSlotTimeSupported whether or not short ERP slot time is supported by the station
+   */
+  void AddSupportedErpSlotTime (Mac48Address address, bool isShortSlotTimeSupported);
+  /**
+   * Return whether the station state is brand new.
+   *
+   * \param address the address of the station
+   *
+   * \return true if the state of the station is brand new,
+   *         false otherwise
+   */
+  bool IsBrandNew (Mac48Address address) const;
+  /**
+   * Return whether the station associated.
+   *
+   * \param address the address of the station
+   *
+   * \return true if the station is associated,
+   *         false otherwise
+   */
+  bool IsAssociated (Mac48Address address) const;
+  /**
+   * Return whether we are waiting for an ACK for
+   * the association response we sent.
+   *
+   * \param address the address of the station
+   *
+   * \return true if the station is associated,
+   *         false otherwise
+   */
+  bool IsWaitAssocTxOk (Mac48Address address) const;
+  /**
+   * Records that we are waiting for an ACK for
+   * the association response we sent.
+   *
+   * \param address the address of the station
+   */
+  void RecordWaitAssocTxOk (Mac48Address address);
+  /**
+   * Records that we got an ACK for
+   * the association response we sent.
+   *
+   * \param address the address of the station
+   */
+  void RecordGotAssocTxOk (Mac48Address address);
+  /**
+   * Records that we missed an ACK for
+   * the association response we sent.
+   *
+   * \param address the address of the station
+   */
+  void RecordGotAssocTxFailed (Mac48Address address);
+  /**
+   * Records that the STA was disassociated.
+   *
+   * \param address the address of the station
+   */
+  void RecordDisassociated (Mac48Address address);
+
+  /**
+   * \param header MAC header
+   *
+   * \return the TXVECTOR to use to send this packet
+   */
+  WifiTxVector GetDataTxVector (const WifiMacHeader &header);
+  /**
+   * \param address remote address
+   *
+   * \return the TXVECTOR to use to send the RTS prior to the
+   *         transmission of the data packet itself.
+   */
+  WifiTxVector GetRtsTxVector (Mac48Address address);
+  /**
+   * Return a TXVECTOR for the CTS frame given the destination and the mode of the RTS
+   * used by the sender.
+   *
+   * \param to the MAC address of the CTS receiver
+   * \param rtsTxMode the mode of the RTS used by the sender
+   * \return TXVECTOR for the CTS
+   */
+  WifiTxVector GetCtsTxVector (Mac48Address to, WifiMode rtsTxMode) const;
+  /**
+   * Since CTS-to-self parameters are not dependent on the station,
+   * it is implemented in wifi remote station manager
+   *
+   * \return the transmission mode to use to send the CTS-to-self prior to the
+   *         transmission of the data packet itself.
+   */
+  WifiTxVector GetCtsToSelfTxVector (void);
+  /**
+   * Return a TXVECTOR for the Ack frame given the destination and the mode of the Data
+   * used by the sender.
+   *
+   * \param to the MAC address of the Ack receiver
+   * \param dataTxVector the TXVECTOR of the Data used by the sender
+   * \return TXVECTOR for the Ack
+   */
+  WifiTxVector GetAckTxVector (Mac48Address to, const WifiTxVector& dataTxVector) const;
+  /**
+   * Return a TXVECTOR for the BlockAck frame given the destination and the mode of the Data
+   * used by the sender.
+   *
+   * \param to the MAC address of the BlockAck receiver
+   * \param dataTxVector the TXVECTOR of the Data used by the sender
+   * \return TXVECTOR for the BlockAck
+   */
+  WifiTxVector GetBlockAckTxVector (Mac48Address to, const WifiTxVector& dataTxVector) const;
+  /**
+   * Get control answer mode function.
+   *
+   * \param reqMode request mode
+   * \return control answer mode
+   */
+  WifiMode GetControlAnswerMode (WifiMode reqMode) const;
+
+  /**
+   * Should be invoked whenever the RtsTimeout associated to a transmission
+   * attempt expires.
+   *
+   * \param header MAC header of the DATA packet
+   */
+  void ReportRtsFailed (const WifiMacHeader& header);
+  /**
+   * Should be invoked whenever the AckTimeout associated to a transmission
+   * attempt expires.
+   *
+   * \param mpdu the MPDU whose transmission failed
+   */
+  void ReportDataFailed (Ptr<const WifiMacQueueItem> mpdu);
+  /**
+   * Should be invoked whenever we receive the CTS associated to an RTS
+   * we just sent. Note that we also get the SNR of the RTS we sent since
+   * the receiver put a SnrTag in the CTS.
+   *
+   * \param header MAC header of the DATA packet
+   * \param ctsSnr the SNR of the CTS we received
+   * \param ctsMode the WifiMode the receiver used to send the CTS
+   * \param rtsSnr the SNR of the RTS we sent
+   */
+  void ReportRtsOk (const WifiMacHeader& header,
+                    double ctsSnr, WifiMode ctsMode, double rtsSnr);
+  /**
+   * Should be invoked whenever we receive the ACK associated to a data packet
+   * we just sent.
+   *
+   * \param mpdu the MPDU
+   * \param ackSnr the SNR of the ACK we received
+   * \param ackMode the WifiMode the receiver used to send the ACK
+   * \param dataSnr the SNR of the DATA we sent
+   * \param dataTxVector the TXVECTOR of the DATA we sent
+   */
+  void ReportDataOk (Ptr<const WifiMacQueueItem> mpdu, double ackSnr,
+                     WifiMode ackMode, double dataSnr, WifiTxVector dataTxVector);
+  /**
+   * Should be invoked after calling ReportRtsFailed if
+   * NeedRetransmission returns false
+   *
+   * \param header MAC header of the DATA packet
+   */
+  void ReportFinalRtsFailed (const WifiMacHeader& header);
+  /**
+   * Should be invoked after calling ReportDataFailed if
+   * NeedRetransmission returns false
+   *
+   * \param mpdu the MPDU which was discarded
+   */
+  void ReportFinalDataFailed (Ptr<const WifiMacQueueItem> mpdu);
+  /**
+   * Typically called per A-MPDU, either when a Block ACK was successfully
+   * received or when a BlockAckTimeout has elapsed.
+   *
+   * \param address the address of the receiver
+   * \param nSuccessfulMpdus number of successfully transmitted MPDUs
+   * A value of 0 means that the Block ACK was missed.
+   * \param nFailedMpdus number of unsuccessfully transmitted MPDUs
+   * \param rxSnr received SNR of the block ack frame itself
+   * \param dataSnr data SNR reported by remote station
+   * \param dataTxVector the TXVECTOR of the MPDUs we sent
+   */
+  void ReportAmpduTxStatus (Mac48Address address, uint16_t nSuccessfulMpdus, uint16_t nFailedMpdus,
+                            double rxSnr, double dataSnr, WifiTxVector dataTxVector);
+
+  /**
+   * \param address remote address
+   * \param rxSignalInfo the info on the received signal (\see RxSignalInfo)
+   * \param txVector the TXVECTOR used for the packet received
+   *
+   * Should be invoked whenever a packet is successfully received.
+   */
+  void ReportRxOk (Mac48Address address, RxSignalInfo rxSignalInfo, WifiTxVector txVector);
+
+  /**
+   * \param header MAC header
+   * \param size the size of the frame to send in bytes
+   *
+   * \return true if we want to use an RTS/CTS handshake for this
+   *         frame before sending it, false otherwise.
+   */
+  bool NeedRts (const WifiMacHeader &header, uint32_t size);
+  /**
+   * Return if we need to do CTS-to-self before sending a DATA.
+   *
+   * \param txVector the TXVECTOR of the packet to be sent
+   *
+   * \return true if CTS-to-self is needed,
+   *         false otherwise
+   */
+  bool NeedCtsToSelf (WifiTxVector txVector);
+
+  /**
+   * \param mpdu the MPDU to send
+   *
+   * \return true if we want to resend a packet after a failed transmission attempt,
+   *         false otherwise.
+   */
+  bool NeedRetransmission (Ptr<const WifiMacQueueItem> mpdu);
+  /**
+   * \param mpdu the MPDU to send
+   *
+   * \return true if this packet should be fragmented,
+   *         false otherwise.
+   */
+  bool NeedFragmentation (Ptr<const WifiMacQueueItem> mpdu);
+  /**
+   * \param mpdu the MPDU to send
+   * \param fragmentNumber the fragment index of the next fragment to send (starts at zero).
+   *
+   * \return the size of the corresponding fragment.
+   */
+  uint32_t GetFragmentSize (Ptr<const WifiMacQueueItem> mpdu, uint32_t fragmentNumber);
+  /**
+   * \param mpdu the packet to send
+   * \param fragmentNumber the fragment index of the next fragment to send (starts at zero).
+   *
+   * \return the offset within the original packet where this fragment starts.
+   */
+  uint32_t GetFragmentOffset (Ptr<const WifiMacQueueItem> mpdu, uint32_t fragmentNumber);
+  /**
+   * \param mpdu the packet to send
+   * \param fragmentNumber the fragment index of the next fragment to send (starts at zero).
+   *
+   * \return true if this is the last fragment, false otherwise.
+   */
+  bool IsLastFragment (Ptr<const WifiMacQueueItem> mpdu, uint32_t fragmentNumber);
+
+  /**
+   * \return the default transmission power
+   */
+  uint8_t GetDefaultTxPowerLevel (void) const;
+  /**
+   * \param address of the remote station
+   *
+   * \return information regarding the remote station associated with the given address
+   */
+  WifiRemoteStationInfo GetInfo (Mac48Address address);
+  /**
+   * \param address of the remote station
+   *
+   * \return the RSSI (in dBm) of the most recent packet received from the remote station (irrespective of TID)
+   *
+   * This method is typically used when the device needs
+   * to estimate the target UL RSSI info to put in the
+   * Trigger frame to send to the remote station.
+   */
+  double GetMostRecentRssi (Mac48Address address) const;
+  /**
+   * Set the default transmission power level
+   *
+   * \param txPower the default transmission power level
+   */
+  void SetDefaultTxPowerLevel (uint8_t txPower);
+  /**
+   * \return the number of antennas supported by the PHY layer
+   */
+  uint8_t GetNumberOfAntennas (void) const;
+  /**
+   * \return the maximum number of spatial streams supported by the PHY layer
+   */
+  uint8_t GetMaxNumberOfTransmitStreams (void) const;
+  /**
+   * \returns whether LDPC should be used for a given destination address.
+   *
+   * \param dest the destination address
+   *
+   * \return whether LDPC should be used for a given destination address
+   */
+  bool UseLdpcForDestination (Mac48Address dest) const;
+
+  /**
+   * TracedCallback signature for power change events.
+   *
+   * \param [in] oldPower The previous power (in dBm).
+   * \param [in] newPower The new power (in dBm).
+   * \param [in] address The remote station MAC address.
+   */
+  typedef void (*PowerChangeTracedCallback)(double oldPower, double newPower, Mac48Address remoteAddress);
+
+  /**
+   * TracedCallback signature for rate change events.
+   *
+   * \param [in] oldRate The previous data rate.
+   * \param [in] newRate The new data rate.
+   * \param [in] address The remote station MAC address.
+   */
+  typedef void (*RateChangeTracedCallback)(DataRate oldRate, DataRate newRate, Mac48Address remoteAddress);
+
+  /**
+   * Return the WifiPhy.
+   *
+   * \return a pointer to the WifiPhy
+   */
+  Ptr<WifiPhy> GetPhy (void) const;
+  /**
+   * Return the WifiMac.
+   *
+   * \return a pointer to the WifiMac
+   */
+  Ptr<WifiMac> GetMac (void) const;
+
+
+protected:
+  virtual void DoDispose (void);
+  /**
+   * Return whether mode associated with the specified station at the specified index.
+   *
+   * \param station the station being queried
+   * \param i the index
+   *
+   * \return WifiMode at the given index of the specified station
+   */
+  WifiMode GetSupported (const WifiRemoteStation *station, uint8_t i) const;
+  /**
+   * Return the number of modes supported by the given station.
+   *
+   * \param station the station being queried
+   *
+   * \return the number of modes supported by the given station
+   */
+  uint8_t GetNSupported (const WifiRemoteStation *station) const;
+  /**
+   * Return whether the given station is QoS capable.
+   *
+   * \param station the station being queried
+   *
+   * \return true if the station has QoS capabilities,
+   *         false otherwise
+   */
+  bool GetQosSupported (const WifiRemoteStation *station) const;
+  /**
+   * Return whether the given station is HT capable.
+   *
+   * \param station the station being queried
+   *
+   * \return true if the station has HT capabilities,
+   *         false otherwise
+   */
+  bool GetHtSupported (const WifiRemoteStation *station) const;
+  /**
+   * Return whether the given station is VHT capable.
+   *
+   * \param station the station being queried
+   *
+   * \return true if the station has VHT capabilities,
+   *         false otherwise
+   */
+  bool GetVhtSupported (const WifiRemoteStation *station) const;
+  /**
+   * Return whether the given station is HE capable.
+   *
+   * \param station the station being queried
+   *
+   * \return true if the station has HE capabilities,
+   *         false otherwise
+   */
+  bool GetHeSupported (const WifiRemoteStation *station) const;
+  /**
+   * Return the WifiMode supported by the specified station at the specified index.
+   *
+   * \param station the station being queried
+   * \param i the index
+   *
+   * \return the WifiMode at the given index of the specified station
+   */
+
+  WifiMode GetMcsSupported (const WifiRemoteStation *station, uint8_t i) const;
+  /**
+   * Return the number of MCS supported by the given station.
+   *
+   * \param station the station being queried
+   *
+   * \return the number of MCS supported by the given station
+   */
+  uint8_t GetNMcsSupported (const WifiRemoteStation *station) const;
+  /**
+   * Return whether non-ERP mode associated with the specified station at the specified index.
+   *
+   * \param station the station being queried
+   * \param i the index
+   *
+   * \return WifiMode at the given index of the specified station
+   */
+  WifiMode GetNonErpSupported (const WifiRemoteStation *station, uint8_t i) const;
+  /**
+   * Return the number of non-ERP modes supported by the given station.
+   *
+   * \param station the station being queried
+   *
+   * \return the number of non-ERP modes supported by the given station
+   */
+  uint32_t GetNNonErpSupported (const WifiRemoteStation *station) const;
+  /**
+   * Return the address of the station.
+   *
+   * \param station the station being queried
+   *
+   * \return the address of the station
+   */
+  Mac48Address GetAddress (const WifiRemoteStation *station) const;
+  /**
+   * Return the channel width supported by the station.
+   *
+   * \param station the station being queried
+   *
+   * \return the channel width (in MHz) supported by the station
+   */
+  uint16_t GetChannelWidth (const WifiRemoteStation *station) const;
+  /**
+   * Return whether the given station supports HT/VHT short guard interval.
+   *
+   * \param station the station being queried
+   *
+   * \return true if the station supports HT/VHT short guard interval,
+   *         false otherwise
+   */
+  bool GetShortGuardIntervalSupported (const WifiRemoteStation *station) const;
+  /**
+   * Return the HE guard interval duration supported by the station.
+   *
+   * \param station the station being queried
+   *
+   * \return the HE guard interval duration (in nanoseconds) supported by the station
+   */
+  uint16_t GetGuardInterval (const WifiRemoteStation *station) const;
+  /**
+   * Return whether the given station supports A-MPDU.
+   *
+   * \param station the station being queried
+   *
+   * \return true if the station supports MPDU aggregation,
+   *         false otherwise
+   */
+  bool GetAggregation (const WifiRemoteStation *station) const;
+
+  /**
+   * Return the number of supported streams the station has.
+   *
+   * \param station the station being queried
+   *
+   * \return the number of supported streams the station has
+   */
+  uint8_t GetNumberOfSupportedStreams (const WifiRemoteStation *station) const;
+  /**
+   * \returns the number of Ness the station has.
+   *
+   * \param station the station being queried
+   *
+   * \return the number of Ness the station has
+   */
+  uint8_t GetNess (const WifiRemoteStation *station) const;
+
+
+private:
+  /**
+   * If the given TXVECTOR is used for a MU transmission, return the STAID of
+   * the station with the given address if we are an AP or our own STAID if we
+   * are a STA associated with some AP. Otherwise, return SU_STA_ID.
+   *
+   * \param address the address of the station
+   * \param txVector the TXVECTOR used for a MU transmission
+   * \return the STA-ID of the station
+   */
+  uint16_t GetStaId (Mac48Address address, const WifiTxVector& txVector) const;
+
+  /**
+   * Apply configured 802.11bd NGV metadata to a data TXVECTOR.
+   *
+   * \param txVector the TXVECTOR to update
+   */
+  void ApplyNgvTxVectorParameters (WifiTxVector& txVector) const;
+
+  /**
+   * \param station the station that we need to communicate
+   * \param size the size of the frame to send in bytes
+   * \param normally indicates whether the normal 802.11 RTS enable mechanism would
+   *        request that the RTS is sent or not.
+   *
+   * \return true if we want to use an RTS/CTS handshake for this frame before sending it,
+   *         false otherwise.
+   *
+   * Note: This method is called before a unicast packet is sent on the medium.
+   */
+  virtual bool DoNeedRts (WifiRemoteStation *station,
+                          uint32_t size, bool normally);
+  /**
+   * \param station the station that we need to communicate
+   * \param packet the packet to send
+   * \param normally indicates whether the normal 802.11 data retransmission mechanism
+   *        would request that the data is retransmitted or not.
+   * \return true if we want to resend a packet after a failed transmission attempt,
+   *         false otherwise.
+   *
+   * Note: This method is called after any unicast packet transmission (control, management,
+   *       or data) has been attempted and has failed.
+   */
+  virtual bool DoNeedRetransmission (WifiRemoteStation *station,
+                                     Ptr<const Packet> packet, bool normally);
+  /**
+   * \param station the station that we need to communicate
+   * \param packet the packet to send
+   * \param normally indicates whether the normal 802.11 data fragmentation mechanism
+   *        would request that the data packet is fragmented or not.
+   *
+   * \return true if this packet should be fragmented,
+   *         false otherwise.
+   *
+   * Note: This method is called before sending a unicast packet.
+   */
+  virtual bool DoNeedFragmentation (WifiRemoteStation *station,
+                                    Ptr<const Packet> packet, bool normally);
+  /**
+   * \return a new station data structure
+   */
+  virtual WifiRemoteStation* DoCreateStation (void) const = 0;
+  /**
+    * \param station the station that we need to communicate
+    *
+    * \return the TXVECTOR to use to send a packet to the station
+    *
+    * Note: This method is called before sending a unicast packet or a fragment
+    *       of a unicast packet to decide which transmission mode to use.
+    */
+  virtual WifiTxVector DoGetDataTxVector (WifiRemoteStation *station) = 0;
+  /**
+   * \param station the station that we need to communicate
+   *
+   * \return the transmission mode to use to send an RTS to the station
+   *
+   * Note: This method is called before sending an RTS to a station
+   *       to decide which transmission mode to use for the RTS.
+   */
+  virtual WifiTxVector DoGetRtsTxVector (WifiRemoteStation *station) = 0;
+
+  /**
+   * This method is a pure virtual method that must be implemented by the sub-class.
+   * This allows different types of WifiRemoteStationManager to respond differently,
+   *
+   * \param station the station that we failed to send RTS
+   */
+  virtual void DoReportRtsFailed (WifiRemoteStation *station) = 0;
+  /**
+   * This method is a pure virtual method that must be implemented by the sub-class.
+   * This allows different types of WifiRemoteStationManager to respond differently,
+   *
+   * \param station the station that we failed to send DATA
+   */
+  virtual void DoReportDataFailed (WifiRemoteStation *station) = 0;
+  /**
+   * This method is a pure virtual method that must be implemented by the sub-class.
+   * This allows different types of WifiRemoteStationManager to respond differently,
+   *
+   * \param station the station that we successfully sent RTS
+   * \param ctsSnr the SNR of the CTS we received
+   * \param ctsMode the WifiMode the receiver used to send the CTS
+   * \param rtsSnr the SNR of the RTS we sent
+   */
+  virtual void DoReportRtsOk (WifiRemoteStation *station,
+                              double ctsSnr, WifiMode ctsMode, double rtsSnr) = 0;
+  /**
+   * This method is a pure virtual method that must be implemented by the sub-class.
+   * This allows different types of WifiRemoteStationManager to respond differently,
+   *
+   * \param station the station that we successfully sent RTS
+   * \param ackSnr the SNR of the ACK we received
+   * \param ackMode the WifiMode the receiver used to send the ACK
+   * \param dataSnr the SNR of the DATA we sent
+   * \param dataChannelWidth the channel width (in MHz) of the DATA we sent
+   * \param dataNss the number of spatial streams used to send the DATA
+   */
+  virtual void DoReportDataOk (WifiRemoteStation *station, double ackSnr, WifiMode ackMode,
+                               double dataSnr, uint16_t dataChannelWidth, uint8_t dataNss) = 0;
+  /**
+   * This method is a pure virtual method that must be implemented by the sub-class.
+   * This allows different types of WifiRemoteStationManager to respond differently,
+   *
+   * \param station the station that we failed to send RTS
+   */
+  virtual void DoReportFinalRtsFailed (WifiRemoteStation *station) = 0;
+  /**
+   * This method is a pure virtual method that must be implemented by the sub-class.
+   * This allows different types of WifiRemoteStationManager to respond differently,
+   *
+   * \param station the station that we failed to send DATA
+   */
+  virtual void DoReportFinalDataFailed (WifiRemoteStation *station) = 0;
+  /**
+   * This method is a pure virtual method that must be implemented by the sub-class.
+   * This allows different types of WifiRemoteStationManager to respond differently,
+   *
+   * \param station the station that sent the DATA to us
+   * \param rxSnr the SNR of the DATA we received
+   * \param txMode the WifiMode the sender used to send the DATA
+   */
+  virtual void DoReportRxOk (WifiRemoteStation *station,
+                             double rxSnr, WifiMode txMode) = 0;
+  /**
+   * Typically called per A-MPDU, either when a Block ACK was successfully received
+   * or when a BlockAckTimeout has elapsed. This method is a virtual method that must
+   * be implemented by the sub-class intended to handle A-MPDUs. This allows different
+   * types of WifiRemoteStationManager to respond differently.
+   *
+   * \param station the station that sent the DATA to us
+   * \param nSuccessfulMpdus number of successfully transmitted MPDUs.
+   *        A value of 0 means that the Block ACK was missed.
+   * \param nFailedMpdus number of unsuccessfully transmitted MPDUs.
+   * \param rxSnr received SNR of the block ack frame itself
+   * \param dataSnr data SNR reported by remote station
+   * \param dataChannelWidth the channel width (in MHz) of the A-MPDU we sent
+   * \param dataNss the number of spatial streams used to send the A-MPDU
+   */
+  virtual void DoReportAmpduTxStatus (WifiRemoteStation *station, uint16_t nSuccessfulMpdus, uint16_t nFailedMpdus,
+                                      double rxSnr, double dataSnr, uint16_t dataChannelWidth, uint8_t dataNss);
+
+  /**
+   * Return the state of the station associated with the given address.
+   *
+   * \param address the address of the station
+   * \return WifiRemoteStationState corresponding to the address
+   */
+  WifiRemoteStationState* LookupState (Mac48Address address) const;
+  /**
+   * Return the station associated with the given address.
+   *
+   * \param address the address of the station
+   *
+   * \return WifiRemoteStation corresponding to the address
+   */
+  WifiRemoteStation* Lookup (Mac48Address address) const;
+
+  /**
+   * Actually sets the fragmentation threshold, it also checks the validity of
+   * the given threshold.
+   *
+   * \param threshold the fragmentation threshold
+   */
+  void DoSetFragmentationThreshold (uint32_t threshold);
+  /**
+   * Return the current fragmentation threshold
+   *
+   * \return the fragmentation threshold
+   */
+  uint32_t DoGetFragmentationThreshold (void) const;
+  /**
+   * Return the number of fragments needed for the given packet.
+   *
+   * \param mpdu the packet to be fragmented
+   *
+   * \return the number of fragments needed
+   */
+  uint32_t GetNFragments (Ptr<const WifiMacQueueItem> mpdu);
+
+  /**
+   * This is a pointer to the WifiPhy associated with this
+   * WifiRemoteStationManager that is set on call to
+   * WifiRemoteStationManager::SetupPhy(). Through this pointer the
+   * station manager can determine PHY characteristics, such as the
+   * set of all transmission rates that may be supported (the
+   * "DeviceRateSet").
+   */
+  Ptr<WifiPhy> m_wifiPhy;
+  /**
+   * This is a pointer to the WifiMac associated with this
+   * WifiRemoteStationManager that is set on call to
+   * WifiRemoteStationManager::SetupMac(). Through this pointer the
+   * station manager can determine MAC characteristics, such as the
+   * interframe spaces.
+   */
+  Ptr<WifiMac> m_wifiMac;
+
+  /**
+   * This member is the list of WifiMode objects that comprise the
+   * BSSBasicRateSet parameter. This list is constructed through calls
+   * to WifiRemoteStationManager::AddBasicMode(), and an API that
+   * allows external access to it is available through
+   * WifiRemoteStationManager::GetNBasicModes() and
+   * WifiRemoteStationManager::GetBasicMode().
+   */
+  WifiModeList m_bssBasicRateSet; //!< basic rate set
+  WifiModeList m_bssBasicMcsSet;  //!< basic MCS set
+
+  StationStates m_states;  //!< States of known stations
+  Stations m_stations;     //!< Information for each known stations
+
+  WifiMode m_defaultTxMode; //!< The default transmission mode
+  WifiMode m_defaultTxMcs;  //!< The default transmission modulation-coding scheme (MCS)
+
+  uint32_t m_maxSsrc;  //!< Maximum STA short retry count (SSRC)
+  uint32_t m_maxSlrc;  //!< Maximum STA long retry count (SLRC)
+  uint32_t m_rtsCtsThreshold;             //!< Threshold for RTS/CTS
+  uint32_t m_fragmentationThreshold;      //!< Current threshold for fragmentation
+  uint8_t m_defaultTxPowerLevel;          //!< Default transmission power level
+  WifiMode m_nonUnicastMode;      //!< Transmission mode for non-unicast Data frames
+  uint8_t m_ngvPpduFormat;        //!< 802.11bd PPDU format for Data frames
+  uint8_t m_ngvMcs;               //!< 802.11bd NGV-MCS index for Data frames
+  uint8_t m_ngvSpatialStreams;    //!< 802.11bd NGV spatial stream count
+  uint16_t m_ngvMidamblePeriodicity; //!< 802.11bd NGV midamble periodicity
+  uint8_t m_ngvLtfType;           //!< 802.11bd NGV-LTF type
+  uint8_t m_ngvPpduRepetitions;   //!< 802.11bd N_PPDU_REP value
+  bool m_useNonErpProtection;     //!< flag if protection for non-ERP stations against ERP transmissions is enabled
+  bool m_useNonHtProtection;      //!< flag if protection for non-HT stations against HT transmissions is enabled
+  bool m_shortPreambleEnabled;    //!< flag if short PHY preamble is enabled
+  bool m_shortSlotTimeEnabled;    //!< flag if short slot time is enabled
+  ProtectionMode m_erpProtectionMode; //!< Protection mode for ERP stations when non-ERP stations are detected
+  ProtectionMode m_htProtectionMode;  //!< Protection mode for HT stations when non-HT stations are detected
+
+  std::array<uint32_t, AC_BE_NQOS> m_ssrc; //!< short retry count per AC
+  std::array<uint32_t, AC_BE_NQOS> m_slrc; //!< long retry count per AC
+
+  /**
+   * The trace source fired when the transmission of a single RTS has failed
+   */
+  TracedCallback<Mac48Address> m_macTxRtsFailed;
+  /**
+   * The trace source fired when the transmission of a single data packet has failed
+   */
+  TracedCallback<Mac48Address> m_macTxDataFailed;
+  /**
+   * The trace source fired when the transmission of a RTS has
+   * exceeded the maximum number of attempts
+   */
+  TracedCallback<Mac48Address> m_macTxFinalRtsFailed;
+  /**
+   * The trace source fired when the transmission of a data packet has
+   * exceeded the maximum number of attempts
+   */
+  TracedCallback<Mac48Address> m_macTxFinalDataFailed;
+};
+
+} //namespace ns3
+
+#endif /* WIFI_REMOTE_STATION_MANAGER_H */

--- a/src/automotive/model/SignalInfo/WiFi/wifi-standards.h
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-standards.h
@@ -1,0 +1,205 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2007 INRIA
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage <mathieu.lacage@sophia.inria.fr>
+ */
+
+#ifndef WIFI_STANDARD_H
+#define WIFI_STANDARD_H
+
+#include <map>
+#include <list>
+#include "wifi-phy-band.h"
+#include "ns3/abort.h"
+
+namespace ns3 {
+
+/**
+ * \ingroup wifi
+ * Identifies the IEEE 802.11 specifications that a Wifi device can be configured to use.
+ */
+enum WifiStandard
+{
+  WIFI_STANDARD_UNSPECIFIED,
+  WIFI_STANDARD_80211a,
+  WIFI_STANDARD_80211b,
+  WIFI_STANDARD_80211g,
+  WIFI_STANDARD_80211p,
+  WIFI_STANDARD_80211bd,
+  WIFI_STANDARD_80211n,
+  WIFI_STANDARD_80211ac,
+  WIFI_STANDARD_80211ax
+};
+
+/**
+* \brief Stream insertion operator.
+*
+* \param os the stream
+* \param standard the standard
+* \returns a reference to the stream
+*/
+inline std::ostream& operator<< (std::ostream& os, WifiStandard standard)
+{
+  switch (standard)
+    {
+    case WIFI_STANDARD_80211a:
+      return (os << "802.11a");
+    case WIFI_STANDARD_80211b:
+      return (os << "802.11b");
+    case WIFI_STANDARD_80211g:
+      return (os << "802.11g");
+    case WIFI_STANDARD_80211p:
+      return (os << "802.11p");
+    case WIFI_STANDARD_80211bd:
+      return (os << "802.11bd");
+    case WIFI_STANDARD_80211n:
+      return (os << "802.11n");
+    case WIFI_STANDARD_80211ac:
+      return (os << "802.11ac");
+    case WIFI_STANDARD_80211ax:
+      return (os << "802.11ax");
+    default:
+      return (os << "UNSPECIFIED");
+    }
+}
+
+
+/**
+ * \brief map a given standard configured by the user to the allowed PHY bands
+ */
+const std::map<WifiStandard, std::list<WifiPhyBand>> wifiStandards =
+{
+  { WIFI_STANDARD_80211a, { WIFI_PHY_BAND_5GHZ } },
+  { WIFI_STANDARD_80211b, { WIFI_PHY_BAND_2_4GHZ } },
+  { WIFI_STANDARD_80211g, { WIFI_PHY_BAND_2_4GHZ } },
+  { WIFI_STANDARD_80211p, { WIFI_PHY_BAND_5GHZ } },
+  { WIFI_STANDARD_80211bd, { WIFI_PHY_BAND_5GHZ } },
+  { WIFI_STANDARD_80211n, { WIFI_PHY_BAND_2_4GHZ, WIFI_PHY_BAND_5GHZ } },
+  { WIFI_STANDARD_80211ac, { WIFI_PHY_BAND_5GHZ } },
+  { WIFI_STANDARD_80211ax, { WIFI_PHY_BAND_2_4GHZ, WIFI_PHY_BAND_5GHZ, WIFI_PHY_BAND_6GHZ } }
+};
+
+/**
+ * \ingroup wifi
+ * \brief Enumeration of frequency channel types
+ */
+enum FrequencyChannelType : uint8_t
+{
+  WIFI_PHY_DSSS_CHANNEL = 0,
+  WIFI_PHY_OFDM_CHANNEL,
+  WIFI_PHY_80211p_CHANNEL
+};
+
+/**
+ * Get the type of the frequency channel for the given standard
+ *
+ * \param standard the standard
+ * \return the type of the frequency channel for the given standard
+ */
+inline FrequencyChannelType GetFrequencyChannelType (WifiStandard standard)
+{
+  switch (standard)
+    {
+      case WIFI_STANDARD_80211b:
+        return WIFI_PHY_DSSS_CHANNEL;
+      case WIFI_STANDARD_80211p:
+      case WIFI_STANDARD_80211bd:
+        return WIFI_PHY_80211p_CHANNEL;
+      default:
+        return WIFI_PHY_OFDM_CHANNEL;
+    }
+}
+
+/**
+ * Get the maximum channel width in MHz allowed for the given standard.
+ *
+ * \param standard the standard
+ * \return the maximum channel width in MHz allowed for the given standard
+ */
+inline uint16_t GetMaximumChannelWidth (WifiStandard standard)
+{
+  switch (standard)
+    {
+      case WIFI_STANDARD_80211b:
+        return 22;
+      case WIFI_STANDARD_80211p:
+        return 10;
+      case WIFI_STANDARD_80211bd:
+        return 20;
+      case WIFI_STANDARD_80211a:
+      case WIFI_STANDARD_80211g:
+        return 20;
+      case WIFI_STANDARD_80211n:
+        return 40;
+      case WIFI_STANDARD_80211ac:
+      case WIFI_STANDARD_80211ax:
+        return 160;
+      default:
+        NS_ABORT_MSG ("Unknown standard: " << standard);
+        return 0;
+    }
+}
+
+/**
+ * Get the default channel width for the given PHY standard and band.
+ *
+ * \param standard the given standard
+ * \param band the given PHY band
+ * \return the default channel width (MHz) for the given standard
+ */
+inline uint16_t GetDefaultChannelWidth (WifiStandard standard, WifiPhyBand band)
+{
+  switch (standard)
+    {
+    case WIFI_STANDARD_80211b:
+      return 22;
+    case WIFI_STANDARD_80211p:
+    case WIFI_STANDARD_80211bd:
+      return 10;
+    case WIFI_STANDARD_80211ac:
+      return 80;
+    case WIFI_STANDARD_80211ax:
+      return (band == WIFI_PHY_BAND_2_4GHZ ? 20 : 80);
+    default:
+      return 20;
+    }
+}
+
+/**
+ * Get the default PHY band for the given standard.
+ *
+ * \param standard the given standard
+ * \return the default PHY band for the given standard
+ */
+inline WifiPhyBand GetDefaultPhyBand (WifiStandard standard)
+{
+  switch (standard)
+    {
+    case WIFI_STANDARD_80211p:
+    case WIFI_STANDARD_80211bd:
+    case WIFI_STANDARD_80211a:
+    case WIFI_STANDARD_80211ac:
+    case WIFI_STANDARD_80211ax:
+      return WIFI_PHY_BAND_5GHZ;
+    default:
+      return WIFI_PHY_BAND_2_4GHZ;
+    }
+}
+
+} //namespace ns3
+
+#endif /* WIFI_STANDARD_H */

--- a/src/automotive/model/SignalInfo/WiFi/wifi-tx-vector.cc
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-tx-vector.cc
@@ -1,0 +1,742 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2010 CTTC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Nicola Baldo <nbaldo@cttc.es>
+ *          Ghada Badawy <gbadawy@gmail.com>
+ */
+
+#include "wifi-tx-vector.h"
+#include "wifi-phy-common.h"
+#include "ns3/abort.h"
+
+namespace ns3 {
+
+namespace {
+
+bool
+IsNgvMcsIndexValid (uint8_t mcs, uint16_t channelWidth, uint8_t nss)
+{
+  if (nss == 1)
+    {
+      if (channelWidth == 10)
+        {
+          return mcs <= 8 || mcs == 15;
+        }
+      if (channelWidth == 20)
+        {
+          return mcs <= 9 || mcs == 15;
+        }
+    }
+  else if (nss == 2)
+    {
+      if (channelWidth == 10)
+        {
+          return mcs <= 8;
+        }
+      if (channelWidth == 20)
+        {
+          return mcs <= 9;
+        }
+    }
+  return false;
+}
+
+const char*
+WifiNgvPpduFormatToString (WifiNgvPpduFormat format)
+{
+  switch (format)
+    {
+    case WifiNgvPpduFormat::NON_NGV_10:
+      return "NON_NGV_10";
+    case WifiNgvPpduFormat::NON_NGV_20_DUPLICATE:
+      return "NON_NGV_20_DUPLICATE";
+    case WifiNgvPpduFormat::NGV:
+      return "NGV";
+    default:
+      return "UNKNOWN";
+    }
+}
+
+const char*
+WifiNgvLtfTypeToString (WifiNgvLtfType type)
+{
+  switch (type)
+    {
+    case WifiNgvLtfType::NGV_LTF_1X:
+      return "NGV_LTF_1X";
+    case WifiNgvLtfType::NGV_LTF_2X:
+      return "NGV_LTF_2X";
+    case WifiNgvLtfType::NGV_LTF_2X_REPEAT:
+      return "NGV_LTF_2X_REPEAT";
+    default:
+      return "UNKNOWN";
+    }
+}
+
+} // namespace
+
+WifiTxVector::WifiTxVector ()
+  : m_preamble (WIFI_PREAMBLE_LONG),
+    m_channelWidth (20),
+    m_guardInterval (800),
+    m_nTx (1),
+    m_nss (1),
+    m_ness (0),
+    m_aggregation (false),
+    m_stbc (false),
+    m_ldpc (false),
+    m_bssColor (0),
+    m_length (0),
+    m_ngvPpduFormat (WifiNgvPpduFormat::NON_NGV_10),
+    m_ngvMcs (0),
+    m_ngvMidamblePeriodicity (0),
+    m_ngvLtfType (WifiNgvLtfType::NGV_LTF_2X),
+    m_ngvPpduRepetitions (0),
+    m_modeInitialized (false)
+{
+}
+
+WifiTxVector::WifiTxVector (WifiMode mode,
+                            uint8_t powerLevel,
+                            WifiPreamble preamble,
+                            uint16_t guardInterval,
+                            uint8_t nTx,
+                            uint8_t nss,
+                            uint8_t ness,
+                            uint16_t channelWidth,
+                            bool aggregation,
+                            bool stbc,
+                            bool ldpc,
+                            uint8_t bssColor,
+                            uint16_t length)
+  : m_mode (mode),
+    m_txPowerLevel (powerLevel),
+    m_preamble (preamble),
+    m_channelWidth (channelWidth),
+    m_guardInterval (guardInterval),
+    m_nTx (nTx),
+    m_nss (nss),
+    m_ness (ness),
+    m_aggregation (aggregation),
+    m_stbc (stbc),
+    m_ldpc (ldpc),
+    m_bssColor (bssColor),
+    m_length (length),
+    m_ngvPpduFormat (WifiNgvPpduFormat::NON_NGV_10),
+    m_ngvMcs (0),
+    m_ngvMidamblePeriodicity (0),
+    m_ngvLtfType (WifiNgvLtfType::NGV_LTF_2X),
+    m_ngvPpduRepetitions (0),
+    m_modeInitialized (true)
+{
+}
+
+WifiTxVector::WifiTxVector (const WifiTxVector& txVector)
+  : m_mode (txVector.m_mode),
+    m_txPowerLevel (txVector.m_txPowerLevel),
+    m_preamble (txVector.m_preamble),
+    m_channelWidth (txVector.m_channelWidth),
+    m_guardInterval (txVector.m_guardInterval),
+    m_nTx (txVector.m_nTx),
+    m_nss (txVector.m_nss),
+    m_ness (txVector.m_ness),
+    m_aggregation (txVector.m_aggregation),
+    m_stbc (txVector.m_stbc),
+    m_ldpc (txVector.m_ldpc),
+    m_bssColor (txVector.m_bssColor),
+    m_length (txVector.m_length),
+    m_ngvPpduFormat (txVector.m_ngvPpduFormat),
+    m_ngvMcs (txVector.m_ngvMcs),
+    m_ngvMidamblePeriodicity (txVector.m_ngvMidamblePeriodicity),
+    m_ngvLtfType (txVector.m_ngvLtfType),
+    m_ngvPpduRepetitions (txVector.m_ngvPpduRepetitions),
+    m_modeInitialized (txVector.m_modeInitialized)
+{
+  m_muUserInfos.clear ();
+  if (!txVector.m_muUserInfos.empty ()) //avoids crashing for loop
+    {
+      for (auto & info : txVector.m_muUserInfos)
+        {
+          m_muUserInfos.insert (std::make_pair (info.first, info.second));
+        }
+    }
+}
+
+WifiTxVector::~WifiTxVector ()
+{
+  m_muUserInfos.clear ();
+}
+
+bool
+WifiTxVector::GetModeInitialized (void) const
+{
+  return m_modeInitialized;
+}
+
+WifiMode
+WifiTxVector::GetMode (uint16_t staId) const
+{
+  if (!m_modeInitialized)
+    {
+      NS_FATAL_ERROR ("WifiTxVector mode must be set before using");
+    }
+  if (IsMu ())
+    {
+      NS_ABORT_MSG_IF (staId > 2048, "STA-ID should be correctly set for MU (" << staId << ")");
+      NS_ASSERT (m_muUserInfos.find (staId) != m_muUserInfos.end ());
+      return m_muUserInfos.at (staId).mcs;
+    }
+  return m_mode;
+}
+
+WifiModulationClass
+WifiTxVector::GetModulationClass (void) const
+{
+  NS_ABORT_MSG_IF (!m_modeInitialized, "WifiTxVector mode must be set before using");
+
+  if (IsMu ())
+    {
+      NS_ASSERT (!m_muUserInfos.empty ());
+      // all the modes belong to the same modulation class
+      return m_muUserInfos.begin ()->second.mcs.GetModulationClass ();
+    }
+  if (IsNgv ())
+    {
+      return WIFI_MOD_CLASS_NGV;
+    }
+  return m_mode.GetModulationClass ();
+}
+
+uint8_t
+WifiTxVector::GetTxPowerLevel (void) const
+{
+  return m_txPowerLevel;
+}
+
+WifiPreamble
+WifiTxVector::GetPreambleType (void) const
+{
+  return m_preamble;
+}
+
+uint16_t
+WifiTxVector::GetChannelWidth (void) const
+{
+  return m_channelWidth;
+}
+
+uint16_t
+WifiTxVector::GetGuardInterval (void) const
+{
+  return m_guardInterval;
+}
+
+uint8_t
+WifiTxVector::GetNTx (void) const
+{
+  return m_nTx;
+}
+
+uint8_t
+WifiTxVector::GetNss (uint16_t staId) const
+{
+  if (IsMu ())
+    {
+      NS_ABORT_MSG_IF (staId > 2048, "STA-ID should be correctly set for MU (" << staId << ")");
+      NS_ASSERT (m_muUserInfos.find (staId) != m_muUserInfos.end ());
+      return m_muUserInfos.at (staId).nss;
+    }
+  return m_nss;
+}
+
+uint8_t
+WifiTxVector::GetNssMax (void) const
+{
+  uint8_t nss = 0;
+  if (IsMu ())
+    {
+      for (const auto & info : m_muUserInfos)
+        {
+          nss = (nss < info.second.nss) ? info.second.nss : nss;
+        }
+    }
+  else
+    {
+      nss = m_nss;
+    }
+  return nss;
+}
+
+uint8_t
+WifiTxVector::GetNess (void) const
+{
+  return m_ness;
+}
+
+bool
+WifiTxVector::IsAggregation (void) const
+{
+  return m_aggregation;
+}
+
+bool
+WifiTxVector::IsStbc (void) const
+{
+  return m_stbc;
+}
+
+bool
+WifiTxVector::IsLdpc (void) const
+{
+  return m_ldpc;
+}
+
+void
+WifiTxVector::SetMode (WifiMode mode)
+{
+  m_mode = mode;
+  m_modeInitialized = true;
+}
+
+void
+WifiTxVector::SetMode (WifiMode mode, uint16_t staId)
+{
+  NS_ABORT_MSG_IF (!IsMu (), "Not a MU transmission");
+  NS_ABORT_MSG_IF (staId > 2048, "STA-ID should be correctly set for MU");
+  m_muUserInfos[staId].mcs = mode;
+  m_modeInitialized = true;
+}
+
+void
+WifiTxVector::SetTxPowerLevel (uint8_t powerlevel)
+{
+  m_txPowerLevel = powerlevel;
+}
+
+void
+WifiTxVector::SetPreambleType (WifiPreamble preamble)
+{
+  m_preamble = preamble;
+}
+
+void
+WifiTxVector::SetChannelWidth (uint16_t channelWidth)
+{
+  m_channelWidth = channelWidth;
+}
+
+void
+WifiTxVector::SetGuardInterval (uint16_t guardInterval)
+{
+  m_guardInterval = guardInterval;
+}
+
+void
+WifiTxVector::SetNTx (uint8_t nTx)
+{
+  m_nTx = nTx;
+}
+
+void
+WifiTxVector::SetNss (uint8_t nss)
+{
+  m_nss = nss;
+}
+
+void
+WifiTxVector::SetNss (uint8_t nss, uint16_t staId)
+{
+  NS_ABORT_MSG_IF (!IsMu (), "Not a MU transmission");
+  NS_ABORT_MSG_IF (staId > 2048, "STA-ID should be correctly set for MU");
+  m_muUserInfos[staId].nss = nss;
+}
+
+void
+WifiTxVector::SetNess (uint8_t ness)
+{
+  m_ness = ness;
+}
+
+void
+WifiTxVector::SetAggregation (bool aggregation)
+{
+  m_aggregation = aggregation;
+}
+
+void
+WifiTxVector::SetStbc (bool stbc)
+{
+  m_stbc = stbc;
+}
+
+void
+WifiTxVector::SetLdpc (bool ldpc)
+{
+  m_ldpc = ldpc;
+}
+
+void
+WifiTxVector::SetBssColor (uint8_t color)
+{
+  m_bssColor = color;
+}
+
+uint8_t
+WifiTxVector::GetBssColor (void) const
+{
+  return m_bssColor;
+}
+
+void
+WifiTxVector::SetLength (uint16_t length)
+{
+  m_length = length;
+}
+
+uint16_t
+WifiTxVector::GetLength (void) const
+{
+  return m_length;
+}
+
+void
+WifiTxVector::SetNgvPpduFormat (WifiNgvPpduFormat format)
+{
+  m_ngvPpduFormat = format;
+}
+
+WifiNgvPpduFormat
+WifiTxVector::GetNgvPpduFormat (void) const
+{
+  return m_ngvPpduFormat;
+}
+
+bool
+WifiTxVector::IsNgv (void) const
+{
+  return m_ngvPpduFormat == WifiNgvPpduFormat::NGV;
+}
+
+bool
+WifiTxVector::IsNonNgv10 (void) const
+{
+  return m_ngvPpduFormat == WifiNgvPpduFormat::NON_NGV_10;
+}
+
+bool
+WifiTxVector::IsNonNgv20Duplicate (void) const
+{
+  return m_ngvPpduFormat == WifiNgvPpduFormat::NON_NGV_20_DUPLICATE;
+}
+
+void
+WifiTxVector::SetNgvMcs (uint8_t mcs)
+{
+  m_ngvMcs = mcs;
+}
+
+uint8_t
+WifiTxVector::GetNgvMcs (void) const
+{
+  return m_ngvMcs;
+}
+
+void
+WifiTxVector::SetNgvMidamblePeriodicity (uint16_t periodicity)
+{
+  m_ngvMidamblePeriodicity = periodicity;
+}
+
+uint16_t
+WifiTxVector::GetNgvMidamblePeriodicity (void) const
+{
+  return m_ngvMidamblePeriodicity;
+}
+
+void
+WifiTxVector::SetNgvLtfType (WifiNgvLtfType type)
+{
+  m_ngvLtfType = type;
+}
+
+WifiNgvLtfType
+WifiTxVector::GetNgvLtfType (void) const
+{
+  return m_ngvLtfType;
+}
+
+void
+WifiTxVector::SetNgvPpduRepetitions (uint8_t repetitions)
+{
+  m_ngvPpduRepetitions = repetitions;
+}
+
+uint8_t
+WifiTxVector::GetNgvPpduRepetitions (void) const
+{
+  return m_ngvPpduRepetitions;
+}
+
+bool
+WifiTxVector::IsValid (void) const
+{
+  if (!GetModeInitialized ())
+    {
+      return false;
+    }
+  if (IsNgv ())
+    {
+      if (!IsNgvMcsIndexValid (m_ngvMcs, m_channelWidth, m_nss))
+        {
+          return false;
+        }
+      if ((m_channelWidth == 10 && m_nss == 1 && m_ngvMcs == 15 &&
+           m_ngvLtfType != WifiNgvLtfType::NGV_LTF_2X_REPEAT) ||
+          ((m_channelWidth != 10 || m_nss != 1 || m_ngvMcs != 15) &&
+           m_ngvLtfType == WifiNgvLtfType::NGV_LTF_2X_REPEAT))
+        {
+          return false;
+        }
+    }
+  std::string modeName = m_mode.GetUniqueName ();
+  if (m_channelWidth == 20)
+    {
+      if (m_nss != 3 && m_nss != 6)
+        {
+          return (modeName != "VhtMcs9");
+        }
+    }
+  else if (m_channelWidth == 80)
+    {
+      if (m_nss == 3 || m_nss == 7)
+        {
+          return (modeName != "VhtMcs6");
+        }
+      else if (m_nss == 6)
+        {
+          return (modeName != "VhtMcs9");
+        }
+    }
+  else if (m_channelWidth == 160)
+    {
+      if (m_nss == 3)
+        {
+          return (modeName != "VhtMcs9");
+        }
+    }
+  return true;
+}
+
+bool
+WifiTxVector::IsMu (void) const
+{
+  return ns3::IsMu (m_preamble);
+}
+
+bool
+WifiTxVector::IsDlMu (void) const
+{
+  return ns3::IsDlMu (m_preamble);
+}
+
+bool
+WifiTxVector::IsUlMu (void) const
+{
+  return ns3::IsUlMu (m_preamble);
+}
+
+HeRu::RuSpec
+WifiTxVector::GetRu (uint16_t staId) const
+{
+  NS_ABORT_MSG_IF (!IsMu (), "RU only available for MU");
+  NS_ABORT_MSG_IF (staId > 2048, "STA-ID should be correctly set for MU");
+  return m_muUserInfos.at (staId).ru;
+}
+
+void
+WifiTxVector::SetRu (HeRu::RuSpec ru, uint16_t staId)
+{
+  NS_ABORT_MSG_IF (!IsMu (), "RU only available for MU");
+  NS_ABORT_MSG_IF (staId > 2048, "STA-ID should be correctly set for MU");
+  m_muUserInfos[staId].ru = ru;
+}
+
+HeMuUserInfo
+WifiTxVector::GetHeMuUserInfo (uint16_t staId) const
+{
+  NS_ABORT_MSG_IF (!IsMu (), "HE MU user info only available for MU");
+  return m_muUserInfos.at (staId);
+}
+
+void
+WifiTxVector::SetHeMuUserInfo (uint16_t staId, HeMuUserInfo userInfo)
+{
+  NS_ABORT_MSG_IF (!IsMu (), "HE MU user info only available for MU");
+  NS_ABORT_MSG_IF (staId > 2048, "STA-ID should be correctly set for MU");
+  NS_ABORT_MSG_IF (userInfo.mcs.GetModulationClass () < WIFI_MOD_CLASS_HE, "Only HE (or newer) modes authorized for MU");
+  m_muUserInfos[staId] = userInfo;
+  m_modeInitialized = true;
+}
+
+const WifiTxVector::HeMuUserInfoMap&
+WifiTxVector::GetHeMuUserInfoMap (void) const
+{
+  NS_ABORT_MSG_IF (!IsMu (), "HE MU user info map only available for MU");
+  return m_muUserInfos;
+}
+
+WifiTxVector::HeMuUserInfoMap&
+WifiTxVector::GetHeMuUserInfoMap (void)
+{
+  NS_ABORT_MSG_IF (!IsMu (), "HE MU user info map only available for MU");
+  return m_muUserInfos;
+}
+
+std::pair<std::size_t, std::size_t>
+WifiTxVector::GetNumRusPerHeSigBContentChannel (void) const
+{
+  //MU-MIMO is not handled for now, i.e. one station per RU
+
+  if (m_channelWidth == 20)
+    {
+      return std::make_pair (m_muUserInfos.size (), 0); //all RUs are in HE-SIG-B content channel 1
+    }
+
+  HeRu::SubcarrierGroup toneRangesContentChannel1, toneRangesContentChannel2;
+  // See section 27.3.10.8.3 of IEEE 802.11ax draft 4.0 for tone ranges per HE-SIG-B content channel
+  switch (m_channelWidth)
+    {
+      case 40:
+        toneRangesContentChannel1.push_back (std::make_pair (-244, -3));
+        toneRangesContentChannel2.push_back (std::make_pair (3, 244));
+        break;
+      case 80:
+        toneRangesContentChannel1.push_back (std::make_pair (-500, -259));
+        toneRangesContentChannel2.push_back (std::make_pair (-258, -17));
+        toneRangesContentChannel1.push_back (std::make_pair (-16, -4)); //first part of center carrier (in HE-SIG-B content channel 1)
+        toneRangesContentChannel1.push_back (std::make_pair (4, 16)); //second part of center carrier (in HE-SIG-B content channel 1)
+        toneRangesContentChannel1.push_back (std::make_pair (17, 258));
+        toneRangesContentChannel2.push_back (std::make_pair (259, 500));
+        break;
+      case 160:
+        toneRangesContentChannel1.push_back (std::make_pair (-1012, -771));
+        toneRangesContentChannel2.push_back (std::make_pair (-770, -529));
+        toneRangesContentChannel1.push_back (std::make_pair (-528, -516)); //first part of center carrier of lower 80 MHz band (in HE-SIG-B content channel 1)
+        toneRangesContentChannel1.push_back (std::make_pair (-508, -496)); //second part of center carrier of lower 80 MHz band (in HE-SIG-B content channel 1)
+        toneRangesContentChannel1.push_back (std::make_pair (-495, -254));
+        toneRangesContentChannel2.push_back (std::make_pair (-253, -12));
+        toneRangesContentChannel1.push_back (std::make_pair (12, 253));
+        toneRangesContentChannel2.push_back (std::make_pair (254, 495));
+        toneRangesContentChannel2.push_back (std::make_pair (496, 508)); //first part of center carrier of upper 80 MHz band (in HE-SIG-B content channel 2)
+        toneRangesContentChannel2.push_back (std::make_pair (516, 528)); //second part of center carrier of upper 80 MHz band (in HE-SIG-B content channel 2)
+        toneRangesContentChannel1.push_back (std::make_pair (529, 770));
+        toneRangesContentChannel2.push_back (std::make_pair (771, 1012));
+        break;
+      default:
+        NS_ABORT_MSG ("Unknown channel width: " << m_channelWidth);
+    }
+
+  std::size_t numRusContentChannel1 = 0;
+  std::size_t numRusContentChannel2 = 0;
+  for (auto & userInfo : m_muUserInfos)
+    {
+      HeRu::RuSpec ru = userInfo.second.ru;
+      if (!ru.IsPhyIndexSet ())
+        {
+          // this method can be called when calculating the TX duration of a frame
+          // and at that time the RU PHY index may have not been set yet
+          ru.SetPhyIndex (m_channelWidth, 0);
+        }
+      if (HeRu::DoesOverlap (m_channelWidth, ru, toneRangesContentChannel1))
+        {
+          numRusContentChannel1++;
+        }
+      if (HeRu::DoesOverlap (m_channelWidth, ru, toneRangesContentChannel2))
+        {
+          numRusContentChannel2++;
+        }
+    }
+  return std::make_pair (numRusContentChannel1, numRusContentChannel2);
+}
+
+std::ostream & operator << ( std::ostream &os, const WifiTxVector &v)
+{
+  if (!v.IsValid ())
+    {
+      os << "TXVECTOR not valid";
+      return os;
+    }
+  os << "txpwrlvl: " << +v.GetTxPowerLevel ()
+     << " preamble: " << v.GetPreambleType ()
+     << " channel width: " << v.GetChannelWidth ()
+     << " GI: " << v.GetGuardInterval ()
+     << " NTx: " << +v.GetNTx ()
+     << " Ness: " << +v.GetNess ()
+     << " MPDU aggregation: " << v.IsAggregation ()
+     << " STBC: " << v.IsStbc ()
+     << " FEC coding: " << (v.IsLdpc () ? "LDPC" : "BCC");
+  if (v.GetPreambleType () >= WIFI_PREAMBLE_HE_SU)
+    {
+      os << " BSS color: " << +v.GetBssColor ();
+    }
+  if (v.IsUlMu ())
+    {
+      os << " Length: " << v.GetLength ();
+    }
+  if (v.IsNgv () || v.IsNonNgv20Duplicate () || v.GetNgvPpduRepetitions () > 0)
+    {
+      os << " 802.11bd PPDU format: " << WifiNgvPpduFormatToString (v.GetNgvPpduFormat ())
+         << " NGV-MCS: " << +v.GetNgvMcs ()
+         << " NGV midamble periodicity: " << v.GetNgvMidamblePeriodicity ()
+         << " NGV-LTF: " << WifiNgvLtfTypeToString (v.GetNgvLtfType ())
+         << " N_PPDU_REP: " << +v.GetNgvPpduRepetitions ();
+    }
+  if (v.IsMu ())
+    {
+      WifiTxVector::HeMuUserInfoMap userInfoMap = v.GetHeMuUserInfoMap ();
+      os << " num User Infos: " << userInfoMap.size ();
+      for (auto & ui : userInfoMap)
+        {
+          os << ", {STA-ID: " << ui.first
+             << ", " << ui.second.ru
+             << ", MCS: " << ui.second.mcs
+             << ", Nss: " << +ui.second.nss << "}";
+        }
+    }
+  else
+    {
+      os << " mode: " << v.GetMode ()
+         << " Nss: " << +v.GetNss ();
+    }
+  return os;
+}
+
+bool
+HeMuUserInfo::operator== (const HeMuUserInfo& other) const
+{
+  return ru == other.ru
+         && mcs.GetMcsValue () == other.mcs.GetMcsValue ()
+         && nss == other.nss;
+}
+
+bool
+HeMuUserInfo::operator!= (const HeMuUserInfo& other) const
+{
+  return !(*this == other);
+}
+
+} //namespace ns3

--- a/src/automotive/model/SignalInfo/WiFi/wifi-tx-vector.h
+++ b/src/automotive/model/SignalInfo/WiFi/wifi-tx-vector.h
@@ -1,0 +1,525 @@
+/* -*-  Mode: C++; c-file-style: "gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2010 CTTC
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors: Nicola Baldo <nbaldo@cttc.es>
+ *          Ghada Badawy <gbadawy@gmail.com>
+ */
+
+#ifndef WIFI_TX_VECTOR_H
+#define WIFI_TX_VECTOR_H
+
+#include <cstdint>
+#include <list>
+#include "wifi-mode.h"
+#include "wifi-phy-common.h"
+#include "ns3/he-ru.h"
+
+namespace ns3 {
+
+/**
+ * \ingroup wifi
+ * Identifies the 802.11bd PPDU format carried by a TXVECTOR.
+ */
+enum class WifiNgvPpduFormat : uint8_t
+{
+  NON_NGV_10,
+  NON_NGV_20_DUPLICATE,
+  NGV
+};
+
+/**
+ * \ingroup wifi
+ * Identifies the 802.11bd NGV-LTF type carried by a TXVECTOR.
+ */
+enum class WifiNgvLtfType : uint8_t
+{
+  NGV_LTF_1X,
+  NGV_LTF_2X,
+  NGV_LTF_2X_REPEAT
+};
+
+/// HE MU specific user transmission parameters.
+struct HeMuUserInfo
+{
+  HeRu::RuSpec ru; ///< RU specification
+  WifiMode mcs;    ///< MCS
+  uint8_t nss;     ///< number of spatial streams
+
+  /**
+    * Compare this user info to the given user info.
+    *
+    * \param other the given user info
+    * \return true if this user info compares equal to the given user info, false otherwise
+    */
+  bool operator== (const HeMuUserInfo& other) const;
+  /**
+    * Compare this user info to the given user info.
+    *
+    * \param other the given user info
+    * \return true if this user info differs from the given user info, false otherwise
+    */
+  bool operator!= (const HeMuUserInfo& other) const;
+};
+
+/**
+ * This class mimics the TXVECTOR which is to be
+ * passed to the PHY in order to define the parameters which are to be
+ * used for a transmission. See IEEE 802.11-2016 16.2.5 "Transmit PHY",
+ * and also 8.3.4.1 "PHY SAP peer-to-peer service primitive
+ * parameters".
+ *
+ * If this class is constructed with the constructor that takes no
+ * arguments, then the client must explicitly set the mode and
+ * transmit power level parameters before using them.  Default
+ * member initializers are provided for the other parameters, to
+ * conform to a non-MIMO/long guard configuration, although these
+ * may also be explicitly set after object construction.
+ *
+ * When used in a infrastructure context, WifiTxVector values should be
+ * drawn from WifiRemoteStationManager parameters since rate adaptation
+ * is responsible for picking the mode, number of streams, etc., but in
+ * the case in which there is no such manager (e.g. mesh), the client
+ * still needs to initialize at least the mode and transmit power level
+ * appropriately.
+ *
+ * \note the above reference is valid for the DSSS PHY only (clause
+ * 16). TXVECTOR is defined also for the other PHYs, however they
+ * don't include the TXPWRLVL explicitly in the TXVECTOR. This is
+ * somewhat strange, since all PHYs actually have a
+ * PMD_TXPWRLVL.request primitive. We decide to include the power
+ * level in WifiTxVector for all PHYs, since it serves better our
+ * purposes, and furthermore it seems close to the way real devices
+ * work (e.g., madwifi).
+ */
+class WifiTxVector
+{
+public:
+  /// map of HE MU specific user info paramters indexed by STA-ID
+  typedef std::map <uint16_t /* staId */, HeMuUserInfo /* HE MU specific user info */> HeMuUserInfoMap;
+
+  WifiTxVector ();
+  ~WifiTxVector ();
+  /**
+   * Create a TXVECTOR with the given parameters.
+   *
+   * \param mode WifiMode
+   * \param powerLevel transmission power level
+   * \param preamble preamble type
+   * \param guardInterval the guard interval duration in nanoseconds
+   * \param nTx the number of TX antennas
+   * \param nss the number of spatial STBC streams (NSS)
+   * \param ness the number of extension spatial streams (NESS)
+   * \param channelWidth the channel width in MHz
+   * \param aggregation enable or disable MPDU aggregation
+   * \param stbc enable or disable STBC
+   * \param ldpc enable or disable LDPC (BCC is used otherwise)
+   * \param bssColor the BSS color
+   * \param length the LENGTH field of the L-SIG
+   */
+  WifiTxVector (WifiMode mode,
+                uint8_t powerLevel,
+                WifiPreamble preamble,
+                uint16_t guardInterval,
+                uint8_t nTx,
+                uint8_t nss,
+                uint8_t ness,
+                uint16_t channelWidth,
+                bool aggregation,
+                bool stbc = false,
+                bool ldpc = false,
+                uint8_t bssColor = 0,
+                uint16_t length = 0);
+  /**
+   * Copy constructor
+   * \param txVector the TXVECTOR to copy
+   */
+  WifiTxVector (const WifiTxVector& txVector);
+
+  /**
+   * \returns whether mode has been initialized
+   */
+  bool GetModeInitialized (void) const;
+  /**
+   * If this TX vector is associated with an SU PPDU, return the selected
+   * payload transmission mode. If this TX vector is associated with an
+   * MU PPDU, return the transmission mode (MCS) selected for the transmission
+   * to the station identified by the given STA-ID.
+   *
+   * \param staId the station ID for MU
+   * \returns the selected payload transmission mode
+   */
+  WifiMode GetMode (uint16_t staId = SU_STA_ID) const;
+  /**
+   * Sets the selected payload transmission mode
+   *
+   * \param mode the payload WifiMode
+   */
+  void SetMode (WifiMode mode);
+  /**
+   * Sets the selected payload transmission mode for a given STA ID (for MU only)
+   *
+   * \param mode
+   * \param staId the station ID for MU
+   */
+  void SetMode (WifiMode mode, uint16_t staId);
+
+  /**
+   * Get the modulation class specified by this TXVECTOR.
+   *
+   * \return the Modulation Class specified by this TXVECTOR
+   */
+  WifiModulationClass GetModulationClass (void) const;
+
+  /**
+   * \returns the transmission power level
+   */
+  uint8_t GetTxPowerLevel (void) const;
+  /**
+   * Sets the selected transmission power level
+   *
+   * \param powerlevel the transmission power level
+   */
+  void SetTxPowerLevel (uint8_t powerlevel);
+  /**
+   * \returns the preamble type
+   */
+  WifiPreamble GetPreambleType (void) const;
+  /**
+   * Sets the preamble type
+   *
+   * \param preamble the preamble type
+   */
+  void SetPreambleType (WifiPreamble preamble);
+  /**
+   * \returns the channel width (in MHz)
+   */
+  uint16_t GetChannelWidth (void) const;
+  /**
+   * Sets the selected channelWidth (in MHz)
+   *
+   * \param channelWidth the channel width (in MHz)
+   */
+  void SetChannelWidth (uint16_t channelWidth);
+  /**
+   * \returns the guard interval duration (in nanoseconds)
+   */
+  uint16_t GetGuardInterval (void) const;
+  /**
+  * Sets the guard interval duration (in nanoseconds)
+  *
+  * \param guardInterval the guard interval duration (in nanoseconds)
+  */
+  void SetGuardInterval (uint16_t guardInterval);
+  /**
+   * \returns the number of TX antennas
+   */
+  uint8_t GetNTx (void) const;
+  /**
+   * Sets the number of TX antennas
+   *
+   * \param nTx the number of TX antennas
+   */
+  void SetNTx (uint8_t nTx);
+  /**
+   * If this TX vector is associated with an SU PPDU, return the number of
+   * spatial streams. If this TX vector is associated with an MU PPDU,
+   * return the number of spatial streams for the transmission to the station
+   * identified by the given STA-ID.
+   *
+   * \param staId the station ID for MU
+   * \returns the number of spatial streams
+   */
+  uint8_t GetNss (uint16_t staId = SU_STA_ID) const;
+  /**
+   * \returns the maximum number of Nss (namely if MU)
+   */
+  uint8_t GetNssMax (void) const;
+  /**
+   * Sets the number of Nss
+   *
+   * \param nss the number of spatial streams
+   */
+  void SetNss (uint8_t nss);
+  /**
+   * Sets the number of Nss for MU
+   *
+   * \param nss the number of spatial streams
+   * \param staId the station ID for MU
+   */
+  void SetNss (uint8_t nss, uint16_t staId);
+  /**
+   * \returns the number of extended spatial streams
+   */
+  uint8_t GetNess (void) const;
+  /**
+   * Sets the Ness number
+   *
+   * \param ness the number of extended spatial streams
+   */
+  void SetNess (uint8_t ness);
+  /**
+   * Checks whether the PSDU contains A-MPDU.
+   *  \returns true if this PSDU has A-MPDU aggregation,
+   *           false otherwise.
+   */
+  bool IsAggregation (void) const;
+  /**
+   * Sets if PSDU contains A-MPDU.
+   *
+   * \param aggregation whether the PSDU contains A-MPDU or not.
+   */
+  void SetAggregation (bool aggregation);
+  /**
+   * Check if STBC is used or not
+   *
+   * \returns true if STBC is used,
+   *           false otherwise
+   */
+  bool IsStbc (void) const;
+  /**
+   * Sets if STBC is being used
+   *
+   * \param stbc enable or disable STBC
+   */
+  void SetStbc (bool stbc);
+  /**
+   * Check if LDPC FEC coding is used or not
+   *
+   * \returns true if LDPC is used,
+   *          false if BCC is used
+   */
+  bool IsLdpc (void) const;
+  /**
+   * Sets if LDPC FEC coding is being used
+   *
+   * \param ldpc enable or disable LDPC
+   */
+  void SetLdpc (bool ldpc);
+  /**
+   * Set the BSS color
+   * \param color the BSS color
+   */
+  void SetBssColor (uint8_t color);
+  /**
+   * Get the BSS color
+   * \return the BSS color
+   */
+  uint8_t GetBssColor (void) const;
+  /**
+   * Set the LENGTH field of the L-SIG
+   * \param length the LENGTH field of the L-SIG
+   */
+  void SetLength (uint16_t length);
+  /**
+   * Get the LENGTH field of the L-SIG
+   * \return the LENGTH field of the L-SIG
+   */
+  uint16_t GetLength (void) const;
+  /**
+   * Set the 802.11bd PPDU format.
+   * \param format the 802.11bd PPDU format
+   */
+  void SetNgvPpduFormat (WifiNgvPpduFormat format);
+  /**
+   * Get the 802.11bd PPDU format.
+   * \return the 802.11bd PPDU format
+   */
+  WifiNgvPpduFormat GetNgvPpduFormat (void) const;
+  /**
+   * Return true if this TXVECTOR carries an 802.11bd NGV PPDU.
+   * \return true for an NGV PPDU
+   */
+  bool IsNgv (void) const;
+  /**
+   * Return true if this TXVECTOR carries a 10 MHz non-NGV PPDU.
+   * \return true for a 10 MHz non-NGV PPDU
+   */
+  bool IsNonNgv10 (void) const;
+  /**
+   * Return true if this TXVECTOR carries a 20 MHz duplicated non-NGV PPDU.
+   * \return true for a 20 MHz duplicated non-NGV PPDU
+   */
+  bool IsNonNgv20Duplicate (void) const;
+  /**
+   * Set the 802.11bd NGV-MCS index.
+   * \param mcs the NGV-MCS index
+   */
+  void SetNgvMcs (uint8_t mcs);
+  /**
+   * Get the 802.11bd NGV-MCS index.
+   * \return the NGV-MCS index
+   */
+  uint8_t GetNgvMcs (void) const;
+  /**
+   * Set the 802.11bd NGV midamble periodicity.
+   * \param periodicity the midamble periodicity
+   */
+  void SetNgvMidamblePeriodicity (uint16_t periodicity);
+  /**
+   * Get the 802.11bd NGV midamble periodicity.
+   * \return the midamble periodicity
+   */
+  uint16_t GetNgvMidamblePeriodicity (void) const;
+  /**
+   * Set the 802.11bd NGV-LTF type.
+   * \param type the NGV-LTF type
+   */
+  void SetNgvLtfType (WifiNgvLtfType type);
+  /**
+   * Get the 802.11bd NGV-LTF type.
+   * \return the NGV-LTF type
+   */
+  WifiNgvLtfType GetNgvLtfType (void) const;
+  /**
+   * Set the 802.11bd PPDU repetition count.
+   * \param repetitions the PPDU repetition count
+   */
+  void SetNgvPpduRepetitions (uint8_t repetitions);
+  /**
+   * Get the 802.11bd PPDU repetition count.
+   * \return the PPDU repetition count
+   */
+  uint8_t GetNgvPpduRepetitions (void) const;
+  /**
+   * The standard disallows certain combinations of WifiMode, number of
+   * spatial streams, and channel widths.  This method can be used to
+   * check whether this WifiTxVector contains an invalid combination.
+   *
+   * \return true if the WifiTxVector parameters are allowed by the standard
+   */
+  bool IsValid (void) const;
+   /**
+   * Return true if this TX vector is used for a multi-user transmission.
+   *
+   * \return true if this TX vector is used for a multi-user transmission
+   */
+  bool IsMu (void) const;
+   /**
+   * Return true if this TX vector is used for a downlink multi-user transmission.
+   *
+   * \return true if this TX vector is used for a downlink multi-user transmission
+   */
+  bool IsDlMu (void) const;
+   /**
+   * Return true if this TX vector is used for an uplink multi-user transmission.
+   *
+   * \return true if this TX vector is used for an uplink multi-user transmission
+   */
+  bool IsUlMu (void) const;
+  /**
+    * Get the RU specification for the STA-ID.
+    * This is applicable only for MU.
+    *
+    * \param staId the station ID
+    * \return the RU specification for the STA-ID
+    */
+   HeRu::RuSpec GetRu (uint16_t staId) const;
+   /**
+    * Set the RU specification for the STA-ID.
+    * This is applicable only for MU.
+    *
+    * \param ru the RU specification
+    * \param staId the station ID
+    */
+   void SetRu (HeRu::RuSpec ru, uint16_t staId);
+   /**
+    * Get the HE MU user-specific transmission information for the given STA-ID.
+    * This is applicable only for HE MU.
+    *
+    * \param staId the station ID
+    * \return the HE MU user-specific transmission information for the given STA-ID
+    */
+   HeMuUserInfo GetHeMuUserInfo (uint16_t staId) const;
+   /**
+    * Set the HE MU user-specific transmission information for the given STA-ID.
+    * This is applicable only for HE MU.
+    *
+    * \param staId the station ID
+    * \param userInfo the HE MU user-specific transmission information
+    */
+   void SetHeMuUserInfo (uint16_t staId, HeMuUserInfo userInfo);
+   /**
+    * Get a const reference to the map HE MU user-specific transmission information indexed by STA-ID.
+    * This is applicable only for HE MU.
+    *
+    * \return a const reference to the map of HE MU user-specific information indexed by STA-ID
+    */
+   const HeMuUserInfoMap& GetHeMuUserInfoMap (void) const;
+   /**
+    * Get a reference to the map HE MU user-specific transmission information indexed by STA-ID.
+    * This is applicable only for HE MU.
+    *
+    * \return a reference to the map of HE MU user-specific information indexed by STA-ID
+    */
+   HeMuUserInfoMap& GetHeMuUserInfoMap (void);
+   /**
+    * Get the number of RUs per HE-SIG-B content channel.
+    * This is applicable only for MU. MU-MIMO (i.e. multiple stations
+    * per RU) is not supported yet.
+    * See section 27.3.10.8.3 of IEEE 802.11ax draft 4.0.
+    *
+    * \return a pair containing the number of RUs in each HE-SIG-B content channel (resp. 1 and 2)
+    */
+   std::pair<std::size_t, std::size_t> GetNumRusPerHeSigBContentChannel (void) const;
+
+
+private:
+  WifiMode m_mode;               /**< The DATARATE parameter in Table 15-4.
+                                 It is the value that will be passed
+                                 to PMD_RATE.request */
+  uint8_t  m_txPowerLevel;       /**< The TXPWR_LEVEL parameter in Table 15-4.
+                                 It is the value that will be passed
+                                 to PMD_TXPWRLVL.request */
+  WifiPreamble m_preamble;       /**< preamble */
+  uint16_t m_channelWidth;       /**< channel width in MHz */
+  uint16_t m_guardInterval;      /**< guard interval duration in nanoseconds */
+  uint8_t  m_nTx;                /**< number of TX antennas */
+  uint8_t  m_nss;                /**< number of spatial streams */
+  uint8_t  m_ness;               /**< number of spatial streams in beamforming */
+  bool     m_aggregation;        /**< Flag whether the PSDU contains A-MPDU. */
+  bool     m_stbc;               /**< STBC used or not */
+  bool     m_ldpc;               /**< LDPC FEC coding if true, BCC otherwise*/
+  uint8_t  m_bssColor;           /**< BSS color */
+  uint16_t m_length;             /**< LENGTH field of the L-SIG */
+  WifiNgvPpduFormat m_ngvPpduFormat;  /**< 802.11bd PPDU format */
+  uint8_t  m_ngvMcs;             /**< 802.11bd NGV-MCS index */
+  uint16_t m_ngvMidamblePeriodicity; /**< 802.11bd NGV midamble periodicity */
+  WifiNgvLtfType m_ngvLtfType;   /**< 802.11bd NGV-LTF type */
+  uint8_t  m_ngvPpduRepetitions; /**< 802.11bd PPDU repetition count */
+
+  bool     m_modeInitialized;         /**< Internal initialization flag */
+
+  //MU information
+  HeMuUserInfoMap m_muUserInfos; /**< HE MU specific per-user information
+                                      indexed by station ID (STA-ID) corresponding
+                                      to the 11 LSBs of the AID of the recipient STA
+                                      This list shall be used only for HE MU */
+};
+
+/**
+ * Serialize WifiTxVector to the given ostream.
+ *
+ * \param os the output stream
+ * \param v the WifiTxVector to stringify
+ *
+ * \return ouput stream
+ */
+std::ostream & operator << (std::ostream & os,const WifiTxVector &v);
+
+} //namespace ns3
+
+#endif /* WIFI_TX_VECTOR_H */

--- a/src/automotive/model/SignalInfo/WiFi/yans-wifi-channel.cc
+++ b/src/automotive/model/SignalInfo/WiFi/yans-wifi-channel.cc
@@ -1,0 +1,223 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+/*
+ * Copyright (c) 2006,2007 INRIA
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation;
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Mathieu Lacage, <mathieu.lacage@sophia.inria.fr>
+ */
+
+#include "ns3/simulator.h"
+#include "ns3/log.h"
+#include "ns3/pointer.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/node.h"
+#include "ns3/propagation-loss-model.h"
+#include "ns3/propagation-delay-model.h"
+#include "ns3/mobility-model.h"
+#include "ns3/ofdm-ppdu.h"
+#include "yans-wifi-channel.h"
+#include "yans-wifi-phy.h"
+#include "wifi-utils.h"
+#include "wifi-ppdu.h"
+#include "wifi-psdu.h"
+
+#include <algorithm>
+
+namespace ns3 {
+
+NS_LOG_COMPONENT_DEFINE ("YansWifiChannel");
+
+namespace
+{
+
+bool
+FrequencyRangesOverlap (uint16_t centerA, uint16_t widthA, uint16_t centerB, uint16_t widthB)
+{
+  const int minA = static_cast<int> (centerA) - static_cast<int> (widthA) / 2;
+  const int maxA = static_cast<int> (centerA) + static_cast<int> (widthA) / 2;
+  const int minB = static_cast<int> (centerB) - static_cast<int> (widthB) / 2;
+  const int maxB = static_cast<int> (centerB) + static_cast<int> (widthB) / 2;
+
+  return std::max (minA, minB) < std::min (maxA, maxB);
+}
+
+bool
+ChannelsOverlap (Ptr<const YansWifiPhy> sender, Ptr<const YansWifiPhy> receiver)
+{
+  if (sender->GetChannelNumber () == receiver->GetChannelNumber ())
+    {
+      return true;
+    }
+  return FrequencyRangesOverlap (sender->GetFrequency (),
+                                 sender->GetChannelWidth (),
+                                 receiver->GetFrequency (),
+                                 receiver->GetChannelWidth ());
+}
+
+Ptr<WifiPpdu>
+GetReceiverPpdu (Ptr<const WifiPpdu> ppdu, Ptr<const YansWifiPhy> sender)
+{
+  WifiTxVector txVector = ppdu->GetTxVector ();
+  if (!txVector.IsNonNgv20Duplicate ())
+    {
+      return ppdu->Copy ();
+    }
+
+  txVector.SetNgvPpduFormat (WifiNgvPpduFormat::NON_NGV_10);
+  txVector.SetChannelWidth (10);
+  txVector.SetNss (1);
+  txVector.SetLdpc (false);
+
+  Ptr<WifiPpdu> copy =
+      Create<OfdmPpdu> (ppdu->GetPsdu (), txVector, sender->GetPhyBand (), ppdu->GetUid ());
+  if (ppdu->IsTruncatedTx ())
+    {
+      copy->SetTruncatedTx ();
+    }
+  return copy;
+}
+
+} // namespace
+
+NS_OBJECT_ENSURE_REGISTERED (YansWifiChannel);
+
+TypeId
+YansWifiChannel::GetTypeId (void)
+{
+  static TypeId tid = TypeId ("ns3::YansWifiChannel")
+                          .SetParent<Channel> ()
+                          .SetGroupName ("Wifi")
+                          .AddConstructor<YansWifiChannel> ()
+                          .AddAttribute ("PropagationLossModel", "A pointer to the propagation loss model attached to this channel.",
+                                         PointerValue (),
+                                         MakePointerAccessor (&YansWifiChannel::m_loss),
+                                         MakePointerChecker<PropagationLossModel> ())
+                          .AddAttribute ("PropagationDelayModel", "A pointer to the propagation delay model attached to this channel.",
+                                         PointerValue (),
+                                         MakePointerAccessor (&YansWifiChannel::m_delay),
+                                         MakePointerChecker<PropagationDelayModel> ())
+      ;
+  return tid;
+}
+
+YansWifiChannel::YansWifiChannel ()
+{
+  NS_LOG_FUNCTION (this);
+}
+
+YansWifiChannel::~YansWifiChannel ()
+{
+  NS_LOG_FUNCTION (this);
+  m_phyList.clear ();
+}
+
+void
+YansWifiChannel::SetPropagationLossModel (const Ptr<PropagationLossModel> loss)
+{
+  NS_LOG_FUNCTION (this << loss);
+  m_loss = loss;
+}
+
+void
+YansWifiChannel::SetPropagationDelayModel (const Ptr<PropagationDelayModel> delay)
+{
+  NS_LOG_FUNCTION (this << delay);
+  m_delay = delay;
+}
+
+void
+YansWifiChannel::Send (Ptr<YansWifiPhy> sender, Ptr<const WifiPpdu> ppdu, double txPowerDbm) const
+{
+  NS_LOG_FUNCTION (this << sender << ppdu << txPowerDbm);
+  Ptr<MobilityModel> senderMobility = sender->GetMobility ();
+  NS_ASSERT (senderMobility != 0);
+  for (PhyList::const_iterator i = m_phyList.begin (); i != m_phyList.end (); i++)
+    {
+      if (sender != (*i))
+        {
+          if (!ChannelsOverlap (sender, *i))
+            {
+              continue;
+            }
+
+          Ptr<MobilityModel> receiverMobility = (*i)->GetMobility ()->GetObject<MobilityModel> ();
+          Time delay = m_delay->GetDelay (senderMobility, receiverMobility);
+          double rxPowerDbm = m_loss->CalcRxPower (txPowerDbm, senderMobility, receiverMobility);
+          NS_LOG_DEBUG ("propagation: txPower=" << txPowerDbm << "dbm, rxPower=" << rxPowerDbm << "dbm, " <<
+                        "distance=" << senderMobility->GetDistanceFrom (receiverMobility) << "m, delay=" << delay);
+          Ptr<WifiPpdu> copy = GetReceiverPpdu (ppdu, sender);
+          Ptr<NetDevice> dstNetDevice = (*i)->GetDevice ();
+          uint32_t dstNode;
+          if (dstNetDevice == 0)
+            {
+              dstNode = 0xffffffff;
+            }
+          else
+            {
+              dstNode = dstNetDevice->GetNode ()->GetId ();
+            }
+
+          Simulator::ScheduleWithContext (dstNode,
+                                          delay, &YansWifiChannel::Receive,
+                                          (*i), copy, rxPowerDbm);
+        }
+    }
+}
+
+void
+YansWifiChannel::Receive (Ptr<YansWifiPhy> phy, Ptr<WifiPpdu> ppdu, double rxPowerDbm)
+{
+  NS_LOG_FUNCTION (phy << ppdu << rxPowerDbm);
+  // Do no further processing if signal is too weak
+  // Current implementation assumes constant RX power over the PPDU duration
+  if ((rxPowerDbm + phy->GetRxGain ()) < phy->GetRxSensitivity ())
+    {
+      NS_LOG_INFO ("Received signal too weak to process: " << rxPowerDbm << " dBm");
+      return;
+    }
+  RxPowerWattPerChannelBand rxPowerW;
+  rxPowerW.insert ({std::make_pair (0, 0), (DbmToW (rxPowerDbm + phy->GetRxGain ()))}); //dummy band for YANS
+  phy->StartReceivePreamble (ppdu, rxPowerW, ppdu->GetTxDuration ());
+}
+
+std::size_t
+YansWifiChannel::GetNDevices (void) const
+{
+  return m_phyList.size ();
+}
+
+Ptr<NetDevice>
+YansWifiChannel::GetDevice (std::size_t i) const
+{
+  return m_phyList[i]->GetDevice ();
+}
+
+void
+YansWifiChannel::Add (Ptr<YansWifiPhy> phy)
+{
+  NS_LOG_FUNCTION (this << phy);
+  m_phyList.push_back (phy);
+}
+
+int64_t
+YansWifiChannel::AssignStreams (int64_t stream)
+{
+  NS_LOG_FUNCTION (this << stream);
+  int64_t currentStream = stream;
+  currentStream += m_loss->AssignStreams (stream);
+  return (currentStream - stream);
+}
+
+} //namespace ns3

--- a/src/automotive/model/TxTracker/txTracker.h
+++ b/src/automotive/model/TxTracker/txTracker.h
@@ -75,6 +75,14 @@ namespace ns3 {
 
     // Method to insert 11p nodes into the tracker
     void Insert11pNodes (std::vector<std::tuple<std::string, uint8_t, Ptr<WifiNetDevice>>> nodes);
+
+    // Method to insert 11bd nodes into the tracker.
+    // The current 11bd profile uses the ns-3 Wi-Fi/WAVE device path, so it
+    // shares the same coexistence bookkeeping as 11p.
+    void Insert11bdNodes (std::vector<std::tuple<std::string, uint8_t, Ptr<WifiNetDevice>>> nodes)
+    {
+      Insert11pNodes (nodes);
+    }
   
     // Method to insert NR nodes into the tracker
     void InsertNrNodes (std::vector<std::tuple<std::string, uint8_t, Ptr<NrUeNetDevice>>> nodes);

--- a/src/automotive/model/Wifi/vehicular-ngv-wifi.cc
+++ b/src/automotive/model/Wifi/vehicular-ngv-wifi.cc
@@ -1,0 +1,139 @@
+#include "vehicular-ngv-wifi.h"
+
+#include "ns3/fatal-error.h"
+
+#include <array>
+
+namespace ns3
+{
+
+namespace
+{
+
+constexpr std::array<VehicularNgvMcs, 10> g_ngvMcs10MHzNss1 = {{
+    {0, "BPSK", 1, 2, 1, 52, 52, 26, 3.3, false},
+    {1, "QPSK", 1, 2, 2, 52, 104, 52, 6.5, false},
+    {2, "QPSK", 3, 4, 2, 52, 104, 78, 9.8, false},
+    {3, "16-QAM", 1, 2, 4, 52, 208, 104, 13.0, false},
+    {4, "16-QAM", 3, 4, 4, 52, 208, 156, 19.5, false},
+    {5, "64-QAM", 2, 3, 6, 52, 312, 208, 26.0, false},
+    {6, "64-QAM", 3, 4, 6, 52, 312, 234, 29.3, false},
+    {7, "64-QAM", 5, 6, 6, 52, 312, 260, 32.5, false},
+    {8, "256-QAM", 3, 4, 8, 52, 416, 312, 39.0, false},
+    {15, "BPSK-DCM", 1, 2, 1, 26, 26, 13, 1.6, true},
+}};
+
+constexpr std::array<VehicularNgvMcs, 9> g_ngvMcs10MHzNss2 = {{
+    {0, "BPSK", 1, 2, 1, 52, 104, 52, 6.5, false},
+    {1, "QPSK", 1, 2, 2, 52, 208, 104, 13.0, false},
+    {2, "QPSK", 3, 4, 2, 52, 208, 156, 19.5, false},
+    {3, "16-QAM", 1, 2, 4, 52, 416, 208, 26.0, false},
+    {4, "16-QAM", 3, 4, 4, 52, 416, 312, 39.0, false},
+    {5, "64-QAM", 2, 3, 6, 52, 624, 416, 52.0, false},
+    {6, "64-QAM", 3, 4, 6, 52, 624, 468, 58.5, false},
+    {7, "64-QAM", 5, 6, 6, 52, 624, 520, 65.0, false},
+    {8, "256-QAM", 3, 4, 8, 52, 832, 624, 78.0, false},
+}};
+
+constexpr std::array<VehicularNgvMcs, 11> g_ngvMcs20MHzNss1 = {{
+    {0, "BPSK", 1, 2, 1, 108, 108, 54, 6.8, false},
+    {1, "QPSK", 1, 2, 2, 108, 216, 108, 13.5, false},
+    {2, "QPSK", 3, 4, 2, 108, 216, 162, 20.3, false},
+    {3, "16-QAM", 1, 2, 4, 108, 432, 216, 27.0, false},
+    {4, "16-QAM", 3, 4, 4, 108, 432, 324, 40.5, false},
+    {5, "64-QAM", 2, 3, 6, 108, 648, 432, 54.0, false},
+    {6, "64-QAM", 3, 4, 6, 108, 648, 486, 60.8, false},
+    {7, "64-QAM", 5, 6, 6, 108, 648, 540, 67.5, false},
+    {8, "256-QAM", 3, 4, 8, 108, 864, 648, 81.0, false},
+    {9, "256-QAM", 5, 6, 8, 108, 864, 720, 90.0, false},
+    {15, "BPSK-DCM", 1, 2, 1, 54, 54, 27, 3.4, true},
+}};
+
+constexpr std::array<VehicularNgvMcs, 10> g_ngvMcs20MHzNss2 = {{
+    {0, "BPSK", 1, 2, 1, 108, 216, 108, 13.5, false},
+    {1, "QPSK", 1, 2, 2, 108, 432, 216, 27.0, false},
+    {2, "QPSK", 3, 4, 2, 108, 432, 324, 40.5, false},
+    {3, "16-QAM", 1, 2, 4, 108, 864, 432, 54.0, false},
+    {4, "16-QAM", 3, 4, 4, 108, 864, 648, 81.0, false},
+    {5, "64-QAM", 2, 3, 6, 108, 1296, 864, 106.0, false},
+    {6, "64-QAM", 3, 4, 6, 108, 1296, 972, 121.5, false},
+    {7, "64-QAM", 5, 6, 6, 108, 1296, 1080, 135.0, false},
+    {8, "256-QAM", 3, 4, 8, 108, 1728, 1296, 162.0, false},
+    {9, "256-QAM", 5, 6, 8, 108, 1728, 1440, 180.0, false},
+}};
+
+template <std::size_t N>
+const VehicularNgvMcs*
+FindMcs (const std::array<VehicularNgvMcs, N>& table, uint8_t index)
+{
+  for (const auto& mcs : table)
+    {
+      if (mcs.index == index)
+        {
+          return &mcs;
+        }
+    }
+  return nullptr;
+}
+
+const VehicularNgvMcs*
+FindMcs (uint8_t index, uint16_t channelWidthMHz, uint8_t spatialStreams)
+{
+  if (channelWidthMHz == 10 && spatialStreams == 1)
+    {
+      return FindMcs (g_ngvMcs10MHzNss1, index);
+    }
+  if (channelWidthMHz == 10 && spatialStreams == 2)
+    {
+      return FindMcs (g_ngvMcs10MHzNss2, index);
+    }
+  if (channelWidthMHz == 20 && spatialStreams == 1)
+    {
+      return FindMcs (g_ngvMcs20MHzNss1, index);
+    }
+  if (channelWidthMHz == 20 && spatialStreams == 2)
+    {
+      return FindMcs (g_ngvMcs20MHzNss2, index);
+    }
+  return nullptr;
+}
+
+} // namespace
+
+std::string
+VehicularWifiPpduFormatName (VehicularWifiPpduFormat format)
+{
+  switch (format)
+    {
+    case VehicularWifiPpduFormat::NON_NGV_10:
+      return "NON_NGV_10";
+    case VehicularWifiPpduFormat::NON_NGV_20_DUPLICATE:
+      return "NON_NGV_20_DUPLICATE";
+    case VehicularWifiPpduFormat::NGV:
+      return "NGV";
+    }
+  NS_FATAL_ERROR ("Unknown vehicular Wi-Fi PPDU format");
+  return "";
+}
+
+bool
+IsVehicularNgvMcsValid (uint8_t index, uint16_t channelWidthMHz, uint8_t spatialStreams)
+{
+  return FindMcs (index, channelWidthMHz, spatialStreams) != nullptr;
+}
+
+const VehicularNgvMcs&
+GetVehicularNgvMcs (uint8_t index, uint16_t channelWidthMHz, uint8_t spatialStreams)
+{
+  if (const VehicularNgvMcs* mcs = FindMcs (index, channelWidthMHz, spatialStreams);
+      mcs != nullptr)
+    {
+      return *mcs;
+    }
+
+  NS_FATAL_ERROR ("Invalid or reserved NGV-MCS index for " << channelWidthMHz
+                                                           << " MHz, NSS=" << +spatialStreams);
+  return g_ngvMcs10MHzNss1.front ();
+}
+
+} // namespace ns3

--- a/src/automotive/model/Wifi/vehicular-ngv-wifi.h
+++ b/src/automotive/model/Wifi/vehicular-ngv-wifi.h
@@ -1,0 +1,39 @@
+#ifndef VEHICULAR_NGV_WIFI_H
+#define VEHICULAR_NGV_WIFI_H
+
+#include <cstdint>
+#include <string>
+
+namespace ns3
+{
+
+enum class VehicularWifiPpduFormat
+{
+  NON_NGV_10,
+  NON_NGV_20_DUPLICATE,
+  NGV
+};
+
+struct VehicularNgvMcs
+{
+  uint8_t index;
+  const char* modulation;
+  uint8_t codeRateNumerator;
+  uint8_t codeRateDenominator;
+  uint16_t bitsPerSubcarrier;
+  uint16_t dataSubcarriers;
+  uint16_t codedBitsPerSymbol;
+  uint16_t dataBitsPerSymbol;
+  double dataRateMbps;
+  bool dcm;
+};
+
+std::string VehicularWifiPpduFormatName (VehicularWifiPpduFormat format);
+bool IsVehicularNgvMcsValid (uint8_t index, uint16_t channelWidthMHz = 10, uint8_t spatialStreams = 1);
+const VehicularNgvMcs& GetVehicularNgvMcs (uint8_t index,
+                                           uint16_t channelWidthMHz = 10,
+                                           uint8_t spatialStreams = 1);
+
+} // namespace ns3
+
+#endif // VEHICULAR_NGV_WIFI_H

--- a/src/automotive/test/vehicular-wifi-profile-test.cc
+++ b/src/automotive/test/vehicular-wifi-profile-test.cc
@@ -1,0 +1,2057 @@
+/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
+
+#include "ns3/test.h"
+#include "ns3/DCC.h"
+#include "ns3/MetricSupervisor.h"
+#include "ns3/config.h"
+#include "ns3/geonet.h"
+#include "ns3/vehicular-wifi-helper.h"
+#include "ns3/mac48-address.h"
+#include "ns3/mobility-helper.h"
+#include "ns3/net-device.h"
+#include "ns3/ngv-calibration.h"
+#include "ns3/node-container.h"
+#include "ns3/ofdm-phy.h"
+#include "ns3/packet.h"
+#include "ns3/position-allocator.h"
+#include "ns3/simulator.h"
+#include "ns3/uinteger.h"
+#include "ns3/vector.h"
+#include "ns3/wifi-mac-header.h"
+#include "ns3/wifi-net-device.h"
+#include "ns3/wifi-phy.h"
+#include "ns3/wifi-phy-state.h"
+#include "ns3/wifi-ppdu.h"
+#include "ns3/wifi-psdu.h"
+#include "ns3/wifi-remote-station-manager.h"
+#include "ns3/wifi-standards.h"
+#include "ns3/wifi-tx-vector.h"
+#include "ns3/wave-mac-helper.h"
+#include "ns3/yans-error-rate-model.h"
+
+#include <cstddef>
+#include <cmath>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace ns3;
+
+class LinearSnrErrorRateModel : public ErrorRateModel
+{
+private:
+  double DoGetChunkSuccessRate (WifiMode mode,
+                                const WifiTxVector& txVector,
+                                double snr,
+                                uint64_t nbits,
+                                uint8_t numRxAntennas,
+                                WifiPpduField field,
+                                uint16_t staId) const override
+  {
+    return snr >= 1.0 ? 1.0 : snr;
+  }
+};
+
+class VehicularWifiProfileTestCase : public TestCase
+{
+public:
+  VehicularWifiProfileTestCase ()
+    : TestCase ("Validate vehicular Wi-Fi profile metadata")
+  {
+  }
+
+private:
+  void DoRun () override
+  {
+    VehicularWifiProfile profile11bd =
+        VehicularWifiProfile::Ieee80211bd ("OfdmRate12MbpsBW10MHz", 24.0, -95.0, 4.0);
+
+    NS_TEST_ASSERT_MSG_EQ (profile11bd.GetTechnologyName (), "80211bd", "Unexpected 802.11bd label");
+    NS_TEST_ASSERT_MSG_EQ (profile11bd.GetDataMode (), "OfdmRate12MbpsBW10MHz", "Unexpected 802.11bd data mode");
+    NS_TEST_ASSERT_MSG_EQ (profile11bd.GetControlMode (), "OfdmRate6MbpsBW10MHz", "Unexpected 802.11bd control mode");
+    NS_TEST_ASSERT_MSG_EQ (profile11bd.GetChannelWidthMHz (), 10, "Unexpected 802.11bd channel width");
+    NS_TEST_ASSERT_MSG_EQ (profile11bd.GetPpduFormatName (), "NGV", "Unexpected 802.11bd PPDU format label");
+    NS_TEST_ASSERT_MSG_EQ (profile11bd.GetNgvMcsIndex (), 3, "Unexpected default 802.11bd NGV-MCS");
+    NS_TEST_ASSERT_MSG_EQ (profile11bd.GetNgvSpatialStreams (), 1, "Unexpected default 802.11bd spatial stream count");
+    NS_TEST_ASSERT_MSG_EQ_TOL (profile11bd.GetDccBitRate (), 13e6, 1.0, "Unexpected 802.11bd DCC bitrate");
+
+    VehicularWifiProfile p =
+        VehicularWifiProfile::Ieee80211p ("OfdmRate6MbpsBW10MHz", 23.0, -93.0, 4.0);
+    NS_TEST_ASSERT_MSG_EQ (p.GetTechnologyName (), "80211p", "Unexpected 802.11p label");
+    NS_TEST_ASSERT_MSG_EQ (p.GetPpduFormatName (), "NON_NGV_10", "Unexpected 802.11p PPDU format");
+    NS_TEST_ASSERT_MSG_EQ_TOL (p.GetDccBitRate (), 6e6, 1.0, "Unexpected 802.11p DCC bitrate");
+
+    VehicularWifiProfile compatible11bd =
+        VehicularWifiProfile::Ieee80211bdNonNgv10 ("OfdmRate6MbpsBW10MHz", 23.0, -93.0, 4.0, 2);
+    NS_TEST_ASSERT_MSG_EQ (compatible11bd.GetTechnologyName (), "80211bd", "Unexpected compatible 802.11bd label");
+    NS_TEST_ASSERT_MSG_EQ (compatible11bd.GetPpduFormatName (), "NON_NGV_10", "Unexpected compatible 802.11bd PPDU format");
+    NS_TEST_ASSERT_MSG_EQ (compatible11bd.GetNonNgvRepetitions (), 2, "Unexpected NON_NGV_10 repetition count");
+
+    VehicularWifiProfile profile11bd20 =
+        VehicularWifiProfile::Ieee80211bd20 ("OfdmRate24Mbps", 23.0, -92.0, 4.0, 9);
+    NS_TEST_ASSERT_MSG_EQ (profile11bd20.GetTechnologyName (), "80211bd", "Unexpected 20 MHz 802.11bd label");
+    NS_TEST_ASSERT_MSG_EQ (profile11bd20.GetChannelWidthMHz (), 20, "Unexpected 20 MHz 802.11bd channel width");
+    NS_TEST_ASSERT_MSG_EQ (profile11bd20.GetNgvMcsIndex (), 9, "Unexpected 20 MHz 802.11bd NGV-MCS");
+    NS_TEST_ASSERT_MSG_EQ_TOL (profile11bd20.GetDccBitRate (), 90e6, 1.0, "Unexpected 20 MHz NGV-MCS 9 bitrate");
+
+    VehicularWifiProfile duplicate11bd =
+        VehicularWifiProfile::Ieee80211bdNonNgv20Duplicate ();
+    NS_TEST_ASSERT_MSG_EQ (duplicate11bd.GetPpduFormatName (),
+                           "NON_NGV_20_DUPLICATE",
+                           "Unexpected 20 MHz duplicate PPDU format");
+    NS_TEST_ASSERT_MSG_EQ (duplicate11bd.GetChannelWidthMHz (),
+                           20,
+                           "Unexpected 20 MHz duplicate channel width");
+  }
+};
+
+class VehicularNgvMcsTestCase : public TestCase
+{
+public:
+  VehicularNgvMcsTestCase ()
+    : TestCase ("Validate 802.11bd NGV-MCS metadata")
+  {
+  }
+
+private:
+  void DoRun () override
+  {
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (0), true, "NGV-MCS 0 should be valid for 10 MHz, NSS=1");
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (8), true, "NGV-MCS 8 should be valid for 10 MHz, NSS=1");
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (15), true, "NGV-MCS 15 should be valid for 10 MHz, NSS=1");
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (9), false, "NGV-MCS 9 should be invalid for 10 MHz, NSS=1");
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (10), false, "NGV-MCS 10 should be reserved for 10 MHz, NSS=1");
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (9, 20, 1), true, "NGV-MCS 9 should be valid for 20 MHz, NSS=1");
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (15, 20, 1), true, "NGV-MCS 15 should be valid for 20 MHz, NSS=1");
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (15, 20, 2), false, "NGV-MCS 15 should be invalid for NSS=2");
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (8, 10, 2), true, "NGV-MCS 8 should be valid for 10 MHz, NSS=2");
+    NS_TEST_ASSERT_MSG_EQ (IsVehicularNgvMcsValid (9, 10, 2), false, "NGV-MCS 9 should be invalid for 10 MHz, NSS=2");
+
+    const auto& mcs3 = GetVehicularNgvMcs (3);
+    NS_TEST_ASSERT_MSG_EQ (mcs3.index, 3, "Unexpected NGV-MCS index");
+    NS_TEST_ASSERT_MSG_EQ (std::string (mcs3.modulation), "16-QAM", "Unexpected NGV-MCS modulation");
+    NS_TEST_ASSERT_MSG_EQ (mcs3.codeRateNumerator, 1, "Unexpected NGV-MCS code rate numerator");
+    NS_TEST_ASSERT_MSG_EQ (mcs3.codeRateDenominator, 2, "Unexpected NGV-MCS code rate denominator");
+    NS_TEST_ASSERT_MSG_EQ (mcs3.dataBitsPerSymbol, 104, "Unexpected NGV-MCS NDBPS");
+    NS_TEST_ASSERT_MSG_EQ_TOL (mcs3.dataRateMbps, 13.0, 0.001, "Unexpected NGV-MCS data rate");
+
+    const auto& mcs15 = GetVehicularNgvMcs (15);
+    NS_TEST_ASSERT_MSG_EQ (mcs15.dcm, true, "NGV-MCS 15 should use DCM");
+    NS_TEST_ASSERT_MSG_EQ_TOL (mcs15.dataRateMbps, 1.6, 0.001, "Unexpected NGV-MCS 15 data rate");
+
+    const auto& mcs9_20 = GetVehicularNgvMcs (9, 20, 1);
+    NS_TEST_ASSERT_MSG_EQ (mcs9_20.dataBitsPerSymbol, 720, "Unexpected 20 MHz NGV-MCS 9 NDBPS");
+    NS_TEST_ASSERT_MSG_EQ_TOL (mcs9_20.dataRateMbps, 90.0, 0.001, "Unexpected 20 MHz NGV-MCS 9 data rate");
+
+    const auto& mcs3_20nss2 = GetVehicularNgvMcs (3, 20, 2);
+    NS_TEST_ASSERT_MSG_EQ (mcs3_20nss2.dataBitsPerSymbol, 432, "Unexpected 20 MHz NSS=2 NGV-MCS 3 NDBPS");
+    NS_TEST_ASSERT_MSG_EQ_TOL (mcs3_20nss2.dataRateMbps, 54.0, 0.001, "Unexpected 20 MHz NSS=2 data rate");
+  }
+};
+
+class VehicularWifiProfileInstallTestCase : public TestCase
+{
+public:
+  VehicularWifiProfileInstallTestCase ()
+    : TestCase ("Validate installed 802.11bd PHY profile")
+  {
+  }
+
+private:
+  void DoRun () override
+  {
+    VehicularWifiProfile profile11bd =
+        VehicularWifiProfile::Ieee80211bd ("OfdmRate12MbpsBW10MHz", 24.0, -95.0, 4.0);
+
+    NodeContainer nodes;
+    nodes.Create (2);
+    MobilityHelper mobility;
+    mobility.Install (nodes);
+
+    YansWifiPhyHelper phy;
+    profile11bd.ConfigurePhy (phy);
+    YansWifiChannelHelper channel = YansWifiChannelHelper::Default ();
+    phy.SetChannel (channel.Create ());
+
+    QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+    Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+    profile11bd.ConfigureRemoteStationManager (wifi);
+
+    NetDeviceContainer devices = wifi.Install (phy, mac, nodes);
+    Ptr<WifiNetDevice> device = DynamicCast<WifiNetDevice> (devices.Get (0));
+    NS_TEST_ASSERT_MSG_NE (device, nullptr, "Expected a Wi-Fi net device");
+
+    Ptr<WifiPhy> installedPhy = device->GetPhy ();
+    NS_TEST_ASSERT_MSG_EQ (installedPhy->GetStandard (),
+                           WIFI_STANDARD_80211bd,
+                           "Installed PHY standard does not match 802.11bd profile");
+    NS_TEST_ASSERT_MSG_EQ (installedPhy->GetChannelWidth (),
+                           profile11bd.GetChannelWidthMHz (),
+                           "Installed PHY channel width does not match profile");
+    NS_TEST_ASSERT_MSG_EQ (installedPhy->GetNumberOfAntennas (),
+                           profile11bd.GetNgvSpatialStreams (),
+                           "Installed 802.11bd PHY antenna count does not match profile NSS");
+    NS_TEST_ASSERT_MSG_EQ (installedPhy->GetMaxSupportedTxSpatialStreams (),
+                           profile11bd.GetNgvSpatialStreams (),
+                           "Installed 802.11bd PHY TX spatial stream support does not match profile NSS");
+    NS_TEST_ASSERT_MSG_EQ (installedPhy->GetMaxSupportedRxSpatialStreams (),
+                           profile11bd.GetNgvSpatialStreams (),
+                           "Installed 802.11bd PHY RX spatial stream support does not match profile NSS");
+    NS_TEST_ASSERT_MSG_EQ_TOL (installedPhy->GetRxSensitivity (),
+                               profile11bd.GetRxSensitivityDbm (),
+                               0.001,
+                               "Installed PHY RxSensitivity does not match profile");
+    NS_TEST_ASSERT_MSG_EQ_TOL (installedPhy->GetCcaEdThreshold (),
+                               -65.0,
+                               0.001,
+                               "Installed 802.11bd PHY CCA ED threshold should match the primary 10 MHz NGV threshold");
+    NS_TEST_ASSERT_MSG_EQ_TOL (installedPhy->GetTxPowerStart (),
+                               profile11bd.GetTxPowerDbm (),
+                               0.001,
+                               "Installed PHY TxPowerStart does not match profile");
+    NS_TEST_ASSERT_MSG_EQ_TOL (installedPhy->GetTxPowerEnd (),
+                               profile11bd.GetTxPowerDbm (),
+                               0.001,
+                               "Installed PHY TxPowerEnd does not match profile");
+
+    Ptr<WifiRemoteStationManager> stationManager = device->GetRemoteStationManager ();
+    NS_TEST_ASSERT_MSG_NE (stationManager, nullptr, "Expected a Wi-Fi remote station manager");
+
+    WifiMacHeader broadcastData;
+    broadcastData.SetType (WIFI_MAC_DATA);
+    broadcastData.SetAddr1 (Mac48Address::GetBroadcast ());
+    broadcastData.SetAddr2 (Mac48Address ("00:00:00:00:00:01"));
+    broadcastData.SetAddr3 (Mac48Address::GetBroadcast ());
+
+    WifiTxVector broadcastTxVector = stationManager->GetDataTxVector (broadcastData);
+    NS_TEST_ASSERT_MSG_EQ (broadcastTxVector.IsNgv (), true, "802.11bd broadcast data TXVECTOR should be NGV");
+    NS_TEST_ASSERT_MSG_EQ (broadcastTxVector.GetNgvMcs (),
+                           profile11bd.GetNgvMcsIndex (),
+                           "802.11bd broadcast data TXVECTOR lost NGV-MCS metadata");
+    NS_TEST_ASSERT_MSG_EQ (broadcastTxVector.GetChannelWidth (),
+                           profile11bd.GetChannelWidthMHz (),
+                           "802.11bd broadcast data TXVECTOR channel width does not match profile");
+    NS_TEST_ASSERT_MSG_EQ (broadcastTxVector.GetNss (),
+                           profile11bd.GetNgvSpatialStreams (),
+                           "802.11bd broadcast data TXVECTOR NSS does not match profile");
+    NS_TEST_ASSERT_MSG_EQ (broadcastTxVector.IsLdpc (), true, "802.11bd NGV data TXVECTOR should request LDPC");
+    NS_TEST_ASSERT_MSG_EQ (broadcastTxVector.IsValid (), true, "802.11bd broadcast data TXVECTOR should be valid");
+
+    VehicularWifiProfile compatible11bd =
+        VehicularWifiProfile::Ieee80211bdNonNgv10 ("OfdmRate6MbpsBW10MHz", 23.0, -93.0, 4.0, 2);
+    YansWifiPhyHelper compatiblePhy;
+    compatible11bd.ConfigurePhy (compatiblePhy);
+    compatiblePhy.SetChannel (channel.Create ());
+
+    Wifi80211pHelper compatibleWifi = Wifi80211pHelper::Default ();
+    compatible11bd.ConfigureRemoteStationManager (compatibleWifi);
+
+    NetDeviceContainer compatibleDevices = compatibleWifi.Install (compatiblePhy, mac, nodes);
+    Ptr<WifiNetDevice> compatibleDevice = DynamicCast<WifiNetDevice> (compatibleDevices.Get (0));
+    NS_TEST_ASSERT_MSG_NE (compatibleDevice, nullptr, "Expected a compatible 802.11bd Wi-Fi net device");
+
+    WifiTxVector compatibleBroadcastTxVector =
+        compatibleDevice->GetRemoteStationManager ()->GetDataTxVector (broadcastData);
+    NS_TEST_ASSERT_MSG_EQ (compatibleBroadcastTxVector.IsNonNgv10 (),
+                           true,
+                           "Compatible 802.11bd broadcast data TXVECTOR should be NON_NGV_10");
+    NS_TEST_ASSERT_MSG_EQ (compatibleBroadcastTxVector.GetNgvPpduRepetitions (),
+                           compatible11bd.GetNonNgvRepetitions (),
+                           "Compatible 802.11bd broadcast data TXVECTOR lost N_PPDU_REP metadata");
+    NS_TEST_ASSERT_MSG_EQ (compatibleBroadcastTxVector.IsLdpc (),
+                           false,
+                           "NON_NGV_10 broadcast data TXVECTOR should not request NGV LDPC");
+
+    VehicularWifiProfile profile11bd20 =
+        VehicularWifiProfile::Ieee80211bd20 ("OfdmRate24Mbps", 23.0, -92.0, 4.0, 9, 2);
+    YansWifiPhyHelper phy20;
+    profile11bd20.ConfigurePhy (phy20);
+    phy20.SetChannel (channel.Create ());
+
+    Wifi80211pHelper wifi20 = Wifi80211pHelper::Default ();
+    profile11bd20.ConfigureRemoteStationManager (wifi20);
+
+    NetDeviceContainer devices20 = wifi20.Install (phy20, mac, nodes);
+    Ptr<WifiNetDevice> device20 = DynamicCast<WifiNetDevice> (devices20.Get (0));
+    NS_TEST_ASSERT_MSG_NE (device20, nullptr, "Expected a 20 MHz 802.11bd Wi-Fi net device");
+    NS_TEST_ASSERT_MSG_EQ (device20->GetPhy ()->GetChannelWidth (),
+                           20,
+                           "Installed 20 MHz 802.11bd PHY lost channel width");
+    NS_TEST_ASSERT_MSG_EQ (device20->GetPhy ()->GetNumberOfAntennas (),
+                           2,
+                           "Installed 20 MHz NSS=2 PHY lost antenna count");
+    NS_TEST_ASSERT_MSG_EQ (device20->GetPhy ()->GetMaxSupportedTxSpatialStreams (),
+                           2,
+                           "Installed 20 MHz NSS=2 PHY lost TX spatial stream support");
+    NS_TEST_ASSERT_MSG_EQ (device20->GetPhy ()->GetMaxSupportedRxSpatialStreams (),
+                           2,
+                           "Installed 20 MHz NSS=2 PHY lost RX spatial stream support");
+
+    WifiTxVector txVector20 =
+        device20->GetRemoteStationManager ()->GetDataTxVector (broadcastData);
+    NS_TEST_ASSERT_MSG_EQ (txVector20.IsNgv (), true, "20 MHz 802.11bd broadcast TXVECTOR should be NGV");
+    NS_TEST_ASSERT_MSG_EQ (txVector20.GetChannelWidth (), 20, "20 MHz NGV TXVECTOR lost channel width");
+    NS_TEST_ASSERT_MSG_EQ (txVector20.GetNgvMcs (), 9, "20 MHz NGV TXVECTOR lost NGV-MCS");
+    NS_TEST_ASSERT_MSG_EQ (txVector20.GetNss (), 2, "20 MHz NGV TXVECTOR lost NSS=2 metadata");
+    NS_TEST_ASSERT_MSG_EQ (txVector20.IsValid (), true, "20 MHz NGV TXVECTOR should be valid");
+
+    VehicularWifiProfile duplicate11bd =
+        VehicularWifiProfile::Ieee80211bdNonNgv20Duplicate ();
+    YansWifiPhyHelper duplicatePhy;
+    duplicate11bd.ConfigurePhy (duplicatePhy);
+    duplicatePhy.SetChannel (channel.Create ());
+
+    Wifi80211pHelper duplicateWifi = Wifi80211pHelper::Default ();
+    duplicate11bd.ConfigureRemoteStationManager (duplicateWifi);
+
+    NetDeviceContainer duplicateDevices = duplicateWifi.Install (duplicatePhy, mac, nodes);
+    Ptr<WifiNetDevice> duplicateDevice = DynamicCast<WifiNetDevice> (duplicateDevices.Get (0));
+    NS_TEST_ASSERT_MSG_NE (duplicateDevice, nullptr, "Expected a 20 MHz duplicate 802.11bd Wi-Fi net device");
+    WifiTxVector duplicateTxVector =
+        duplicateDevice->GetRemoteStationManager ()->GetDataTxVector (broadcastData);
+    NS_TEST_ASSERT_MSG_EQ (duplicateTxVector.IsNonNgv20Duplicate (),
+                           true,
+                           "20 MHz duplicate profile should transmit NON_NGV_20_DUPLICATE");
+    NS_TEST_ASSERT_MSG_EQ (duplicateTxVector.GetChannelWidth (),
+                           20,
+                           "20 MHz duplicate TXVECTOR lost channel width");
+    NS_TEST_ASSERT_MSG_EQ (duplicateTxVector.IsLdpc (),
+                           false,
+                           "20 MHz duplicate TXVECTOR should not request NGV LDPC");
+
+    Simulator::Destroy ();
+  }
+};
+
+class VehicularWifiFallbackControllerTestCase : public TestCase
+{
+public:
+  VehicularWifiFallbackControllerTestCase ()
+    : TestCase ("Validate 802.11bd fallback policy selection")
+  {
+  }
+
+private:
+  NetDeviceContainer InstallVehicularDevice (NodeContainer nodes,
+                                             Ptr<YansWifiChannel> channel,
+                                             const VehicularWifiProfile& profile)
+  {
+    YansWifiPhyHelper phy;
+    profile.ConfigurePhy (phy);
+    phy.SetChannel (channel);
+
+    QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+    Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+    profile.ConfigureRemoteStationManager (wifi);
+    return wifi.Install (phy, mac, nodes);
+  }
+
+  WifiMacHeader MakeBroadcastDataHeader () const
+  {
+    WifiMacHeader broadcastData;
+    broadcastData.SetType (WIFI_MAC_DATA);
+    broadcastData.SetAddr1 (Mac48Address::GetBroadcast ());
+    broadcastData.SetAddr2 (Mac48Address ("00:00:00:00:00:01"));
+    broadcastData.SetAddr3 (Mac48Address::GetBroadcast ());
+    return broadcastData;
+  }
+
+  void CheckAppliedMode (const std::string& scenario,
+                         VehicularWifiFallbackMode mode,
+                         const VehicularWifiProfile& installProfile)
+  {
+    NodeContainer nodes;
+    nodes.Create (1);
+    MobilityHelper mobility;
+    mobility.Install (nodes);
+
+    YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+    Ptr<YansWifiChannel> channel = channelHelper.Create ();
+    NetDeviceContainer devices = InstallVehicularDevice (nodes, channel, installProfile);
+    Ptr<WifiNetDevice> device = DynamicCast<WifiNetDevice> (devices.Get (0));
+    NS_TEST_ASSERT_MSG_NE (device, nullptr, scenario << " expected a Wi-Fi net device");
+
+    Ptr<WifiRemoteStationManager> manager = device->GetRemoteStationManager ();
+    VehicularWifiFallbackController::ConfigureRemoteStationManager (manager, mode);
+    WifiTxVector txVector = manager->GetDataTxVector (MakeBroadcastDataHeader ());
+
+    if (mode == VehicularWifiFallbackMode::NGV_20)
+      {
+        NS_TEST_ASSERT_MSG_EQ (txVector.IsNgv (), true, scenario << " should select native NGV");
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetChannelWidth (), 20, scenario << " should use 20 MHz NGV");
+      }
+    else if (mode == VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE)
+      {
+        NS_TEST_ASSERT_MSG_EQ (txVector.IsNonNgv20Duplicate (),
+                               true,
+                               scenario << " should select NON_NGV_20_DUPLICATE");
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetChannelWidth (),
+                               20,
+                               scenario << " should occupy a 20 MHz duplicate channel");
+      }
+    else
+      {
+        NS_TEST_ASSERT_MSG_EQ (txVector.IsNonNgv10 (),
+                               true,
+                               scenario << " should select primary-only NON_NGV_10");
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetChannelWidth (),
+                               10,
+                               scenario << " should use the 10 MHz primary channel");
+      }
+
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), true, scenario << " selected TXVECTOR should be valid");
+    Simulator::Destroy ();
+  }
+
+  void DoRun () override
+  {
+    const VehicularWifiFallbackMode nativeMode =
+        VehicularWifiFallbackController::Select (false, true, false);
+    const VehicularWifiFallbackMode duplicateMode =
+        VehicularWifiFallbackController::Select (true, true, false);
+    const VehicularWifiFallbackMode primaryMode =
+        VehicularWifiFallbackController::Select (true, false, false);
+    const VehicularWifiFallbackMode forcedPrimaryMode =
+        VehicularWifiFallbackController::Select (true, true, true);
+    VehicularWifiFallbackController::LinkQualityPolicy highQualityPolicy;
+    highQualityPolicy.legacyReceiverPresent = false;
+    highQualityPolicy.estimatedSnrDb = 25.0;
+    VehicularWifiFallbackController::LinkQualityPolicy midQualityPolicy;
+    midQualityPolicy.legacyReceiverPresent = false;
+    midQualityPolicy.estimatedSnrDb = 12.0;
+    VehicularWifiFallbackController::LinkQualityPolicy lowQualityPolicy;
+    lowQualityPolicy.legacyReceiverPresent = false;
+    lowQualityPolicy.estimatedSnrDb = 2.0;
+    VehicularWifiFallbackController::LinkQualityPolicy legacyHighQualityPolicy;
+    legacyHighQualityPolicy.legacyReceiverPresent = true;
+    legacyHighQualityPolicy.estimatedSnrDb = 25.0;
+    VehicularWifiFallbackController::LinkQualityPolicy legacyLowQualityPolicy;
+    legacyLowQualityPolicy.legacyReceiverPresent = true;
+    legacyLowQualityPolicy.estimatedSnrDb = 2.0;
+
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (nativeMode),
+                           static_cast<uint32_t> (VehicularWifiFallbackMode::NGV_20),
+                           "Policy without legacy receivers should select 20 MHz NGV");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (duplicateMode),
+                           static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+                           "Policy with legacy receivers should prefer 20 MHz duplicate fallback");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (primaryMode),
+                           static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_10),
+                           "Policy should fall back to primary-only when duplicate is disabled");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (forcedPrimaryMode),
+                           static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_10),
+                           "Policy should honor forced primary-only fallback");
+    NS_TEST_ASSERT_MSG_EQ (VehicularWifiFallbackModeName (duplicateMode),
+                           "NON_NGV_20_DUPLICATE",
+                           "Unexpected fallback mode name");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (VehicularWifiFallbackController::SelectForLinkQuality (highQualityPolicy)),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NGV_20),
+        "High-quality non-legacy policy should select 20 MHz NGV");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (VehicularWifiFallbackController::SelectForLinkQuality (midQualityPolicy)),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+        "Mid-quality non-legacy policy should select 20 MHz duplicate fallback");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (VehicularWifiFallbackController::SelectForLinkQuality (lowQualityPolicy)),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_10),
+        "Low-quality non-legacy policy should select primary-only fallback");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (VehicularWifiFallbackController::SelectForLinkQuality (legacyHighQualityPolicy)),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+        "High-quality legacy policy should select 20 MHz duplicate fallback");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (VehicularWifiFallbackController::SelectForLinkQuality (legacyLowQualityPolicy)),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_10),
+        "Low-quality legacy policy should select primary-only fallback");
+
+    VehicularWifiFallbackController::ObservationState observationState;
+    observationState.ewmaAlpha = 0.5;
+    observationState.policy.minNgv20SnrDb = 18.0;
+    observationState.policy.minDuplicate20SnrDb = 6.0;
+    VehicularWifiFallbackMode observedHigh =
+        VehicularWifiFallbackController::UpdateFromObservation (observationState,
+                                                                25.0,
+                                                                true,
+                                                                false);
+    VehicularWifiFallbackMode observedMid =
+        VehicularWifiFallbackController::UpdateFromObservation (observationState,
+                                                                9.0,
+                                                                true,
+                                                                false);
+    VehicularWifiFallbackMode observedLowFailureOne =
+        VehicularWifiFallbackController::UpdateFromObservation (observationState,
+                                                                2.0,
+                                                                false,
+                                                                false);
+    VehicularWifiFallbackMode observedLowFailureTwo =
+        VehicularWifiFallbackController::UpdateFromObservation (observationState,
+                                                                2.0,
+                                                                false,
+                                                                false);
+    VehicularWifiFallbackMode observedLegacyRecovery =
+        VehicularWifiFallbackController::UpdateFromObservation (observationState,
+                                                                25.0,
+                                                                true,
+                                                                true);
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (observedHigh),
+                           static_cast<uint32_t> (VehicularWifiFallbackMode::NGV_20),
+                           "High-SNR observed policy should select 20 MHz NGV");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (observedMid),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+        "EWMA mid-SNR observed policy should select 20 MHz duplicate fallback");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (observedLowFailureOne),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+        "First low-SNR failure should not force primary-only before the failure threshold");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (observedLowFailureTwo),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_10),
+        "Failure-threshold crossing should force primary-only for the current decision");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (observedLegacyRecovery),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+        "Legacy recovery observation should clear the failure streak and select duplicate fallback");
+    NS_TEST_ASSERT_MSG_EQ_TOL (observationState.ewmaSnrDb,
+                               15.375,
+                               0.001,
+                               "Unexpected observed-policy EWMA SNR");
+    NS_TEST_ASSERT_MSG_EQ (observationState.sampleCount,
+                           5,
+                           "Unexpected observed-policy sample count");
+    NS_TEST_ASSERT_MSG_EQ (observationState.consecutiveFailures,
+                           0,
+                           "Successful observation should clear consecutive failures");
+
+    NS_TEST_ASSERT_MSG_EQ_TOL (VehicularWifiFallbackController::EstimateSnrDb (-70.0, -95.0),
+                               25.0,
+                               0.001,
+                               "Signal/noise adapter should calculate SNR in dB");
+
+    VehicularWifiFallbackController::ObservationState traceObservationState;
+    traceObservationState.ewmaAlpha = 0.5;
+    traceObservationState.policy.minNgv20SnrDb = 18.0;
+    traceObservationState.policy.minDuplicate20SnrDb = 6.0;
+    VehicularWifiFallbackMode traceHigh =
+        VehicularWifiFallbackController::UpdateFromSignalNoise (traceObservationState,
+                                                                -70.0,
+                                                                -95.0,
+                                                                true,
+                                                                false);
+    VehicularWifiFallbackMode traceLegacy =
+        VehicularWifiFallbackController::UpdateFromSignalNoise (traceObservationState,
+                                                                -70.0,
+                                                                -95.0,
+                                                                true,
+                                                                true);
+    VehicularWifiFallbackMode traceLowFailure =
+        VehicularWifiFallbackController::UpdateFromSignalNoise (traceObservationState,
+                                                                -93.0,
+                                                                -95.0,
+                                                                false,
+                                                                true);
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (traceHigh),
+                           static_cast<uint32_t> (VehicularWifiFallbackMode::NGV_20),
+                           "Trace SNR adapter should keep high-quality non-legacy links on NGV");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (traceLegacy),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+        "Trace SNR adapter should select duplicate fallback for high-quality legacy links");
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (traceLowFailure),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+        "First trace-observed failure should not force primary-only before the threshold");
+    NS_TEST_ASSERT_MSG_EQ (traceObservationState.sampleCount,
+                           3,
+                           "Trace SNR adapter should update observation sample count");
+    NS_TEST_ASSERT_MSG_EQ (traceObservationState.consecutiveFailures,
+                           1,
+                           "Trace SNR adapter should preserve the observed failure streak");
+
+    VehicularWifiFallbackController::LinkQualityPolicy resetPolicy;
+    resetPolicy.estimatedSnrDb = 12.0;
+    observationState.ewmaAlpha = 0.25;
+    observationState.failureThreshold = 3;
+    VehicularWifiFallbackController::ResetObservationState (observationState, resetPolicy);
+    NS_TEST_ASSERT_MSG_EQ (observationState.initialized,
+                           false,
+                           "Reset observed-policy state should be uninitialized");
+    NS_TEST_ASSERT_MSG_EQ_TOL (observationState.ewmaSnrDb,
+                               12.0,
+                               0.001,
+                               "Reset observed-policy EWMA should use the initial policy SNR");
+    NS_TEST_ASSERT_MSG_EQ_TOL (observationState.ewmaAlpha,
+                               0.25,
+                               0.001,
+                               "Reset observed-policy state should preserve EWMA alpha");
+    NS_TEST_ASSERT_MSG_EQ (observationState.failureThreshold,
+                           3,
+                           "Reset observed-policy state should preserve failure threshold");
+
+    VehicularWifiProfile nativeProfile =
+        VehicularWifiFallbackController::MakeProfile (VehicularWifiFallbackMode::NGV_20);
+    VehicularWifiProfile duplicateProfile =
+        VehicularWifiFallbackController::MakeProfile (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE);
+    VehicularWifiProfile primaryProfile =
+        VehicularWifiFallbackController::MakeProfile (VehicularWifiFallbackMode::NON_NGV_10);
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (nativeProfile.GetPpduFormat ()),
+                           static_cast<uint32_t> (VehicularWifiPpduFormat::NGV),
+                           "Native policy profile should use NGV");
+    NS_TEST_ASSERT_MSG_EQ (nativeProfile.GetChannelWidthMHz (),
+                           20,
+                           "Native policy profile should use 20 MHz");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (duplicateProfile.GetPpduFormat ()),
+                           static_cast<uint32_t> (VehicularWifiPpduFormat::NON_NGV_20_DUPLICATE),
+                           "Duplicate policy profile should use NON_NGV_20_DUPLICATE");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (primaryProfile.GetPpduFormat ()),
+                           static_cast<uint32_t> (VehicularWifiPpduFormat::NON_NGV_10),
+                           "Primary-only policy profile should use NON_NGV_10");
+    NS_TEST_ASSERT_MSG_EQ (primaryProfile.GetChannelWidthMHz (),
+                           10,
+                           "Primary-only policy profile should use 10 MHz");
+
+    CheckAppliedMode ("20 MHz NGV fallback policy",
+                      VehicularWifiFallbackMode::NGV_20,
+                      nativeProfile);
+    CheckAppliedMode ("20 MHz duplicate fallback policy",
+                      VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE,
+                      duplicateProfile);
+    CheckAppliedMode ("10 MHz primary-only fallback policy",
+                      VehicularWifiFallbackMode::NON_NGV_10,
+                      primaryProfile);
+  }
+};
+
+class VehicularWifiRateControllerTestCase : public TestCase
+{
+public:
+  VehicularWifiRateControllerTestCase ()
+    : TestCase ("Validate modular 802.11bd/802.11p rate control decisions")
+  {
+  }
+
+private:
+  NetDeviceContainer InstallVehicularDevice (NodeContainer nodes,
+                                             Ptr<YansWifiChannel> channel,
+                                             const VehicularWifiProfile& profile)
+  {
+    YansWifiPhyHelper phy;
+    profile.ConfigurePhy (phy);
+    phy.SetChannel (channel);
+
+    QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+    Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+    profile.ConfigureRemoteStationManager (wifi);
+    return wifi.Install (phy, mac, nodes);
+  }
+
+  WifiMacHeader MakeBroadcastDataHeader () const
+  {
+    WifiMacHeader broadcastData;
+    broadcastData.SetType (WIFI_MAC_DATA);
+    broadcastData.SetAddr1 (Mac48Address::GetBroadcast ());
+    broadcastData.SetAddr2 (Mac48Address ("00:00:00:00:00:01"));
+    broadcastData.SetAddr3 (Mac48Address::GetBroadcast ());
+    return broadcastData;
+  }
+
+  void CheckAppliedDecision (const std::string& scenario,
+                             const VehicularWifiRateController::Decision& decision)
+  {
+    NodeContainer nodes;
+    nodes.Create (1);
+    MobilityHelper mobility;
+    mobility.Install (nodes);
+
+    YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+    Ptr<YansWifiChannel> channel = channelHelper.Create ();
+    NetDeviceContainer devices =
+        InstallVehicularDevice (nodes, channel, VehicularWifiRateController::MakeProfile (decision));
+    Ptr<WifiNetDevice> device = DynamicCast<WifiNetDevice> (devices.Get (0));
+    NS_TEST_ASSERT_MSG_NE (device, nullptr, scenario << " expected a Wi-Fi net device");
+
+    Ptr<WifiRemoteStationManager> manager = device->GetRemoteStationManager ();
+    VehicularWifiRateController::ConfigureRemoteStationManager (manager, decision);
+    WifiTxVector txVector = manager->GetDataTxVector (MakeBroadcastDataHeader ());
+
+    if (decision.standard == VehicularWifiProfile::Standard::IEEE_80211P)
+      {
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetMode ().GetUniqueName (),
+                               decision.dataMode,
+                               scenario << " did not apply the 802.11p data mode");
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetChannelWidth (),
+                               10,
+                               scenario << " should keep 802.11p on a 10 MHz channel");
+      }
+    else if (decision.fallbackMode == VehicularWifiFallbackMode::NGV_20)
+      {
+        NS_TEST_ASSERT_MSG_EQ (txVector.IsNgv (), true, scenario << " should apply NGV");
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetChannelWidth (),
+                               20,
+                               scenario << " should apply a 20 MHz NGV channel");
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetNgvMcs (),
+                               decision.ngvMcsIndex,
+                               scenario << " did not apply the selected NGV-MCS");
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetNss (),
+                               decision.ngvSpatialStreams,
+                               scenario << " did not apply the selected NGV NSS");
+      }
+    else if (decision.fallbackMode == VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE)
+      {
+        NS_TEST_ASSERT_MSG_EQ (txVector.IsNonNgv20Duplicate (),
+                               true,
+                               scenario << " should apply NON_NGV_20_DUPLICATE");
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetNgvMcs (),
+                               0,
+                               scenario << " duplicate fallback should clear NGV-MCS");
+      }
+    else
+      {
+        NS_TEST_ASSERT_MSG_EQ (txVector.IsNonNgv10 (),
+                               true,
+                               scenario << " should apply NON_NGV_10");
+        NS_TEST_ASSERT_MSG_EQ (txVector.GetChannelWidth (),
+                               10,
+                               scenario << " should apply a 10 MHz primary channel");
+      }
+
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), true, scenario << " selected TXVECTOR should be valid");
+    Simulator::Destroy ();
+  }
+
+  void DoRun () override
+  {
+    VehicularWifiRateController::Policy high11bd;
+    high11bd.linkQuality.estimatedSnrDb = 35.0;
+    VehicularWifiRateController::Decision high11bdDecision =
+        VehicularWifiRateController::Select (high11bd);
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (high11bdDecision.fallbackMode),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NGV_20),
+        "High-SNR 802.11bd rate control should keep native NGV");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (high11bdDecision.ngvMcsIndex),
+                           7,
+                           "High-SNR 802.11bd rate control should select NGV-MCS 7");
+    NS_TEST_ASSERT_MSG_EQ (VehicularWifiRateController::DecisionName (high11bdDecision),
+                           "80211bd:NGV_20:MCS7:NSS1",
+                           "Unexpected high-SNR 802.11bd decision name");
+
+    VehicularWifiRateController::Policy medium11bd;
+    medium11bd.linkQuality.estimatedSnrDb = 22.0;
+    VehicularWifiRateController::Decision medium11bdDecision =
+        VehicularWifiRateController::Select (medium11bd);
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (medium11bdDecision.fallbackMode),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NGV_20),
+        "Medium-SNR 802.11bd rate control should stay on native NGV");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (medium11bdDecision.ngvMcsIndex),
+                           3,
+                           "Medium-SNR 802.11bd rate control should select NGV-MCS 3");
+
+    VehicularWifiRateController::Policy low11bd;
+    low11bd.linkQuality.estimatedSnrDb = 14.0;
+    VehicularWifiRateController::Decision low11bdDecision =
+        VehicularWifiRateController::Select (low11bd);
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (low11bdDecision.fallbackMode),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NGV_20),
+        "Low-but-usable 802.11bd SNR should use the lowest NGV-MCS before fallback");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (low11bdDecision.ngvMcsIndex),
+                           0,
+                           "Low-but-usable 802.11bd SNR should select NGV-MCS 0");
+
+    VehicularWifiRateController::Policy duplicate11bd;
+    duplicate11bd.linkQuality.estimatedSnrDb = 8.0;
+    VehicularWifiRateController::Decision duplicate11bdDecision =
+        VehicularWifiRateController::Select (duplicate11bd);
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (duplicate11bdDecision.fallbackMode),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+        "Sub-NGV 802.11bd SNR should select duplicate fallback when it is still usable");
+
+    VehicularWifiRateController::Policy primary11bd;
+    primary11bd.linkQuality.estimatedSnrDb = 2.0;
+    VehicularWifiRateController::Decision primary11bdDecision =
+        VehicularWifiRateController::Select (primary11bd);
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (primary11bdDecision.fallbackMode),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_10),
+        "Very low 802.11bd SNR should select primary-only fallback");
+
+    VehicularWifiRateController::Policy legacy11bd;
+    legacy11bd.linkQuality.estimatedSnrDb = 35.0;
+    legacy11bd.linkQuality.legacyReceiverPresent = true;
+    VehicularWifiRateController::Decision legacy11bdDecision =
+        VehicularWifiRateController::Select (legacy11bd);
+    NS_TEST_ASSERT_MSG_EQ (
+        static_cast<uint32_t> (legacy11bdDecision.fallbackMode),
+        static_cast<uint32_t> (VehicularWifiFallbackMode::NON_NGV_20_DUPLICATE),
+        "802.11bd rate control should keep legacy receivers on duplicate fallback");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (legacy11bdDecision.ngvMcsIndex),
+                           0,
+                           "Legacy fallback should not retain a native NGV-MCS");
+
+    VehicularWifiRateController::Policy invalidMcs11bd;
+    invalidMcs11bd.linkQuality.estimatedSnrDb = 35.0;
+    invalidMcs11bd.highNgvMcsIndex = 15;
+    invalidMcs11bd.ngvSpatialStreams = 2;
+    VehicularWifiRateController::Decision clamped11bdDecision =
+        VehicularWifiRateController::Select (invalidMcs11bd);
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (clamped11bdDecision.ngvSpatialStreams),
+                           2,
+                           "Valid NSS=2 request should be preserved");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (clamped11bdDecision.ngvMcsIndex),
+                           9,
+                           "Invalid 20 MHz NSS=2 NGV-MCS request should degrade to MCS 9");
+
+    VehicularWifiRateController::Policy high11p;
+    high11p.standard = VehicularWifiProfile::Standard::IEEE_80211P;
+    high11p.linkQuality.estimatedSnrDb = 20.0;
+    VehicularWifiRateController::Decision high11pDecision =
+        VehicularWifiRateController::Select (high11p);
+    NS_TEST_ASSERT_MSG_EQ (high11pDecision.dataMode,
+                           "OfdmRate12MbpsBW10MHz",
+                           "High-SNR 802.11p rate control should select the high data mode");
+    NS_TEST_ASSERT_MSG_EQ (VehicularWifiRateController::DecisionName (high11pDecision),
+                           "80211p:OfdmRate12MbpsBW10MHz",
+                           "Unexpected high-SNR 802.11p decision name");
+
+    VehicularWifiRateController::Policy medium11p;
+    medium11p.standard = VehicularWifiProfile::Standard::IEEE_80211P;
+    medium11p.linkQuality.estimatedSnrDb = 10.0;
+    VehicularWifiRateController::Decision medium11pDecision =
+        VehicularWifiRateController::Select (medium11p);
+    NS_TEST_ASSERT_MSG_EQ (medium11pDecision.dataMode,
+                           "OfdmRate6MbpsBW10MHz",
+                           "Medium-SNR 802.11p rate control should select the middle data mode");
+
+    VehicularWifiRateController::Policy low11p;
+    low11p.standard = VehicularWifiProfile::Standard::IEEE_80211P;
+    low11p.linkQuality.estimatedSnrDb = 2.0;
+    VehicularWifiRateController::Decision low11pDecision =
+        VehicularWifiRateController::Select (low11p);
+    NS_TEST_ASSERT_MSG_EQ (low11pDecision.dataMode,
+                           "OfdmRate3MbpsBW10MHz",
+                           "Low-SNR 802.11p rate control should select the low data mode");
+
+    CheckAppliedDecision ("High-SNR 802.11bd rate control", high11bdDecision);
+    CheckAppliedDecision ("Medium-SNR 802.11bd rate control", medium11bdDecision);
+    CheckAppliedDecision ("Legacy-compatible 802.11bd rate control", legacy11bdDecision);
+    CheckAppliedDecision ("Primary-only 802.11bd rate control", primary11bdDecision);
+    CheckAppliedDecision ("High-SNR 802.11p rate control", high11pDecision);
+  }
+};
+
+class VehicularWifiCore11bdTestCase : public TestCase
+{
+public:
+  VehicularWifiCore11bdTestCase ()
+    : TestCase ("Validate core 802.11bd Wi-Fi metadata")
+  {
+  }
+
+private:
+  void DoRun () override
+  {
+    NS_TEST_ASSERT_MSG_EQ (GetFrequencyChannelType (WIFI_STANDARD_80211bd),
+                           WIFI_PHY_80211p_CHANNEL,
+                           "802.11bd should use the vehicular operating channel type");
+    NS_TEST_ASSERT_MSG_EQ (GetMaximumChannelWidth (WIFI_STANDARD_80211bd),
+                           20,
+                           "Unexpected 802.11bd maximum channel width");
+    NS_TEST_ASSERT_MSG_EQ (GetDefaultChannelWidth (WIFI_STANDARD_80211bd, WIFI_PHY_BAND_5GHZ),
+                           10,
+                           "Unexpected 802.11bd default channel width");
+    NS_TEST_ASSERT_MSG_EQ (GetDefaultPhyBand (WIFI_STANDARD_80211bd),
+                           WIFI_PHY_BAND_5GHZ,
+                           "Unexpected 802.11bd default band");
+
+    WifiTxVector txVector (OfdmPhy::GetOfdmRate12MbpsBW10MHz (),
+                           0,
+                           WIFI_PREAMBLE_LONG,
+                           800,
+                           1,
+                           1,
+                           0,
+                           10,
+                           false,
+                           false,
+                           true);
+    txVector.SetNgvPpduFormat (WifiNgvPpduFormat::NGV);
+    txVector.SetNgvMcs (3);
+    txVector.SetNgvMidamblePeriodicity (16);
+    txVector.SetNgvLtfType (WifiNgvLtfType::NGV_LTF_2X);
+    txVector.SetNgvPpduRepetitions (0);
+
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsNgv (), true, "Expected an NGV PPDU");
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsNonNgv10 (), false, "NGV PPDU should not be NON_NGV_10");
+    NS_TEST_ASSERT_MSG_EQ (txVector.GetNgvMcs (), 3, "Unexpected NGV-MCS index");
+    NS_TEST_ASSERT_MSG_EQ (txVector.GetNgvMidamblePeriodicity (), 16, "Unexpected NGV midamble periodicity");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (txVector.GetNgvLtfType ()),
+                           static_cast<uint32_t> (WifiNgvLtfType::NGV_LTF_2X),
+                           "Unexpected NGV-LTF type");
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), true, "Expected valid 802.11bd NGV TXVECTOR metadata");
+
+    WifiTxVector copiedTxVector (txVector);
+    NS_TEST_ASSERT_MSG_EQ (copiedTxVector.GetNgvMcs (), 3, "Copy lost NGV-MCS metadata");
+    NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (copiedTxVector.GetNgvLtfType ()),
+                           static_cast<uint32_t> (WifiNgvLtfType::NGV_LTF_2X),
+                           "Copy lost NGV-LTF metadata");
+
+    NS_TEST_ASSERT_MSG_EQ (txVector.GetModulationClass (),
+                           WIFI_MOD_CLASS_NGV,
+                           "NGV TXVECTOR should use the NGV modulation class");
+    NS_TEST_ASSERT_MSG_EQ (WifiPhy::CalculateTxDuration (128, txVector, WIFI_PHY_BAND_5GHZ).GetNanoSeconds (),
+                           168000,
+                           "Unexpected 802.11bd NGV TXTIME for 128-byte MCS3 PPDU");
+
+    txVector.SetNgvMidamblePeriodicity (4);
+    NS_TEST_ASSERT_MSG_EQ (WifiPhy::CalculateTxDuration (2048, txVector, WIFI_PHY_BAND_5GHZ).GetNanoSeconds (),
+                           1656000,
+                           "Unexpected 802.11bd NGV TXTIME with midambles");
+    txVector.SetNgvMidamblePeriodicity (0);
+
+    WifiTxVector nonNgvTxVector (OfdmPhy::GetOfdmRate6MbpsBW10MHz (),
+                                 0,
+                                 WIFI_PREAMBLE_LONG,
+                                 800,
+                                 1,
+                                 1,
+                                 0,
+                                 10,
+                                 false);
+    nonNgvTxVector.SetNgvPpduFormat (WifiNgvPpduFormat::NON_NGV_10);
+    NS_TEST_ASSERT_MSG_EQ (nonNgvTxVector.GetModulationClass (),
+                           WIFI_MOD_CLASS_OFDM,
+                           "NON_NGV_10 TXVECTOR should remain OFDM");
+
+    txVector.SetNgvMcs (15);
+    txVector.SetNgvLtfType (WifiNgvLtfType::NGV_LTF_2X);
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), false, "NGV-MCS 15 should require NGV_LTF_2X_REPEAT");
+    txVector.SetNgvLtfType (WifiNgvLtfType::NGV_LTF_2X_REPEAT);
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), true, "NGV-MCS 15 should allow NGV_LTF_2X_REPEAT");
+    txVector.SetNgvMcs (3);
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), false, "NGV_LTF_2X_REPEAT should be restricted to NGV-MCS 15");
+    txVector.SetNgvLtfType (WifiNgvLtfType::NGV_LTF_2X);
+
+    txVector.SetNgvMcs (10);
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), false, "Reserved NGV-MCS should be rejected");
+
+    txVector.SetNgvMcs (3);
+    txVector.SetChannelWidth (20);
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), true, "20 MHz NGV channel width should be valid");
+    NS_TEST_ASSERT_MSG_EQ (WifiPhy::CalculateTxDuration (128, txVector, WIFI_PHY_BAND_5GHZ).GetNanoSeconds (),
+                           120000,
+                           "Unexpected 20 MHz 802.11bd NGV TXTIME for 128-byte MCS3 PPDU");
+    txVector.SetNgvMcs (9);
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), true, "NGV-MCS 9 should be valid for 20 MHz");
+
+    txVector.SetChannelWidth (10);
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), false, "NGV-MCS 9 should be invalid for 10 MHz");
+    txVector.SetNgvMcs (3);
+    txVector.SetNss (2);
+    NS_TEST_ASSERT_MSG_EQ (txVector.IsValid (), true, "NGV NSS=2 should be valid for the supported abstraction");
+    txVector.SetChannelWidth (20);
+    NS_TEST_ASSERT_MSG_EQ (WifiPhy::CalculateTxDuration (128, txVector, WIFI_PHY_BAND_5GHZ).GetNanoSeconds (),
+                           112000,
+                           "Unexpected 20 MHz NSS=2 NGV TXTIME for 128-byte MCS3 PPDU");
+
+    WifiTxVector duplicateTxVector (OfdmPhy::GetOfdmRate6MbpsBW10MHz (),
+                                    0,
+                                    WIFI_PREAMBLE_LONG,
+                                    800,
+                                    1,
+                                    1,
+                                    0,
+                                    20,
+                                    false);
+    duplicateTxVector.SetNgvPpduFormat (WifiNgvPpduFormat::NON_NGV_20_DUPLICATE);
+    WifiTxVector primaryOnlyTxVector (duplicateTxVector);
+    primaryOnlyTxVector.SetNgvPpduFormat (WifiNgvPpduFormat::NON_NGV_10);
+    primaryOnlyTxVector.SetChannelWidth (10);
+    NS_TEST_ASSERT_MSG_EQ (duplicateTxVector.IsNonNgv20Duplicate (),
+                           true,
+                           "Expected a 20 MHz duplicated non-NGV PPDU");
+    NS_TEST_ASSERT_MSG_EQ (WifiPhy::CalculateTxDuration (128, duplicateTxVector, WIFI_PHY_BAND_5GHZ).GetNanoSeconds (),
+                           WifiPhy::CalculateTxDuration (128, primaryOnlyTxVector, WIFI_PHY_BAND_5GHZ).GetNanoSeconds (),
+                           "20 MHz non-NGV duplicate PPDU should use primary 10 MHz non-NGV duration");
+  }
+};
+
+class VehicularWifiActualTxVectorTestCase : public TestCase
+{
+public:
+  VehicularWifiActualTxVectorTestCase ()
+    : TestCase ("Validate transmitted 802.11bd TXVECTOR metadata and NON_NGV_10 repetition")
+  {
+  }
+
+private:
+  NetDeviceContainer InstallVehicularDevice (NodeContainer nodes,
+                                             Ptr<YansWifiChannel> channel,
+                                             const VehicularWifiProfile& profile)
+  {
+    YansWifiPhyHelper phy;
+    profile.ConfigurePhy (phy);
+    phy.SetChannel (channel);
+
+    QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+    Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+    profile.ConfigureRemoteStationManager (wifi);
+    return wifi.Install (phy, mac, nodes);
+  }
+
+  void NotifyTxPsduBegin (WifiConstPsduMap psduMap, WifiTxVector txVector, double txPowerW)
+  {
+    m_traceFired = true;
+    m_observedPsduCounts.push_back (psduMap.size ());
+    m_observedTxVectors.push_back (txVector);
+    m_observedTxPowersW.push_back (txPowerW);
+    m_observedTxStartTimes.push_back (Simulator::Now ());
+    m_observedTxDurations.push_back (
+        WifiPhy::CalculateTxDuration (psduMap, txVector, m_tracePhy->GetPhyBand ()));
+  }
+
+  bool Receive (Ptr<NetDevice> dev, Ptr<const Packet> pkt, uint16_t protocol, const Address& sender)
+  {
+    m_rxPackets++;
+    m_lastProtocol = protocol;
+    return true;
+  }
+
+  void SendPacket (Ptr<NetDevice> device)
+  {
+    static const uint16_t wsmpProtocol = 0x88DC;
+    m_txSucceeded = device->Send (Create<Packet> (128), Mac48Address::GetBroadcast (), wsmpProtocol);
+  }
+
+  void RunOneTransmission (const std::string& scenario,
+                           const VehicularWifiProfile& senderProfile,
+                           const VehicularWifiProfile& receiverProfile)
+  {
+    m_traceFired = false;
+    m_txSucceeded = false;
+    m_rxPackets = 0;
+    m_lastProtocol = 0;
+    m_tracePhy = nullptr;
+    m_observedPsduCounts.clear ();
+    m_observedTxVectors.clear ();
+    m_observedTxPowersW.clear ();
+    m_observedTxStartTimes.clear ();
+    m_observedTxDurations.clear ();
+
+    NodeContainer nodes;
+    nodes.Create (2);
+
+    Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+    positions->Add (Vector (0.0, 0.0, 0.0));
+    positions->Add (Vector (5.0, 0.0, 0.0));
+    MobilityHelper mobility;
+    mobility.SetPositionAllocator (positions);
+    mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+    mobility.Install (nodes);
+
+    YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+    Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+    NodeContainer senderNode;
+    senderNode.Add (nodes.Get (0));
+    NodeContainer receiverNode;
+    receiverNode.Add (nodes.Get (1));
+
+    NetDeviceContainer senderDevices = InstallVehicularDevice (senderNode, channel, senderProfile);
+    NetDeviceContainer receiverDevices = InstallVehicularDevice (receiverNode, channel, receiverProfile);
+    receiverDevices.Get (0)->SetReceiveCallback (
+        MakeCallback (&VehicularWifiActualTxVectorTestCase::Receive, this));
+
+    Ptr<WifiNetDevice> senderWifi = DynamicCast<WifiNetDevice> (senderDevices.Get (0));
+    NS_TEST_ASSERT_MSG_NE (senderWifi, nullptr, scenario << " expected a Wi-Fi sender device");
+    NS_TEST_ASSERT_MSG_EQ (senderWifi->GetPhy ()->GetStandard (),
+	                           WIFI_STANDARD_80211bd,
+	                           scenario << " sender PHY standard should be 802.11bd");
+    m_tracePhy = senderWifi->GetPhy ();
+
+    bool traceConnected = m_tracePhy->TraceConnectWithoutContext (
+        "PhyTxPsduBegin",
+        MakeCallback (&VehicularWifiActualTxVectorTestCase::NotifyTxPsduBegin, this));
+    NS_TEST_ASSERT_MSG_EQ (traceConnected, true, scenario << " failed to connect PhyTxPsduBegin trace");
+
+    Simulator::Schedule (MilliSeconds (100),
+                         &VehicularWifiActualTxVectorTestCase::SendPacket,
+                         this,
+                         senderDevices.Get (0));
+    Simulator::Stop (Seconds (1));
+    Simulator::Run ();
+
+    NS_TEST_ASSERT_MSG_EQ (m_txSucceeded, true, scenario << " send failed");
+    NS_TEST_ASSERT_MSG_EQ (m_traceFired, true, scenario << " did not emit PhyTxPsduBegin");
+    NS_TEST_ASSERT_MSG_EQ (m_rxPackets,
+                           1u,
+                           scenario << " repeated physical PPDUs should deliver one MAC payload");
+    NS_TEST_ASSERT_MSG_EQ (m_lastProtocol, 0x88DC, scenario << " received packet with unexpected protocol");
+
+    const std::size_t expectedPpduTraces =
+        1 + (senderProfile.GetPpduFormat () == VehicularWifiPpduFormat::NON_NGV_10
+                 ? senderProfile.GetNonNgvRepetitions ()
+                 : 0);
+    NS_TEST_ASSERT_MSG_EQ (m_observedTxVectors.size (),
+                           expectedPpduTraces,
+                           scenario << " unexpected transmitted PPDU count");
+    NS_TEST_ASSERT_MSG_EQ (m_observedTxPowersW.size (),
+                           expectedPpduTraces,
+                           scenario << " unexpected transmitted power trace count");
+    NS_TEST_ASSERT_MSG_EQ (m_observedTxStartTimes.size (),
+                           expectedPpduTraces,
+                           scenario << " unexpected transmitted timestamp count");
+    NS_TEST_ASSERT_MSG_EQ (m_observedTxDurations.size (),
+                           expectedPpduTraces,
+                           scenario << " unexpected transmitted duration count");
+
+    for (std::size_t i = 0; i < expectedPpduTraces; ++i)
+      {
+        const WifiTxVector& observedTxVector = m_observedTxVectors.at (i);
+        NS_TEST_ASSERT_MSG_EQ (m_observedPsduCounts.at (i), 1u, scenario << " should transmit one PSDU per PPDU");
+        NS_TEST_ASSERT_MSG_GT (m_observedTxPowersW.at (i), 0.0, scenario << " should transmit with positive power");
+        NS_TEST_ASSERT_MSG_EQ (observedTxVector.GetChannelWidth (),
+                               senderProfile.GetChannelWidthMHz (),
+                               scenario << " lost channel width in transmitted TXVECTOR");
+        NS_TEST_ASSERT_MSG_EQ (observedTxVector.GetNss (),
+                               senderProfile.GetNgvSpatialStreams (),
+                               scenario << " lost NSS in transmitted TXVECTOR");
+        NS_TEST_ASSERT_MSG_EQ (observedTxVector.IsValid (),
+                               true,
+                               scenario << " transmitted TXVECTOR should be valid");
+      }
+
+    for (std::size_t i = 1; i < expectedPpduTraces; ++i)
+      {
+        const Time observedInterval = m_observedTxStartTimes.at (i) - m_observedTxStartTimes.at (i - 1);
+        const Time expectedInterval = m_observedTxDurations.at (i - 1) + m_tracePhy->GetSifs ();
+        NS_TEST_ASSERT_MSG_EQ (observedInterval.GetNanoSeconds (),
+                               expectedInterval.GetNanoSeconds (),
+                               scenario << " repeated NON_NGV_10 PPDU should start after previous PPDU plus SIFS");
+      }
+
+    if (senderProfile.GetPpduFormat () == VehicularWifiPpduFormat::NGV)
+      {
+        const WifiTxVector& observedTxVector = m_observedTxVectors.front ();
+        NS_TEST_ASSERT_MSG_EQ (observedTxVector.IsNgv (),
+                               true,
+                               scenario << " transmitted TXVECTOR should be NGV");
+        NS_TEST_ASSERT_MSG_EQ (observedTxVector.GetNgvMcs (),
+                               senderProfile.GetNgvMcsIndex (),
+                               scenario << " lost NGV-MCS in transmitted TXVECTOR");
+        NS_TEST_ASSERT_MSG_EQ (observedTxVector.IsLdpc (),
+                               true,
+                               scenario << " NGV transmitted TXVECTOR should request LDPC");
+        NS_TEST_ASSERT_MSG_EQ (observedTxVector.GetNgvMidamblePeriodicity (),
+                               0,
+                               scenario << " unexpected NGV midamble periodicity");
+        NS_TEST_ASSERT_MSG_EQ (static_cast<uint32_t> (observedTxVector.GetNgvLtfType ()),
+                               static_cast<uint32_t> (WifiNgvLtfType::NGV_LTF_2X),
+                               scenario << " unexpected NGV-LTF type");
+      }
+    else
+      {
+        for (const auto& observedTxVector : m_observedTxVectors)
+          {
+            NS_TEST_ASSERT_MSG_EQ ((senderProfile.GetPpduFormat () == VehicularWifiPpduFormat::NON_NGV_20_DUPLICATE)
+                                       ? observedTxVector.IsNonNgv20Duplicate ()
+                                       : observedTxVector.IsNonNgv10 (),
+                                   true,
+                                   scenario << " transmitted TXVECTOR carried unexpected non-NGV format");
+            NS_TEST_ASSERT_MSG_EQ (observedTxVector.GetNgvPpduRepetitions (),
+                                   senderProfile.GetNonNgvRepetitions (),
+                                   scenario << " lost N_PPDU_REP in transmitted TXVECTOR");
+            NS_TEST_ASSERT_MSG_EQ (observedTxVector.IsLdpc (),
+                                   false,
+                                   scenario << " NON_NGV_10 transmitted TXVECTOR should not request LDPC");
+          }
+      }
+
+    m_tracePhy = nullptr;
+    Simulator::Destroy ();
+  }
+
+  void DoRun () override
+  {
+    RunOneTransmission ("802.11bd NGV",
+                        VehicularWifiProfile::Ieee80211bd (),
+                        VehicularWifiProfile::Ieee80211bd ());
+    RunOneTransmission ("802.11bd 20 MHz NGV",
+                        VehicularWifiProfile::Ieee80211bd20 (),
+                        VehicularWifiProfile::Ieee80211bd20 ());
+    RunOneTransmission ("802.11bd NGV NSS=2",
+                        VehicularWifiProfile::Ieee80211bd ("OfdmRate12MbpsBW10MHz",
+                                                           23.0,
+                                                           -92.0,
+                                                           4.0,
+                                                           3,
+                                                           2),
+                        VehicularWifiProfile::Ieee80211bd ("OfdmRate12MbpsBW10MHz",
+                                                           23.0,
+                                                           -92.0,
+                                                           4.0,
+                                                           3,
+                                                           2));
+    RunOneTransmission ("802.11bd 20 MHz NGV NSS=2",
+                        VehicularWifiProfile::Ieee80211bd20 ("OfdmRate24Mbps",
+                                                             23.0,
+                                                             -92.0,
+                                                             4.0,
+                                                             3,
+                                                             2),
+                        VehicularWifiProfile::Ieee80211bd20 ("OfdmRate24Mbps",
+                                                             23.0,
+                                                             -92.0,
+                                                             4.0,
+                                                             3,
+                                                             2));
+    RunOneTransmission ("802.11bd NON_NGV_10",
+                        VehicularWifiProfile::Ieee80211bdNonNgv10 ("OfdmRate6MbpsBW10MHz",
+                                                                    23.0,
+                                                                    -93.0,
+                                                                    4.0,
+                                                                    2),
+                        VehicularWifiProfile::Ieee80211p ());
+    RunOneTransmission ("802.11bd NON_NGV_20_DUPLICATE to 802.11bd",
+                        VehicularWifiProfile::Ieee80211bdNonNgv20Duplicate (),
+                        VehicularWifiProfile::Ieee80211bd20 ());
+    RunOneTransmission ("802.11bd NON_NGV_20_DUPLICATE to 802.11p",
+                        VehicularWifiProfile::Ieee80211bdNonNgv20Duplicate (),
+                        VehicularWifiProfile::Ieee80211p ());
+  }
+
+  bool m_traceFired = false;
+  bool m_txSucceeded = false;
+  uint32_t m_rxPackets = 0;
+  uint16_t m_lastProtocol = 0;
+  Ptr<WifiPhy> m_tracePhy;
+  std::vector<std::size_t> m_observedPsduCounts;
+  std::vector<double> m_observedTxPowersW;
+  std::vector<Time> m_observedTxStartTimes;
+  std::vector<Time> m_observedTxDurations;
+  std::vector<WifiTxVector> m_observedTxVectors;
+};
+
+class VehicularWifiInteroperabilityTestCase : public TestCase
+{
+public:
+  VehicularWifiInteroperabilityTestCase ()
+    : TestCase ("Validate 802.11p/802.11bd interoperability and NGV isolation")
+  {
+  }
+
+private:
+  NetDeviceContainer InstallVehicularDevice (NodeContainer nodes,
+                                             Ptr<YansWifiChannel> channel,
+                                             const VehicularWifiProfile& profile)
+  {
+    YansWifiPhyHelper phy;
+    profile.ConfigurePhy (phy);
+    phy.SetChannel (channel);
+
+    QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+    Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+    profile.ConfigureRemoteStationManager (wifi);
+    return wifi.Install (phy, mac, nodes);
+  }
+
+  bool Receive (Ptr<NetDevice> dev, Ptr<const Packet> pkt, uint16_t protocol, const Address& sender)
+  {
+    m_rxPackets++;
+    m_lastProtocol = protocol;
+    return true;
+  }
+
+  void SendPacket (Ptr<NetDevice> device)
+  {
+    static const uint16_t wsmpProtocol = 0x88DC;
+    m_txSucceeded = device->Send (Create<Packet> (128), Mac48Address::GetBroadcast (), wsmpProtocol);
+  }
+
+  void RunOneWay (const std::string& scenario,
+                  const VehicularWifiProfile& senderProfile,
+                  const VehicularWifiProfile& receiverProfile,
+                  uint32_t expectedRxPackets)
+  {
+    m_rxPackets = 0;
+    m_lastProtocol = 0;
+    m_txSucceeded = false;
+
+    NodeContainer nodes;
+    nodes.Create (2);
+
+    Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+    positions->Add (Vector (0.0, 0.0, 0.0));
+    positions->Add (Vector (5.0, 0.0, 0.0));
+    MobilityHelper mobility;
+    mobility.SetPositionAllocator (positions);
+    mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+    mobility.Install (nodes);
+
+    YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+    Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+    NodeContainer senderNode;
+    senderNode.Add (nodes.Get (0));
+    NodeContainer receiverNode;
+    receiverNode.Add (nodes.Get (1));
+
+    NetDeviceContainer senderDevices = InstallVehicularDevice (senderNode, channel, senderProfile);
+    NetDeviceContainer receiverDevices = InstallVehicularDevice (receiverNode, channel, receiverProfile);
+
+    receiverDevices.Get (0)->SetReceiveCallback (
+        MakeCallback (&VehicularWifiInteroperabilityTestCase::Receive, this));
+
+    Simulator::Schedule (MilliSeconds (100),
+                         &VehicularWifiInteroperabilityTestCase::SendPacket,
+                         this,
+                         senderDevices.Get (0));
+    Simulator::Stop (Seconds (1));
+    Simulator::Run ();
+
+    NS_TEST_ASSERT_MSG_EQ (m_txSucceeded, true, scenario << " send failed");
+    NS_TEST_ASSERT_MSG_EQ (m_rxPackets,
+                           expectedRxPackets,
+                           scenario << " received unexpected packet count");
+    if (expectedRxPackets > 0)
+      {
+        NS_TEST_ASSERT_MSG_EQ (m_lastProtocol, 0x88DC, scenario << " received packet with unexpected protocol");
+      }
+
+    Simulator::Destroy ();
+  }
+
+  void DoRun () override
+  {
+    RunOneWay ("802.11p to 802.11bd",
+               VehicularWifiProfile::Ieee80211p (),
+               VehicularWifiProfile::Ieee80211bd (),
+               1);
+    RunOneWay ("802.11bd NON_NGV_10 to 802.11p",
+               VehicularWifiProfile::Ieee80211bdNonNgv10 (),
+               VehicularWifiProfile::Ieee80211p (),
+               1);
+    RunOneWay ("802.11bd NGV to 802.11p",
+               VehicularWifiProfile::Ieee80211bd (),
+               VehicularWifiProfile::Ieee80211p (),
+               0);
+  }
+
+  uint32_t m_rxPackets = 0;
+  uint16_t m_lastProtocol = 0;
+  bool m_txSucceeded = false;
+};
+
+class VehicularWifiNgvErrorRateTestCase : public TestCase
+{
+public:
+  VehicularWifiNgvErrorRateTestCase ()
+    : TestCase ("Validate 802.11bd NGV error-rate model")
+  {
+  }
+
+private:
+  WifiTxVector MakeNgvTxVector (uint8_t mcs,
+                                uint16_t channelWidthMHz = 10,
+                                uint8_t nss = 1,
+                                uint16_t midamblePeriodicity = 0) const
+  {
+    WifiTxVector txVector (channelWidthMHz == 20 ? OfdmPhy::GetOfdmRate24Mbps ()
+                                                 : OfdmPhy::GetOfdmRate12MbpsBW10MHz (),
+                           0,
+                           WIFI_PREAMBLE_LONG,
+                           800,
+                           nss,
+                           nss,
+                           0,
+                           channelWidthMHz,
+                           false,
+                           false,
+                           true);
+    txVector.SetNgvPpduFormat (WifiNgvPpduFormat::NGV);
+    txVector.SetNgvMcs (mcs);
+    txVector.SetNgvMidamblePeriodicity (midamblePeriodicity);
+    txVector.SetNgvLtfType ((channelWidthMHz == 10 && nss == 1 && mcs == 15)
+                                ? WifiNgvLtfType::NGV_LTF_2X_REPEAT
+                                : WifiNgvLtfType::NGV_LTF_2X);
+    return txVector;
+  }
+
+  double GetNgvPer (Ptr<ErrorRateModel> errorModel,
+                    uint8_t mcs,
+                    uint16_t channelWidthMHz,
+                    uint8_t nss,
+                    double snrDb,
+                    uint32_t bytes,
+                    uint16_t midamblePeriodicity = 0) const
+  {
+    WifiTxVector txVector = MakeNgvTxVector (mcs, channelWidthMHz, nss, midamblePeriodicity);
+    const double snr = std::pow (10.0, snrDb / 10.0);
+    const double psr = errorModel->GetChunkSuccessRate (txVector.GetMode (),
+                                                        txVector,
+                                                        snr,
+                                                        bytes * 8,
+                                                        1,
+                                                        WIFI_PPDU_FIELD_DATA);
+    return 1.0 - psr;
+  }
+
+  void DoRun () override
+  {
+    Ptr<ErrorRateModel> errorModel = CreateObject<YansErrorRateModel> ();
+
+    for (const auto& point : NgvCalibration::PER_REFERENCES)
+      {
+        const double below = GetNgvPer (errorModel,
+                                        point.mcs,
+                                        point.channelWidthMHz,
+                                        point.nss,
+                                        point.snr10PercentPerDb - 6.0,
+                                        point.referenceBytes);
+        const double atTarget = GetNgvPer (errorModel,
+                                           point.mcs,
+                                           point.channelWidthMHz,
+                                           point.nss,
+                                           point.snr10PercentPerDb,
+                                           point.referenceBytes);
+        const double above = GetNgvPer (errorModel,
+                                        point.mcs,
+                                        point.channelWidthMHz,
+                                        point.nss,
+                                        point.snr10PercentPerDb + 6.0,
+                                        point.referenceBytes);
+
+        NS_TEST_ASSERT_MSG_GT (below,
+                               atTarget,
+                               "NGV-MCS " << static_cast<uint32_t> (point.mcs)
+                                          << " " << point.channelWidthMHz
+                                          << " MHz NSS=" << +point.nss
+                                          << " PER should decrease as SNR increases");
+        NS_TEST_ASSERT_MSG_GT (atTarget,
+                               above,
+                               "NGV-MCS " << static_cast<uint32_t> (point.mcs)
+                                          << " " << point.channelWidthMHz
+                                          << " MHz NSS=" << +point.nss
+                                          << " PER should keep decreasing above the target SNR");
+        NS_TEST_ASSERT_MSG_EQ_TOL (atTarget,
+                                   0.1,
+                                   0.000001,
+                                   "NGV-MCS " << static_cast<uint32_t> (point.mcs)
+                                              << " " << point.channelWidthMHz
+                                              << " MHz NSS=" << +point.nss
+                                              << " target PER calibration drifted");
+      }
+
+    NS_TEST_ASSERT_MSG_LT (GetNgvPer (errorModel, 15, 10, 1, 12.0, 2048),
+                           GetNgvPer (errorModel, 0, 10, 1, 12.0, 4096),
+                           "NGV-MCS 15 BPSK-DCM should be more robust than NGV-MCS 0 at 12 dB");
+    NS_TEST_ASSERT_MSG_LT (GetNgvPer (errorModel, 3, 10, 1, 26.0, 4096),
+                           GetNgvPer (errorModel, 8, 10, 1, 26.0, 4096),
+                           "NGV-MCS 3 should be more robust than 256-QAM NGV-MCS 8 at 26 dB");
+    NS_TEST_ASSERT_MSG_LT (GetNgvPer (errorModel, 8, 20, 1, 37.0, 4096),
+                           GetNgvPer (errorModel, 9, 20, 1, 37.0, 4096),
+                           "20 MHz NGV-MCS 8 should be more robust than NGV-MCS 9 at 37 dB");
+
+    const double longNoMidamble = GetNgvPer (errorModel, 3, 10, 1, 20.0, 4096, 0);
+    const double longMidamble16 = GetNgvPer (errorModel, 3, 10, 1, 20.0, 4096, 16);
+    const double longMidamble4 = GetNgvPer (errorModel, 3, 10, 1, 20.0, 4096, 4);
+    NS_TEST_ASSERT_MSG_LT (longMidamble16,
+                           longNoMidamble,
+                           "NGV midambles should improve high-mobility PER for long PPDUs");
+    NS_TEST_ASSERT_MSG_LT (longMidamble4,
+                           longMidamble16,
+                           "Shorter NGV midamble periodicity should give stronger Doppler tracking gain");
+
+    const double shortNoMidamble = GetNgvPer (errorModel, 3, 10, 1, 20.0, 128, 0);
+    const double shortMidamble4 = GetNgvPer (errorModel, 3, 10, 1, 20.0, 128, 4);
+    NS_TEST_ASSERT_MSG_EQ_TOL (shortMidamble4,
+                               shortNoMidamble,
+                               0.000000000001,
+                               "Short NGV PPDUs should not receive midamble/Doppler gain");
+  }
+};
+
+class VehicularWifiNonNgv10CombiningTestCase : public TestCase
+{
+public:
+  VehicularWifiNonNgv10CombiningTestCase ()
+    : TestCase ("Validate 802.11bd NON_NGV_10 repetition combining")
+  {
+  }
+
+private:
+  WifiTxVector MakeNonNgv10TxVector (uint8_t repetitions) const
+  {
+    WifiTxVector txVector (OfdmPhy::GetOfdmRate6MbpsBW10MHz (),
+                           0,
+                           WIFI_PREAMBLE_LONG,
+                           800,
+                           1,
+                           1,
+                           0,
+                           10,
+                           false);
+    txVector.SetNgvPpduFormat (WifiNgvPpduFormat::NON_NGV_10);
+    txVector.SetNgvPpduRepetitions (repetitions);
+    return txVector;
+  }
+
+  double GetNonNgv10Per (uint8_t repetitions, WifiPpduField field) const
+  {
+    LinearSnrErrorRateModel errorModel;
+    WifiTxVector txVector = MakeNonNgv10TxVector (repetitions);
+    const double psr = errorModel.GetChunkSuccessRate (txVector.GetMode (),
+                                                       txVector,
+                                                       0.2,
+                                                       1024 * 8,
+                                                       1,
+                                                       field);
+    return 1.0 - psr;
+  }
+
+  void DoRun () override
+  {
+    const double payloadNoCombining = GetNonNgv10Per (0, WIFI_PPDU_FIELD_DATA);
+    const double payloadWithCombining = GetNonNgv10Per (2, WIFI_PPDU_FIELD_DATA);
+    NS_TEST_ASSERT_MSG_LT (payloadWithCombining,
+                           payloadNoCombining,
+                           "NON_NGV_10 repeated payload should benefit from repetition combining");
+
+    const double headerNoCombining = GetNonNgv10Per (0, WIFI_PPDU_FIELD_NON_HT_HEADER);
+    const double headerWithRepeats = GetNonNgv10Per (2, WIFI_PPDU_FIELD_NON_HT_HEADER);
+    NS_TEST_ASSERT_MSG_EQ_TOL (headerWithRepeats,
+                               headerNoCombining,
+                               0.000000000001,
+                               "NON_NGV_10 repetition combining should not alter header decoding");
+  }
+};
+
+class VehicularWifiMarginalSnrGainTestCase : public TestCase
+{
+public:
+  VehicularWifiMarginalSnrGainTestCase ()
+    : TestCase ("Validate 802.11bd marginal-SNR reliability gains from installed profiles")
+  {
+  }
+
+private:
+  NetDeviceContainer InstallVehicularDevice (NodeContainer nodes,
+                                             Ptr<YansWifiChannel> channel,
+                                             const VehicularWifiProfile& profile)
+  {
+    YansWifiPhyHelper phy;
+    profile.ConfigurePhy (phy);
+    phy.SetChannel (channel);
+
+    QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+    Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+    profile.ConfigureRemoteStationManager (wifi);
+    return wifi.Install (phy, mac, nodes);
+  }
+
+  WifiMacHeader MakeBroadcastDataHeader () const
+  {
+    WifiMacHeader broadcastData;
+    broadcastData.SetType (WIFI_MAC_DATA);
+    broadcastData.SetAddr1 (Mac48Address::GetBroadcast ());
+    broadcastData.SetAddr2 (Mac48Address ("00:00:00:00:00:01"));
+    broadcastData.SetAddr3 (Mac48Address::GetBroadcast ());
+    return broadcastData;
+  }
+
+  WifiTxVector GetDataTxVector (const VehicularWifiProfile& profile)
+  {
+    NodeContainer nodes;
+    nodes.Create (1);
+    MobilityHelper mobility;
+    mobility.Install (nodes);
+
+    YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+    Ptr<YansWifiChannel> channel = channelHelper.Create ();
+    NetDeviceContainer devices = InstallVehicularDevice (nodes, channel, profile);
+    Ptr<WifiNetDevice> device = DynamicCast<WifiNetDevice> (devices.Get (0));
+    NS_ABORT_MSG_IF (device == nullptr, "Expected an installed Wi-Fi device");
+
+    WifiTxVector txVector =
+        device->GetRemoteStationManager ()->GetDataTxVector (MakeBroadcastDataHeader ());
+    Simulator::Destroy ();
+    return txVector;
+  }
+
+  WifiTxVector GetDataTxVectorWithMidamble (uint16_t midamblePeriodicity)
+  {
+    NodeContainer nodes;
+    nodes.Create (1);
+    MobilityHelper mobility;
+    mobility.Install (nodes);
+
+    YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+    Ptr<YansWifiChannel> channel = channelHelper.Create ();
+    NetDeviceContainer devices =
+        InstallVehicularDevice (nodes, channel, VehicularWifiProfile::Ieee80211bd ());
+    Ptr<WifiNetDevice> device = DynamicCast<WifiNetDevice> (devices.Get (0));
+    NS_ABORT_MSG_IF (device == nullptr, "Expected an installed 802.11bd Wi-Fi device");
+
+    device->GetRemoteStationManager ()->SetAttribute ("NgvMidamblePeriodicity",
+                                                      UintegerValue (midamblePeriodicity));
+    WifiTxVector txVector =
+        device->GetRemoteStationManager ()->GetDataTxVector (MakeBroadcastDataHeader ());
+    Simulator::Destroy ();
+    return txVector;
+  }
+
+  double GetPer (Ptr<ErrorRateModel> errorModel,
+                 const WifiTxVector& txVector,
+                 double snrDb,
+                 uint32_t bytes,
+                 WifiPpduField field = WIFI_PPDU_FIELD_DATA) const
+  {
+    const double snr = std::pow (10.0, snrDb / 10.0);
+    const double psr = errorModel->GetChunkSuccessRate (txVector.GetMode (),
+                                                        txVector,
+                                                        snr,
+                                                        bytes * 8,
+                                                        1,
+                                                        field);
+    return 1.0 - psr;
+  }
+
+  void DoRun () override
+  {
+    Ptr<ErrorRateModel> yansErrorModel = CreateObject<YansErrorRateModel> ();
+
+    const WifiTxVector ngvNoMidamble = GetDataTxVector (VehicularWifiProfile::Ieee80211bd ());
+    const WifiTxVector ngvMidamble4 = GetDataTxVectorWithMidamble (4);
+    NS_TEST_ASSERT_MSG_EQ (ngvNoMidamble.IsNgv (), true, "Expected installed 802.11bd profile to use native NGV");
+    NS_TEST_ASSERT_MSG_EQ (ngvNoMidamble.GetNgvMidamblePeriodicity (),
+                           0,
+                           "Default installed 802.11bd profile should keep midambles disabled");
+    NS_TEST_ASSERT_MSG_EQ (ngvMidamble4.GetNgvMidamblePeriodicity (),
+                           4,
+                           "Installed 802.11bd manager did not apply configured midamble periodicity");
+    NS_TEST_ASSERT_MSG_LT (GetPer (yansErrorModel, ngvMidamble4, 20.0, 4096),
+                           GetPer (yansErrorModel, ngvNoMidamble, 20.0, 4096),
+                           "Installed 802.11bd NGV midambles should improve long-PPDU PER at marginal SNR");
+
+    Ptr<ErrorRateModel> linearErrorModel = CreateObject<LinearSnrErrorRateModel> ();
+    const WifiTxVector nonNgvNoRepeats =
+        GetDataTxVector (VehicularWifiProfile::Ieee80211bdNonNgv10 ());
+    const WifiTxVector nonNgvRepeated =
+        GetDataTxVector (VehicularWifiProfile::Ieee80211bdNonNgv10 ("OfdmRate6MbpsBW10MHz",
+                                                                    23.0,
+                                                                    -93.0,
+                                                                    4.0,
+                                                                    2));
+    NS_TEST_ASSERT_MSG_EQ (nonNgvNoRepeats.IsNonNgv10 (),
+                           true,
+                           "Expected compatible 802.11bd profile to use NON_NGV_10");
+    NS_TEST_ASSERT_MSG_EQ (nonNgvRepeated.GetNgvPpduRepetitions (),
+                           2,
+                           "Installed 802.11bd manager did not apply NON_NGV_10 repetitions");
+    NS_TEST_ASSERT_MSG_LT (GetPer (linearErrorModel, nonNgvRepeated, -6.9897, 1024),
+                           GetPer (linearErrorModel, nonNgvNoRepeats, -6.9897, 1024),
+                           "Installed repeated NON_NGV_10 profile should improve Data-field PER at marginal SNR");
+    NS_TEST_ASSERT_MSG_EQ_TOL (
+        GetPer (linearErrorModel, nonNgvRepeated, -6.9897, 1024, WIFI_PPDU_FIELD_NON_HT_HEADER),
+        GetPer (linearErrorModel, nonNgvNoRepeats, -6.9897, 1024, WIFI_PPDU_FIELD_NON_HT_HEADER),
+        0.000000000001,
+        "Installed repeated NON_NGV_10 profile should not change non-HT header PER");
+  }
+};
+
+class VehicularWifiDccAirtimeTestCase : public TestCase
+{
+public:
+  VehicularWifiDccAirtimeTestCase ()
+    : TestCase ("Validate 802.11bd DCC uses PHY airtime")
+  {
+  }
+
+private:
+  NetDeviceContainer InstallVehicularDevice (NodeContainer nodes,
+                                             Ptr<YansWifiChannel> channel,
+                                             const VehicularWifiProfile& profile)
+  {
+    YansWifiPhyHelper phy;
+    profile.ConfigurePhy (phy);
+    phy.SetChannel (channel);
+
+    QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+    Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+    profile.ConfigureRemoteStationManager (wifi);
+    return wifi.Install (phy, mac, nodes);
+  }
+
+  WifiMacHeader MakeBroadcastDataHeader () const
+  {
+    WifiMacHeader broadcastData;
+    broadcastData.SetType (WIFI_MAC_DATA);
+    broadcastData.SetAddr1 (Mac48Address::GetBroadcast ());
+    broadcastData.SetAddr2 (Mac48Address ("00:00:00:00:00:01"));
+    broadcastData.SetAddr3 (Mac48Address::GetBroadcast ());
+    return broadcastData;
+  }
+
+  Time GetExpectedDccAirtime (Ptr<WifiNetDevice> device, uint32_t psduSize) const
+  {
+    WifiTxVector txVector = device->GetRemoteStationManager ()->GetDataTxVector (MakeBroadcastDataHeader ());
+    Time txDuration = WifiPhy::CalculateTxDuration (psduSize, txVector, device->GetPhy ()->GetPhyBand ());
+    if (txVector.IsNonNgv10 () && txVector.GetNgvPpduRepetitions () > 0)
+      {
+        const uint8_t repetitions = txVector.GetNgvPpduRepetitions ();
+        txDuration = txDuration * (1 + repetitions) + device->GetPhy ()->GetSifs () * repetitions;
+      }
+    return txDuration;
+  }
+
+  void CheckProfile (const std::string& scenario,
+                     const VehicularWifiProfile& profile,
+                     bool expectDifferentFromNominalBitrate)
+  {
+    constexpr uint32_t psduSize = 128;
+
+    NodeContainer nodes;
+    nodes.Create (1);
+    MobilityHelper mobility;
+    mobility.Install (nodes);
+
+    YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+    Ptr<YansWifiChannel> channel = channelHelper.Create ();
+    NetDeviceContainer devices = InstallVehicularDevice (nodes, channel, profile);
+    Ptr<WifiNetDevice> device = DynamicCast<WifiNetDevice> (devices.Get (0));
+    NS_TEST_ASSERT_MSG_NE (device, nullptr, scenario << " expected a Wi-Fi device");
+
+    Ptr<DCC> dcc = CreateObject<DCC> ();
+    Ptr<MetricSupervisor> metricSupervisor = CreateObject<MetricSupervisor> ();
+    dcc->SetupDCC ("0", metricSupervisor, nodes.Get (0), "adaptive", 200);
+    dcc->setBitRate (static_cast<long> (profile.GetDccBitRate ()));
+    dcc->updateTonpp (psduSize);
+
+    const double expectedMs = GetExpectedDccAirtime (device, psduSize).GetSeconds () * 1000.0;
+    NS_TEST_ASSERT_MSG_EQ_TOL (dcc->getTonPpMs (),
+                               expectedMs,
+                               0.00001,
+                               scenario << " DCC Ton_pp should match PHY airtime");
+
+    if (expectDifferentFromNominalBitrate)
+      {
+        const double nominalMs = ((psduSize * 8.0) / profile.GetDccBitRate () + 68e-6) * 1000.0;
+        NS_TEST_ASSERT_MSG_GT (std::abs (dcc->getTonPpMs () - nominalMs),
+                               0.001,
+                               scenario << " DCC Ton_pp should not use the legacy nominal bitrate formula");
+      }
+
+    Simulator::Destroy ();
+  }
+
+  void DoRun () override
+  {
+    CheckProfile ("802.11bd NGV", VehicularWifiProfile::Ieee80211bd (), true);
+    CheckProfile ("802.11bd 20 MHz NGV", VehicularWifiProfile::Ieee80211bd20 (), true);
+    CheckProfile ("802.11bd NON_NGV_10",
+                  VehicularWifiProfile::Ieee80211bdNonNgv10 ("OfdmRate6MbpsBW10MHz",
+                                                              23.0,
+                                                              -93.0,
+                                                              4.0,
+                                                              2),
+                  true);
+    CheckProfile ("802.11bd NON_NGV_20_DUPLICATE",
+                  VehicularWifiProfile::Ieee80211bdNonNgv20Duplicate (),
+                  true);
+  }
+};
+
+class VehicularWifiCbrOracleTestCase : public TestCase
+{
+public:
+  VehicularWifiCbrOracleTestCase ()
+    : TestCase ("Validate 802.11bd CBR matches PHY busy-time oracle")
+  {
+  }
+
+private:
+  NetDeviceContainer InstallVehicularDevice (NodeContainer nodes,
+                                             Ptr<YansWifiChannel> channel,
+                                             const VehicularWifiProfile& profile)
+  {
+    YansWifiPhyHelper phy;
+    profile.ConfigurePhy (phy);
+    phy.SetChannel (channel);
+
+    QosWaveMacHelper mac = QosWaveMacHelper::Default ();
+    Wifi80211pHelper wifi = Wifi80211pHelper::Default ();
+    profile.ConfigureRemoteStationManager (wifi);
+    return wifi.Install (phy, mac, nodes);
+  }
+
+  bool Receive (Ptr<NetDevice> dev, Ptr<const Packet> pkt, uint16_t protocol, const Address& sender)
+  {
+    m_rxPackets++;
+    return true;
+  }
+
+  void SendPacket (Ptr<NetDevice> device)
+  {
+    static const uint16_t wsmpProtocol = 0x88DC;
+    m_txAttempts++;
+    if (device->Send (Create<Packet> (128), Mac48Address::GetBroadcast (), wsmpProtocol))
+      {
+        m_txSucceededPackets++;
+      }
+  }
+
+  static bool IsBusyForOracle (WifiPhyState state)
+  {
+    return state != WifiPhyState::SLEEP && state != WifiPhyState::IDLE;
+  }
+
+  void NotifyState (std::string context, Time start, Time duration, WifiPhyState state)
+  {
+    if (!IsBusyForOracle (state))
+      {
+        return;
+      }
+
+    std::size_t first = context.find ("/NodeList/");
+    if (first == std::string::npos)
+      {
+        m_oracleTraceContextError = true;
+        return;
+      }
+    first += std::string ("/NodeList/").size ();
+    std::size_t last = context.find ("/", first);
+    if (last == std::string::npos)
+      {
+        m_oracleTraceContextError = true;
+        return;
+      }
+    const std::string nodeId = context.substr (first, last - first);
+
+    const Time end = start + duration;
+    if (end <= m_windowStart || start >= m_windowEnd)
+      {
+        return;
+      }
+
+    const Time clippedStart = start < m_windowStart ? m_windowStart : start;
+    const Time clippedEnd = end > m_windowEnd ? m_windowEnd : end;
+    const Time clippedDuration = clippedEnd - clippedStart;
+    if (clippedDuration.IsStrictlyPositive ())
+      {
+        m_oracleBusy[nodeId] += clippedDuration;
+      }
+  }
+
+  void RunScenario (const std::string& scenario,
+                    const std::vector<Time>& transmissionTimes,
+                    const std::set<uint32_t>& comparedNodeIndexes)
+  {
+    m_txAttempts = 0;
+    m_txSucceededPackets = 0;
+    m_rxPackets = 0;
+    m_oracleTraceContextError = false;
+    m_oracleBusy.clear ();
+
+    NodeContainer nodes;
+    nodes.Create (2);
+
+    Ptr<ListPositionAllocator> positions = CreateObject<ListPositionAllocator> ();
+    positions->Add (Vector (0.0, 0.0, 0.0));
+    positions->Add (Vector (5.0, 0.0, 0.0));
+    MobilityHelper mobility;
+    mobility.SetPositionAllocator (positions);
+    mobility.SetMobilityModel ("ns3::ConstantPositionMobilityModel");
+    mobility.Install (nodes);
+
+    YansWifiChannelHelper channelHelper = YansWifiChannelHelper::Default ();
+    Ptr<YansWifiChannel> channel = channelHelper.Create ();
+
+    NodeContainer senderNode;
+    senderNode.Add (nodes.Get (0));
+    NodeContainer receiverNode;
+    receiverNode.Add (nodes.Get (1));
+
+    NetDeviceContainer senderDevices =
+        InstallVehicularDevice (senderNode, channel, VehicularWifiProfile::Ieee80211bd ());
+    NetDeviceContainer receiverDevices =
+        InstallVehicularDevice (receiverNode, channel, VehicularWifiProfile::Ieee80211bd ());
+    receiverDevices.Get (0)->SetReceiveCallback (
+        MakeCallback (&VehicularWifiCbrOracleTestCase::Receive, this));
+
+    for (uint32_t i = 0; i < nodes.GetN (); ++i)
+      {
+        std::ostringstream oss;
+        oss << "/NodeList/" << nodes.Get (i)->GetId ()
+            << "/DeviceList/*/$ns3::WifiNetDevice/Phy/State/State";
+        Config::Connect (oss.str (),
+                         MakeCallback (&VehicularWifiCbrOracleTestCase::NotifyState, this));
+      }
+
+    Ptr<MetricSupervisor> metricSupervisor = CreateObject<MetricSupervisor> ();
+    metricSupervisor->setNodeContainer (nodes);
+    metricSupervisor->setChannelTechnology ("80211bd");
+    metricSupervisor->setCBRWindowValue (m_cbrWindowMs);
+    metricSupervisor->setCBRAlphaValue (0.0);
+    metricSupervisor->setSimulationTimeValue (0.02);
+    metricSupervisor->startCheckCBR ();
+
+    for (const Time& transmissionTime : transmissionTimes)
+      {
+        Simulator::Schedule (transmissionTime,
+                             &VehicularWifiCbrOracleTestCase::SendPacket,
+                             this,
+                             senderDevices.Get (0));
+      }
+    Simulator::Stop (MilliSeconds (15));
+    Simulator::Run ();
+
+    NS_TEST_ASSERT_MSG_EQ (m_txAttempts,
+                           transmissionTimes.size (),
+                           scenario << " attempted an unexpected number of transmissions");
+    NS_TEST_ASSERT_MSG_EQ (m_txSucceededPackets,
+                           transmissionTimes.size (),
+                           scenario << " send failed");
+    NS_TEST_ASSERT_MSG_EQ (m_rxPackets,
+                           transmissionTimes.size (),
+                           scenario << " did not receive every broadcast");
+    NS_TEST_ASSERT_MSG_EQ (m_oracleTraceContextError, false, scenario << " failed to parse CBR oracle trace context");
+
+    for (uint32_t nodeIndex : comparedNodeIndexes)
+      {
+        const std::string nodeId = std::to_string (nodes.Get (nodeIndex)->GetId ());
+        const auto oracleIt = m_oracleBusy.find (nodeId);
+        if (oracleIt == m_oracleBusy.end ())
+          {
+            NS_TEST_ASSERT_MSG_EQ (false,
+                                   true,
+                                   scenario << " 802.11bd CBR oracle did not observe busy time for node "
+                                       << nodeId);
+            continue;
+          }
+
+        const double expectedCbr = oracleIt->second.GetDouble () / (m_cbrWindowMs * 1e6);
+        const double observedCbr = metricSupervisor->getCBRPerItem (nodeId);
+        NS_TEST_ASSERT_MSG_GT (expectedCbr,
+                               0.0,
+                               scenario << " expected non-zero busy time for node " << nodeId);
+        NS_TEST_ASSERT_MSG_EQ_TOL (observedCbr,
+                                   expectedCbr,
+                                   1e-12,
+                                   scenario << " CBR should match PHY busy-time oracle for node " << nodeId);
+      }
+
+    Simulator::Destroy ();
+  }
+
+  void DoRun () override
+  {
+    RunScenario ("802.11bd CBR in-window busy interval", {MilliSeconds (1)}, {0, 1});
+    RunScenario ("802.11bd CBR window-clipped sender busy interval", {MicroSeconds (9950)}, {0});
+  }
+
+  const Time m_windowStart = Seconds (0);
+  const Time m_windowEnd = MilliSeconds (10);
+  const double m_cbrWindowMs = 10.0;
+  bool m_oracleTraceContextError = false;
+  std::size_t m_txAttempts = 0;
+  std::size_t m_txSucceededPackets = 0;
+  uint32_t m_rxPackets = 0;
+  std::unordered_map<std::string, Time> m_oracleBusy;
+};
+
+class VehicularGeoNetGlobalCbrTestCase : public TestCase
+{
+public:
+  VehicularGeoNetGlobalCbrTestCase ()
+    : TestCase ("Validate GeoNet global CBR uses simulation-time expiry")
+  {
+  }
+
+private:
+  void DoRun () override
+  {
+    GeoNet::LocationTableExtension firstNeighbor;
+    firstNeighbor.CBR_R0_Hop.push_back (std::make_tuple (0, 0.95));
+    firstNeighbor.CBR_R0_Hop.push_back (std::make_tuple (600, 0.40));
+    firstNeighbor.CBR_R0_Hop.push_back (std::make_tuple (1500, 0.70));
+    firstNeighbor.CBR_R1_Hop.push_back (std::make_tuple (0, 0.90));
+    firstNeighbor.CBR_R1_Hop.push_back (std::make_tuple (700, 0.30));
+    firstNeighbor.CBR_R1_Hop.push_back (std::make_tuple (900, 0.45));
+
+    GeoNet::LocationTableExtension secondNeighbor;
+    secondNeighbor.CBR_R0_Hop.push_back (std::make_tuple (700, 0.80));
+
+    std::vector<GeoNet::LocationTableExtension*> extensions = {&firstNeighbor, &secondNeighbor};
+
+    GeoNet::GlobalCbrAggregation aggregation =
+        GeoNet::ComputeGlobalCbrAggregation (extensions, 1600, 1000, 0.50, 0.25);
+
+    NS_TEST_ASSERT_MSG_EQ (aggregation.r0SampleCount,
+                           3u,
+                           "GeoNet CBR_G should keep R0 samples within the simulation-time window");
+    NS_TEST_ASSERT_MSG_EQ (aggregation.r1SampleCount,
+                           2u,
+                           "GeoNet CBR_G should keep R1 samples within the simulation-time window");
+    NS_TEST_ASSERT_MSG_EQ (firstNeighbor.CBR_R0_Hop.size (),
+                           2u,
+                           "GeoNet CBR_G should prune expired R0 samples");
+    NS_TEST_ASSERT_MSG_EQ (std::get<0> (firstNeighbor.CBR_R0_Hop.front ()),
+                           600,
+                           "GeoNet CBR_G should keep samples exactly on the expiry boundary");
+    NS_TEST_ASSERT_MSG_EQ_TOL (aggregation.cbrL1Hop,
+                               0.80,
+                               1e-12,
+                               "GeoNet CBR_G should select max R0 when mean R0 exceeds target");
+    NS_TEST_ASSERT_MSG_EQ_TOL (aggregation.cbrL2Hop,
+                               0.30,
+                               1e-12,
+                               "GeoNet CBR_G should select second max R1 when mean R1 does not exceed target");
+    NS_TEST_ASSERT_MSG_EQ_TOL (aggregation.cbrG,
+                               0.80,
+                               1e-12,
+                               "GeoNet CBR_G should aggregate L0 previous, L1, and L2");
+
+    aggregation = GeoNet::ComputeGlobalCbrAggregation (extensions, 2700, 1000, 0.50, 0.25);
+
+    NS_TEST_ASSERT_MSG_EQ (aggregation.r0SampleCount,
+                           0u,
+                           "GeoNet CBR_G should expire R0 samples using simulation time");
+    NS_TEST_ASSERT_MSG_EQ (aggregation.r1SampleCount,
+                           0u,
+                           "GeoNet CBR_G should expire R1 samples using simulation time");
+    NS_TEST_ASSERT_MSG_EQ_TOL (aggregation.cbrG,
+                               0.25,
+                               1e-12,
+                               "GeoNet CBR_G should fall back to previous local CBR when remote samples expire");
+  }
+};
+
+class VehicularWifiProfileTestSuite : public TestSuite
+{
+public:
+  VehicularWifiProfileTestSuite ()
+    : TestSuite ("vehicular-wifi-profile", UNIT)
+  {
+    AddTestCase (new VehicularNgvMcsTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiProfileTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiProfileInstallTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiFallbackControllerTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiRateControllerTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiCore11bdTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiActualTxVectorTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiInteroperabilityTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiNgvErrorRateTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiNonNgv10CombiningTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiMarginalSnrGainTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiDccAirtimeTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularWifiCbrOracleTestCase, TestCase::QUICK);
+    AddTestCase (new VehicularGeoNetGlobalCbrTestCase, TestCase::QUICK);
+  }
+};
+
+static VehicularWifiProfileTestSuite vehicularWifiProfileTestSuite;


### PR DESCRIPTION
# 802.11bd support

This patch adds an 802.11bd/NGV vehicular Wi-Fi path to the automotive module.
It is intended for V2X simulations that already use the ns-3 WAVE/OCB stack and
need to compare 802.11p, 802.11bd native NGV transmissions, and 802.11bd
legacy-compatible fallback modes.

## What is available

- A new `WIFI_STANDARD_80211bd` Wi-Fi standard entry for the vehicular OCB path.
- 802.11bd TXVECTOR metadata for PPDU format, NGV-MCS, spatial streams,
  midamble periodicity, NGV-LTF type, LDPC, and `NON_NGV_10` repetitions.
- Native NGV PPDU handling for 10 MHz and 20 MHz channel profiles.
- Legacy-compatible `NON_NGV_10` and `NON_NGV_20_DUPLICATE` fallback modes.
- Basic 802.11p/802.11bd interoperability behavior:
  - 802.11bd receivers can receive supported non-NGV fallback transmissions.
  - 802.11p receivers do not decode native NGV transmissions.
  - 802.11p receivers can decode compatible non-NGV fallback transmissions.
- 802.11bd profile helpers for configuring PHY, remote station manager, and
  metrics consistently.
- A bounded fallback controller for switching between native NGV, duplicated
  non-NGV 20 MHz fallback, and primary-only non-NGV 10 MHz fallback.
- A modular rate controller that can select 802.11bd NGV-MCS values and can
  reuse the same SNR-threshold policy shape for 802.11p OFDM data rates.
- CBR and DCC accounting paths updated to handle 802.11bd Wi-Fi devices.

The implementation is a network-simulation model integrated into the existing
Yans/WAVE-style automotive stack. It does not attempt to provide a full
waveform-level 802.11bd PHY.

## Helper API

Use `VehicularWifiProfile` from `ns3/vehicular-wifi-helper.h` to configure
common vehicular Wi-Fi profiles:

```cpp
VehicularWifiProfile profile = VehicularWifiProfile::Ieee80211bd ();
profile.ConfigurePhy (wifiPhy);
profile.ConfigureRemoteStationManager (wifi);
```

Useful factory methods include:

- `VehicularWifiProfile::Ieee80211p()`
- `VehicularWifiProfile::Ieee80211bd()`
- `VehicularWifiProfile::Ieee80211bd20()`
- `VehicularWifiProfile::Ieee80211bdNonNgv10()`
- `VehicularWifiProfile::Ieee80211bdNonNgv20Duplicate()`

For explicit fallback selection, use `VehicularWifiFallbackController`:

```cpp
auto mode = VehicularWifiFallbackController::SelectForLinkQuality (policy);
VehicularWifiProfile profile = VehicularWifiFallbackController::MakeProfile (mode);
```

For MCS/rate decisions, use `VehicularWifiRateController`:

```cpp
VehicularWifiRateController::Policy policy;
policy.linkQuality.estimatedSnrDb = 30.0;

auto decision = VehicularWifiRateController::Select (policy);
VehicularWifiProfile profile = VehicularWifiRateController::MakeProfile (decision);
```

The default 802.11bd rate policy selects native NGV MCS 7, 3, or 0 according to
explicit SNR thresholds, then falls back to `NON_NGV_20_DUPLICATE` or
`NON_NGV_10` through the fallback controller.

## Examples

The following examples exercise the new 802.11bd path:

- `v2v-simple-cam-exchange-80211bd`
- `v2v-congestion-80211bd`
- `v2v-marginal-snr-80211bd`
- `v2v-nss2-comparison-80211bd`
- `v2v-runtime-fallback-80211bd`
- `v2v-link-quality-fallback-80211bd`
- `v2v-observed-fallback-80211bd`
- `v2v-trace-observed-fallback-80211bd`
- `v2v-rate-control-80211bd`
- `v2v-coexistence-80211bd-nrv2x`

Example runs:

```bash
./ns3 run "v2v-simple-cam-exchange-80211bd --sumo-gui=false --sim-time=1"
./ns3 run "v2v-rate-control-80211bd"
./ns3 run "v2v-runtime-fallback-80211bd"
```

## Tests

The `vehicular-wifi-profile` test suite covers the core 802.11bd behavior:

```bash
./build/utils/ns3-dev-test-runner-optimized --suite=vehicular-wifi-profile --verbose
```

The suite includes tests for:

- profile metadata and installed PHY settings;
- NGV-MCS table validity;
- TXVECTOR metadata;
- `NON_NGV_10` repetition behavior;
- 802.11p/802.11bd interoperability;
- NGV error-rate model behavior;
- CBR/DCC integration;
- fallback and rate-control decisions.

## Modeling limitations

The current model uses static NGV PER and midamble/Doppler parameters in
`src/automotive/model/SignalInfo/WiFi/ngv/ngv-calibration.h`. These values are
modeling assumptions, not a calibrated link-level reference.

The following items are intentionally left for future work:

- calibrated PER-vs-SNR curves for NGV modes;
- waveform-level duplicate combining;
- full receiver-capability discovery;
- failed-reception evidence for closed-loop rate control;
- CBR-aware rate-control constraints;
- a detailed MIMO PHY model for NSS greater than one.